### PR TITLE
Cpdp 1835

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/config/ErrorHandler.scala
@@ -41,14 +41,13 @@ class ErrorHandler @Inject() (
   )(implicit
     request: Request[_]
   ): Html =
-    error_template(None, pageTitle, heading, message)
+    error_template(pageTitle, heading, message)
 
   def errorResult[R <: Request[_]](
     userType: Option[UserType]
   )(implicit request: R): Result =
     InternalServerError(
       error_template(
-        userType,
         Messages("global.error.InternalServerError500.title"),
         Messages("global.error.InternalServerError500.heading"),
         Messages("global.error.InternalServerError500.message")
@@ -58,7 +57,6 @@ class ErrorHandler @Inject() (
   def tmpErrorResult()(implicit request: Request[_]): Result =
     InternalServerError(
       error_template(
-        None,
         Messages("tmpCustomError.title"),
         Messages("tmpCustomError.heading"),
         Messages("tmpCustomError.p1"),

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/LandingPageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/LandingPageController.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 
 import com.google.inject.{Inject, Singleton}
-import play.api.Configuration
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views
@@ -26,7 +25,6 @@ import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 @Singleton
 class LandingPageController @Inject() (
   cc: MessagesControllerComponents,
-  config: Configuration,
   landing_page: views.html.landing_page,
   agents_landing_page: views.html.agents_landing_page
 )(implicit viewConfig: ViewConfig)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/StartController.scala
@@ -165,7 +165,7 @@ class StartController @Inject() (
       case _: SubscriptionStatus.SubscriptionReady                                                    =>
         Redirect(onboarding.routes.SubscriptionController.checkYourDetails())
 
-      case i: SubscriptionStatus.TryingToGetIndividualsFootprint                                      =>
+      case _: SubscriptionStatus.TryingToGetIndividualsFootprint                                      =>
         // this is not the first time a person with individual insufficient confidence level has come to start
         Redirect(
           onboarding.routes.InsufficientConfidenceLevelController

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/AccountController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/AccountController.scala
@@ -18,13 +18,12 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.accounts
 
 import com.google.inject.{Inject, Singleton}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.{ErrorHandler, ViewConfig}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.{AuthenticatedAction, RequestWithSessionData, SessionDataAction, WithAuthAndSessionDataAction}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionDetail
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.SessionData
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -35,11 +34,8 @@ import scala.concurrent.Future
 class AccountController @Inject() (
   val authenticatedAction: AuthenticatedAction,
   val sessionDataAction: SessionDataAction,
-  errorHandler: ErrorHandler,
-  sessionStore: SessionStore,
   cc: MessagesControllerComponents,
   manageYourDetailsPage: views.html.account.manage_your_details,
-  homePage: views.html.account.home,
   detailUpdatedPage: views.html.account.details_updated,
   signedOutPage: views.html.account.signed_out
 )(implicit viewConfig: ViewConfig)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageController.scala
@@ -52,10 +52,7 @@ class HomePageController @Inject() (
   returnsService: ReturnsService,
   paymentsService: PaymentsService,
   cc: MessagesControllerComponents,
-  manageYourDetailsPage: views.html.account.manage_your_details,
   homePage: views.html.account.home,
-  detailUpdatedPage: views.html.account.details_updated,
-  signedOutPage: views.html.account.signed_out,
   subsequentReturnExitPage: views.html.returns.subsequent_return_exit
 )(implicit viewConfig: ViewConfig, ec: ExecutionContext)
     extends FrontendController(cc)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RegistrationController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RegistrationController.scala
@@ -58,7 +58,6 @@ class RegistrationController @Inject() (
   metrics: Metrics,
   selectEntityTypePage: views.html.onboarding.registration.select_entity_type,
   wrongGGAccountForTrustPage: views.html.onboarding.wrong_gg_account_for_trust,
-  enterNamePage: views.html.onboarding.name.enter_name,
   checkYourDetailsPage: views.html.onboarding.registration.check_your_details,
   cc: MessagesControllerComponents
 )(implicit

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsController.scala
@@ -737,7 +737,7 @@ class AcquisitionDetailsController @Inject() (
 
   def shouldUseRebase(): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
-      withFillingOutReturnAndAcquisitionDetailsAnswers(request) { (_, _, state, answers) =>
+      withFillingOutReturnAndAcquisitionDetailsAnswers(request) { (_, _, state, _) =>
         withAssetTypeAndResidentialStatus(state) { (assetType, wasAUkResident) =>
           if (wasAUkResident)
             Redirect(routes.AcquisitionDetailsController.checkYourAnswers())

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/disposaldetails/DisposalDetailsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/disposaldetails/DisposalDetailsController.scala
@@ -334,7 +334,7 @@ class DisposalDetailsController @Inject() (
               controllers.returns.disposaldetails.routes.DisposalDetailsController.howMuchDidYouOwn()
 
           withDisposalMethodAndShareOfProperty(state, answers) {
-            case (disposalMethod, shareOfProperty) =>
+            case (disposalMethod, _) =>
               displayPage(answers)(
                 form = _.fold(
                   _.disposalPrice.fold(disposalPriceForm)(a => disposalPriceForm.fill(a.inPounds())),
@@ -345,7 +345,6 @@ class DisposalDetailsController @Inject() (
                   _,
                   _,
                   disposalMethod,
-                  shareOfProperty,
                   fillingOutReturn.subscribedDetails.isATrust,
                   representativeType(state),
                   isIndirectDisposal(state)
@@ -363,7 +362,7 @@ class DisposalDetailsController @Inject() (
       withFillingOutReturnAndDisposalDetailsAnswers(request) {
         case (_, fillingOutReturn, state, answers) =>
           withDisposalMethodAndShareOfProperty(state, answers) {
-            case (disposalMethod, shareOfProperty) =>
+            case (disposalMethod, _) =>
               submitBehaviour(fillingOutReturn, state, answers)(
                 form = disposalPriceForm
               )(
@@ -371,7 +370,6 @@ class DisposalDetailsController @Inject() (
                   _,
                   _,
                   disposalMethod,
-                  shareOfProperty,
                   fillingOutReturn.subscribedDetails.isATrust,
                   representativeType(state),
                   isIndirectDisposal(state)
@@ -425,7 +423,7 @@ class DisposalDetailsController @Inject() (
       withFillingOutReturnAndDisposalDetailsAnswers(request) {
         case (_, fillingOutReturn, state, answers) =>
           withDisposalMethodAndShareOfProperty(state, answers) {
-            case (disposalMethod, shareOfProperty) =>
+            case (_, _) =>
               displayPage(answers)(
                 form = _.fold(
                   _.disposalFees.fold(disposalFeesForm)(a => disposalFeesForm.fill(a.inPounds())),
@@ -435,8 +433,6 @@ class DisposalDetailsController @Inject() (
                 page = disposalFeesPage(
                   _,
                   _,
-                  disposalMethod,
-                  shareOfProperty,
                   fillingOutReturn.subscribedDetails.isATrust,
                   representativeType(state),
                   isIndirectDisposal(state)
@@ -456,15 +452,13 @@ class DisposalDetailsController @Inject() (
       withFillingOutReturnAndDisposalDetailsAnswers(request) {
         case (_, fillingOutReturn, state, answers) =>
           withDisposalMethodAndShareOfProperty(state, answers) {
-            case (disposalMethod, shareOfProperty) =>
+            case (_, _) =>
               submitBehaviour(fillingOutReturn, state, answers)(
                 form = disposalFeesForm
               )(
                 page = disposalFeesPage(
                   _,
                   _,
-                  disposalMethod,
-                  shareOfProperty,
                   fillingOutReturn.subscribedDetails.isATrust,
                   representativeType(state),
                   isIndirectDisposal(state)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/RepresenteeController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/RepresenteeController.scala
@@ -222,7 +222,7 @@ class RepresenteeController @Inject() (
 
   def confirmPerson(): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
-      withCapacitorOrPersonalRepresentativeAnswers(request) { (representativeType, journey, answers) =>
+      withCapacitorOrPersonalRepresentativeAnswers(request) { (_, journey, answers) =>
         answers match {
           case IncompleteRepresenteeAnswers(
                 Some(name),
@@ -236,7 +236,6 @@ class RepresenteeController @Inject() (
               confirmPersonPage(
                 id,
                 name,
-                representativeType,
                 journey.isRight,
                 confirmPersonForm,
                 routes.RepresenteeController.enterId()
@@ -250,7 +249,7 @@ class RepresenteeController @Inject() (
 
   def confirmPersonSubmit(): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
-      withCapacitorOrPersonalRepresentativeAnswers(request) { (representativeType, journey, answers) =>
+      withCapacitorOrPersonalRepresentativeAnswers(request) { (_, journey, answers) =>
         answers match {
           case incompleteRepresenteeAnswers @ IncompleteRepresenteeAnswers(
                 Some(name),
@@ -268,7 +267,6 @@ class RepresenteeController @Inject() (
                     confirmPersonPage(
                       id,
                       name,
-                      representativeType,
                       journey.isRight,
                       formWithErrors,
                       routes.RepresenteeController.enterId()
@@ -748,7 +746,6 @@ class RepresenteeController @Inject() (
                   cyaPage(
                     completeAnswers,
                     representativeType,
-                    journey.isRight,
                     triageRoutes.CommonTriageQuestionsController
                       .whoIsIndividualRepresenting()
                   )
@@ -760,7 +757,6 @@ class RepresenteeController @Inject() (
               cyaPage(
                 completeAnswers,
                 representativeType,
-                journey.isRight,
                 triageRoutes.CommonTriageQuestionsController
                   .whoIsIndividualRepresenting()
               )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/supportingevidence/SupportingEvidenceController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/supportingevidence/SupportingEvidenceController.scala
@@ -480,7 +480,7 @@ class SupportingEvidenceController @Inject() (
 
   def checkYourAnswers(): Action[AnyContent] =
     authenticatedActionWithSessionData.async { implicit request =>
-      withUploadSupportingEvidenceAnswers(request) { (_, fillingOutReturn, answers) =>
+      withUploadSupportingEvidenceAnswers(request) { (_, _, answers) =>
         checkYourAnswersHandler(answers)
       }
     }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
@@ -654,7 +654,6 @@ object CommonTriageQuestionsController {
       mapping(
         "individualUserType" -> of(
           FormUtils.radioFormFormatter(
-            "individualUserType",
             if (isAgent) List(Self, PersonalRepresentative)
             else List(Self, Capacitor, PersonalRepresentative)
           )
@@ -666,7 +665,7 @@ object CommonTriageQuestionsController {
     mapping(
       "numberOfProperties" -> of(
         FormUtils
-          .radioFormFormatter("numberOfProperties", List(One, MoreThanOne))
+          .radioFormFormatter(List(One, MoreThanOne))
       )
     )(identity)(Some(_))
   )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageController.scala
@@ -1438,7 +1438,7 @@ object MultipleDisposalsTriageController {
       mapping(
         "multipleDisposalsTaxYear" -> of(
           FormUtils
-            .radioFormFormatter("multipleDisposalsTaxYear", List(true, false))
+            .radioFormFormatter(List(true, false))
         )
       )(identity)(Some(_))
     )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
@@ -430,7 +430,7 @@ class SingleDisposalsTriageController @Inject() (
           i => i.disposalDate.map(_.value).orElse(i.tooEarlyDisposalDate),
           c => Some(c.disposalDate.value)
         ),
-        page = { (journeyStatus, currentAnswers, form, isDraftReturn, assetType) =>
+        page = { (journeyStatus, currentAnswers, form, isDraftReturn, _) =>
           val isATrust = journeyStatus
             .fold(
               _.subscribedDetails.isATrust,
@@ -440,7 +440,6 @@ class SingleDisposalsTriageController @Inject() (
             form,
             disposalDateBackLink(currentAnswers),
             isDraftReturn,
-            assetType,
             isATrust,
             currentAnswers.representativeType()
           )
@@ -457,8 +456,8 @@ class SingleDisposalsTriageController @Inject() (
             f => f._2.subscribedDetails.isATrust
           )
         triageAnswers.fold(_.assetType, c => Some(c.assetType)) match {
-          case None            => Redirect(disposalDateBackLink(triageAnswers))
-          case Some(assetType) =>
+          case None    => Redirect(disposalDateBackLink(triageAnswers))
+          case Some(_) =>
             disposalDateForm(TimeUtils.today())
               .bindFromRequest()
               .fold(
@@ -468,7 +467,6 @@ class SingleDisposalsTriageController @Inject() (
                       formWithErrors,
                       disposalDateBackLink(triageAnswers),
                       state.isRight,
-                      assetType,
                       isATrust,
                       triageAnswers.representativeType()
                     )
@@ -1147,7 +1145,7 @@ class SingleDisposalsTriageController @Inject() (
                 _,
                 _,
                 _,
-                __
+                _
               ) if isIndividual =>
             Redirect(
               routes.CommonTriageQuestionsController

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
@@ -1726,7 +1726,6 @@ object SingleDisposalsTriageController {
     mapping(
       "individualUserType" -> of(
         FormUtils.radioFormFormatter(
-          "individualUserType",
           List(Self, Capacitor, PersonalRepresentative)
         )
       )
@@ -1737,7 +1736,7 @@ object SingleDisposalsTriageController {
     mapping(
       "numberOfProperties" -> of(
         FormUtils
-          .radioFormFormatter("numberOfProperties", List(One, MoreThanOne))
+          .radioFormFormatter(List(One, MoreThanOne))
       )
     )(identity)(Some(_))
   )
@@ -1746,7 +1745,7 @@ object SingleDisposalsTriageController {
     mapping(
       "disposalMethod" -> of(
         FormUtils
-          .radioFormFormatter("disposalMethod", List(Sold, Gifted, Other))
+          .radioFormFormatter(List(Sold, Gifted, Other))
       )
     )(identity)(Some(_))
   )
@@ -1808,7 +1807,6 @@ object SingleDisposalsTriageController {
     mapping(
       "assetTypeForNonUkResidents" -> of(
         FormUtils.radioFormFormatter(
-          "assetTypeForNonUkResidents",
           List(Residential, NonResidential, MixedUse, IndirectDisposal)
         )
       )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/yeartodatelliability/YearToDateLiabilityController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/yeartodatelliability/YearToDateLiabilityController.scala
@@ -1714,7 +1714,7 @@ class YearToDateLiabilityController @Inject() (
             _,
             _,
             _,
-            Some(expiredEvidence),
+            Some(_),
             _
           ) =>
         Redirect(
@@ -1727,7 +1727,7 @@ class YearToDateLiabilityController @Inject() (
             _,
             _,
             _,
-            Some(pendingUpscanUpload)
+            Some(_)
           ) =>
         removePendingUpscanUpload(Left(n), fillingOutReturn).fold(
           { e =>
@@ -1852,7 +1852,7 @@ class YearToDateLiabilityController @Inject() (
             _,
             _,
             _,
-            Some(expiredEvidence),
+            Some(_),
             _
           ) =>
         Redirect(
@@ -1867,7 +1867,7 @@ class YearToDateLiabilityController @Inject() (
             _,
             _,
             _,
-            Some(pendingUpscanUpload)
+            Some(_)
           ) =>
         removePendingUpscanUpload(Right(c), fillingOutReturn).fold(
           { e =>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/FormUtils.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/FormUtils.scala
@@ -42,7 +42,6 @@ object FormUtils {
       }
 
   def radioFormFormatter[A : Eq](
-    id: String,
     orderedOptions: List[A]
   ): Formatter[A] =
     new Formatter[A] {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/DmsSubmissionController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/DmsSubmissionController.scala
@@ -20,14 +20,12 @@ import cats.instances.future._
 import cats.instances.int._
 import cats.syntax.eq._
 import com.google.inject.Inject
-import play.api.Configuration
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.CGTPropertyDisposalsConnector
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.SessionUpdates
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.{AuthenticatedAction, RequestWithSessionData, SessionDataAction, WithAuthAndSessionDataAction}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, SessionData}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
@@ -36,8 +34,6 @@ class DmsSubmissionController @Inject() (
   val authenticatedAction: AuthenticatedAction,
   val sessionDataAction: SessionDataAction,
   cgtPropertyDisposalsConnector: CGTPropertyDisposalsConnector,
-  config: Configuration,
-  sessionStore: SessionStore,
   cc: MessagesControllerComponents
 )(implicit ec: ExecutionContext)
     extends FrontendController(cc)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/accessibility_statement.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/accessibility_statement.scala.html
@@ -32,7 +32,7 @@
 @title = @{messages(s"$key.title")}
 @availableAtLocation = @{ s"tax.service.gov.uk${routes.LandingPageController.landingPage().url}" }
 
-@mainTemplate(title = title, userType = None, withSignOutLink = false) {
+@mainTemplate(title = title, withSignOutLink = false) {
 
  @caption(messages(s"$key.caption"))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/details_updated.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/details_updated.scala.html
@@ -19,7 +19,6 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.accounts.routes
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionDetail
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -28,11 +27,11 @@
     accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.account_menu
 )
 
-@(detailChanged: SubscriptionDetail)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+@(detailChanged: SubscriptionDetail)(implicit messages:Messages, appConfig: ViewConfig)
 
 @title = @{messages(s"account.manageYourDetails.$detailChanged.changed")}
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = false, accountMenu = Some(accountMenu(None))) {
+@mainTemplate(title = title, withSignOutLink = false, accountMenu = Some(accountMenu(None))) {
 
   @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/home.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/home.scala.html
@@ -26,7 +26,6 @@
 mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
 pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
 accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.account_menu,
-insetPanel: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.inset_panel,
 buttonLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.button_link,
 sentReturnsList: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.account.components.sent_returns_list,
 draftReturnsList: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.account.components.draft_returns_list,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/home.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/home.scala.html
@@ -19,7 +19,6 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.account.AccountMenuItem
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 
 @this(
@@ -32,13 +31,13 @@ draftReturnsList: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.account.co
 caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )
 
-@(subscribed: Subscribed)(implicit request:RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(subscribed: Subscribed)(implicit messages: Messages, appConfig: ViewConfig)
 
 @isAnAgent = @{subscribed.agentReferenceNumber.isDefined}
 @title = @{messages(s"account.home.title")}
 @subtitle = @{messages("account.home.subtitle", subscribed.subscribedDetails.cgtReference.value)}
 
-@mainTemplate(title = title, userType = request.userType, mainClass=Some("full-width"), withSignOutLink = false, accountMenu=Some(accountMenu(Some(AccountMenuItem.Home())))) {
+@mainTemplate(title = title, mainClass=Some("full-width"), withSignOutLink = false, accountMenu=Some(accountMenu(Some(AccountMenuItem.Home())))) {
 
  <div class="grid-row">
   <div class="column-two-thirds account-header">

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/manage_your_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/manage_your_details.scala.html
@@ -26,14 +26,11 @@
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
- formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
  cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
  cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
  cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change,
  addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.address_display,
- submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
- warningMessage: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning,
  accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.account_menu
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/manage_your_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/manage_your_details.scala.html
@@ -22,7 +22,6 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.DisplayFormat.Block
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.account.AccountMenuItem
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -35,7 +34,7 @@
 )
 
 
-@(details: SubscribedDetails)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(details: SubscribedDetails)(implicit messages: Messages, appConfig: ViewConfig)
 
 @fullName = @{details.name.fold(_.value, n => s"${n.firstName} ${n.lastName}")}
 @title = @{messages("account.manageYourDetails.title", fullName)}
@@ -49,7 +48,7 @@
 
 @changeAccountName = @{details.name.fold(_ => Html(""), _ => Html(messages(s"account.manageYourDetails.individual.p2", appConfig.tellHmrcChangeDetails)))}
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = false, accountMenu=Some(accountMenu(Some(AccountMenuItem.ManageYourDetails())))) {
+@mainTemplate(title = title, withSignOutLink = false, accountMenu=Some(accountMenu(Some(AccountMenuItem.ManageYourDetails())))) {
 
  @pageHeading(title, Some(messages("account.caption")))
   @cyaSection(None, Some("cya-questions-long no-border")) {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/signed_out.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/signed_out.scala.html
@@ -30,7 +30,7 @@
 
 @title = @{messages("signed-out.title")}
 
-@mainTemplate(title = title, userType = None, withSignOutLink = false) {
+@mainTemplate(title = title, withSignOutLink = false) {
 
   @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_nonUk_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_nonUk_address.scala.html
@@ -81,7 +81,7 @@
 @menu = {@if(addressJourneyType.showAccountMenu()) { @accountMenu(None) }}
 
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
 
   @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_postcode.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_postcode.scala.html
@@ -73,7 +73,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 @menu = {@if(addressJourneyType.showAccountMenu()) { @accountMenu(None) }}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
 
  @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_uk_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_uk_address.scala.html
@@ -92,7 +92,7 @@
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 @menu = {@if(addressJourneyType.showAccountMenu()) { @accountMenu(None) }}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
 
   @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/isUk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/isUk.scala.html
@@ -66,7 +66,7 @@
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 @menu = {@if(addressJourneyType.showAccountMenu()) { @accountMenu(None) }}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
   @backLinkComponent(backLink)
 
   @if(hasErrors) {
@@ -77,7 +77,6 @@
    @yesNo(
     fieldId = key,
     label = pageHeading(title, Some(messages(addressJourneyType.captionMessageKey()))),
-    labelAsHeading = true,
     errorKey = form.error(key).map(e => s"${journeyErrorKey.stripPrefix(".")}${e.message}"),
     hasErrors = hasErrors,
     selected = form.value

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/select_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/select_address.scala.html
@@ -56,7 +56,7 @@ representativeType: Option[Either[PersonalRepresentative.type, Capacitor.type]]
  else ""
 }
 @journeyErrorKey = @{ addressJourneyType match {
- case f: AddressJourneyType.Returns.FillingOutReturnAddressJourney => ".returns."
+ case _: AddressJourneyType.Returns.FillingOutReturnAddressJourney => ".returns."
  case _ => ""
 }}
 @title = @{ addressJourneyType match {
@@ -73,7 +73,7 @@ representativeType: Option[Either[PersonalRepresentative.type, Capacitor.type]]
 @menu = {@if(addressJourneyType.showAccountMenu()) { @accountMenu(None) }}
 
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = !addressJourneyType.showAccountMenu(), accountMenu = Some(menu)) {
 
  @backLinkComponent(backLink)
 
@@ -87,7 +87,6 @@ representativeType: Option[Either[PersonalRepresentative.type, Capacitor.type]]
    options = addresses.map(a => addressDisplay(a, Line)),
    selected = form.value.map(addresses.indexOf(_)),
    label = pageHeading(title, Some(messages(addressJourneyType.captionMessageKey()))),
-   labelAsHeading = true,
    errorKey = form.error(key).map(e => s"${journeyErrorKey.stripPrefix(".")}${userKey.stripPrefix(".")}${e.message}"),
    hasErrors = hasErrors
   )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agent_no_enrolment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agent_no_enrolment.scala.html
@@ -20,7 +20,6 @@
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.routes
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -35,7 +34,7 @@
 @key = @{ "agentNoEnrolment" }
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = Some(UserType.Agent), withSignOutLink = false) {
+@mainTemplate(title = title, withSignOutLink = false) {
 
     @pageHeading(title)
     <p>@Html(messages(s"$key.p1", viewConfig.createAgentsAccountUrl))</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/confirm_client.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/confirm_client.scala.html
@@ -35,7 +35,7 @@
 
 @title = @{messages("agent.confirm-client.title")}
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, withSignOutLink = true) {
 
  @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_client_cgt_ref.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_client_cgt_ref.scala.html
@@ -39,7 +39,7 @@
 @title = @{messages("agent.enter-client-cgt-ref.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, hasErrors = hasErrors, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
  @if(hasErrors) {
   @errorSummary(form)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_country.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_country.scala.html
@@ -39,7 +39,7 @@
 @title = @{messages("agent.enter-client-country.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, hasErrors = hasErrors, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
  @backLinkComponent(routes.AgentAccessController.enterClientsCgtRef())
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_postcode.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_postcode.scala.html
@@ -39,7 +39,7 @@
 @title = @{messages("agent.enter-client-postcode.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, hasErrors = hasErrors, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
  @backLinkComponent(routes.AgentAccessController.enterClientsCgtRef())
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/too_many_attempts.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/too_many_attempts.scala.html
@@ -18,7 +18,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.agents.routes
 
 @this(
@@ -27,12 +26,12 @@ pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page
 backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@()(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("agent.too-many-attempts.title")}
 @enterCgtRefCall = @{routes.AgentAccessController.enterClientsCgtRef()}
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, withSignOutLink = true) {
 
     @backLinkComponent(enterCgtRefCall)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents_landing_page.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents_landing_page.scala.html
@@ -47,7 +47,7 @@
     </div>
 }
 
-@mainTemplate(title = title, userType = None, withSignOutLink = false, sidebar = Some(sidebarContent)) {
+@mainTemplate(title = title, withSignOutLink = false, sidebar = Some(sidebarContent)) {
 
     <h1 class="heading-xlarge">@title</h1>
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents_landing_page.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents_landing_page.scala.html
@@ -21,8 +21,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.routes
 
 @this(
-        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-        warningMessage: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning
+        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template
 )
 
 @()(implicit messages: Messages, appConfig: ViewConfig)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/checkbox_group.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/checkbox_group.scala.html
@@ -29,9 +29,7 @@
     label: Html,
     options: List[RadioOption],
     helpText: Option[Html] = None,
-    labelAsHeading: Boolean = false,
     error: Option[FormError] = None,
-    hasErrors: Boolean = false,
     selected: List[Int]
 )(implicit messages: Messages)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/date_input.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/date_input.scala.html
@@ -28,7 +28,6 @@
   monthValue: Option[String],
   yearValue: Option[String],
   helpText: Option[Html],
-  labelAsHeading: Boolean,
   errorKey: Option[String],
   hasErrors: Boolean
 )(implicit messages: Messages)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/radio_group.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/radio_group.scala.html
@@ -26,7 +26,6 @@
   label: Html,
   options: List[Html],
   helpText: Option[Html] = None,
-  labelAsHeading: Boolean = false,
   errorKey: Option[String] = None,
   hasErrors: Boolean = false,
   selected: Option[Int] = None

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/radio_group_conditional.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/radio_group_conditional.scala.html
@@ -29,9 +29,7 @@
         label: Html,
         options: List[RadioOption],
         helpText: Option[Html] = None,
-        labelAsHeading: Boolean = false,
         error: Option[FormError] = None,
-        hasErrors: Boolean = false,
         selected: Option[Int] = None,
         customErrorKey: Option[String] = None
 )(implicit messages: Messages)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/yes_no.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/yes_no.scala.html
@@ -25,7 +25,6 @@
   fieldId: String,
   label: Html,
   helpText: Option[Html] = None,
-  labelAsHeading: Boolean = false,
   errorKey: Option[String] = None,
   hasErrors: Boolean = false,
   selected: Option[Boolean] = None,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/error_template.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/error_template.scala.html
@@ -35,4 +35,4 @@
 
 }
 
-@govUkWrapper(appConfig = appConfig, title = pageTitle, contentHeader = Some(contentHeader), mainContent = mainContent, withAccount = false, userType = userType)
+@govUkWrapper(appConfig = appConfig, title = pageTitle, contentHeader = Some(contentHeader), mainContent = mainContent, withAccount = false)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/error_template.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/error_template.scala.html
@@ -17,12 +17,11 @@
 @import play.api.i18n.Messages
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 
 @this(govUkWrapper: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.govuk_wrapper)
 
 
-@(userType: Option[UserType], pageTitle: String, heading: String, message: String, extraMessage: Option[String] = None)(implicit messages: Messages, appConfig: ViewConfig)
+@(pageTitle: String, heading: String, message: String, extraMessage: Option[String] = None)(implicit messages: Messages, appConfig: ViewConfig)
 
 @contentHeader = {
   <h1>@heading</h1>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/govuk_wrapper.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/govuk_wrapper.scala.html
@@ -23,14 +23,12 @@
 @import cats.syntax.eq._
 @import controllers.routes
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{routes => controllerRoutes}
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 
 @this(
     govUkTemplate: views.html.layouts.GovUkTemplate,
     uiHead: uk.gov.hmrc.play.views.html.layouts.Head,
     uiHeaderNav: uk.gov.hmrc.play.views.html.layouts.HeaderNav,
     uiFooter: uk.gov.hmrc.play.views.html.layouts.Footer,
-    uiServiceInfo: uk.gov.hmrc.play.views.html.layouts.ServiceInfo,
     uiMainContentHeader: uk.gov.hmrc.play.views.html.layouts.MainContentHeader,
     uiMainContent: uk.gov.hmrc.play.views.html.layouts.MainContent,
     uiFooterLinks: uk.gov.hmrc.play.views.html.layouts.FooterLinks,
@@ -42,7 +40,6 @@
 
 @(appConfig: ViewConfig,
   title: String,
-  userType: Option[UserType],
   hasErrors: Boolean = false,
   mainClass: Option[String] = None,
   mainDataAttributes: Option[Html] = None,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/landing_page.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/landing_page.scala.html
@@ -21,8 +21,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.routes
 
 @this(
-        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-        warningMessage: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning
+        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template
 )
 
 @()(implicit messages: Messages, appConfig: ViewConfig)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/landing_page.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/landing_page.scala.html
@@ -62,7 +62,7 @@
     </div>
 }
 
-@mainTemplate(title = title, userType = None, withSignOutLink = false, sidebar = Some(sidebarContent)) {
+@mainTemplate(title = title, withSignOutLink = false, sidebar = Some(sidebarContent)) {
 
     <h1 class="heading-xlarge">@title</h1>
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/main_template.scala.html
@@ -21,7 +21,6 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 
 @this(
-        uiSidebar: uk.gov.hmrc.play.views.html.layouts.Sidebar,
         uiArticle: uk.gov.hmrc.play.views.html.layouts.Article,
         govUkWrapper: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.govuk_wrapper
 )
@@ -29,7 +28,6 @@
 @(title: String,
         hasErrors: Boolean = false,
         userType: Option[UserType],
-        sidebarLinks: Option[Html] = None,
         contentHeader: Option[Html] = None,
         bodyClasses: Option[String] = None,
         mainClass: Option[String] = None,
@@ -44,7 +42,6 @@
 
 @govUkWrapper(appConfig = appConfig,
     title = title,
-    userType = userType,
     hasErrors = hasErrors,
     mainClass = mainClass,
     bodyClasses = bodyClasses,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/main_template.scala.html
@@ -18,7 +18,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 
 @this(
         uiArticle: uk.gov.hmrc.play.views.html.layouts.Article,
@@ -27,7 +26,6 @@
 
 @(title: String,
         hasErrors: Boolean = false,
-        userType: Option[UserType],
         contentHeader: Option[Html] = None,
         bodyClasses: Option[String] = None,
         mainClass: Option[String] = None,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/already_subscribed_with_different_gg_account.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/already_subscribed_with_different_gg_account.scala.html
@@ -18,18 +18,17 @@
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.routes
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
        pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@()(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("alreadySubscribedWithDifferentGGAccount.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
    @pageHeading(title)
    <p>
     @messages("alreadySubscribedWithDifferentGGAccount.p")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/change_gg_account.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/change_gg_account.scala.html
@@ -19,7 +19,6 @@
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.routes
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSubscriptionReady
 
 @this(
        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,11 +26,11 @@
        backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSubscriptionReady[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("changeGGAccount.title")}
 
-@mainTemplate(title = title, userType = request.sessionData.userType) {
+@mainTemplate(title = title) {
 
    @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/contactname/contact_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/contactname/contact_name.scala.html
@@ -47,7 +47,7 @@
 @menu = {@if(showAccountMenu) { @accountMenu(None) }}
 
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = !showAccountMenu, accountMenu = Some(menu)) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = !showAccountMenu, accountMenu = Some(menu)) {
 
   @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/contactname/contact_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/contactname/contact_name.scala.html
@@ -26,7 +26,6 @@
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-        pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
         textInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.text_input,
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_a_nino.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_a_nino.scala.html
@@ -37,7 +37,7 @@
 @title = @{messages("haveANino.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
  @if(hasErrors) {
   @errorSummary(form)
@@ -47,7 +47,6 @@
    @yesNo(
     fieldId = key,
     label = pageHeading(title, Some(messages("subscription.caption"))),
-    labelAsHeading = true,
     errorKey = form.error(key).map(e => e.message),
     hasErrors = hasErrors,
     selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_an_sa_utr.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_an_sa_utr.scala.html
@@ -37,9 +37,9 @@
 
 @key = @{"hasSaUtr"}
 @title = @{messages("haveAnSaUtr.title")}
-@hasErrors = @{form.hasErrors || form.hasGlobalErrors}
+@hasErrors = @{form.hasErrors || form.hasGlobalErrors}Ø
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
  @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_an_sa_utr.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_an_sa_utr.scala.html
@@ -30,7 +30,6 @@
  errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
  formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
  yesNo: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.yes_no,
- textInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.text_input,
  backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/check_your_inbox.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/check_your_inbox.scala.html
@@ -59,7 +59,7 @@
  else None
 }
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = !isManagingSubscriptionJourney, accountMenu = menu) {
+@mainTemplate(title = title, withSignOutLink = !isManagingSubscriptionJourney, accountMenu = menu) {
 
  @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/check_your_inbox.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/check_your_inbox.scala.html
@@ -29,7 +29,6 @@
  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
  submitButton:  uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
  backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
- alertBanner: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.alert_banner,
  accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.account_menu,
  caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/email_verified.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/email_verified.scala.html
@@ -21,7 +21,6 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailJourneyType
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.email.Email
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -30,7 +29,7 @@
  caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )
 
-@(email: Email, continueCall: Call, emailJourneyType: EmailJourneyType)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(email: Email, continueCall: Call, emailJourneyType: EmailJourneyType)(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("confirmEmail.verified.title")}
 
@@ -46,7 +45,7 @@
  else None
 }
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = !isManagingSubscriptionJourney, accountMenu = menu) {
+@mainTemplate(title = title, withSignOutLink = !isManagingSubscriptionJourney, accountMenu = menu) {
 
   @caption(messages(emailJourneyType.captionMessageKey))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/enter_email.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/enter_email.scala.html
@@ -67,7 +67,7 @@
   }
  }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = !isManagingSubscriptionJourney, accountMenu = menu) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = !isManagingSubscriptionJourney, accountMenu = menu) {
 
  @backLink.map(link => backLinkComponent(link))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/enter_email.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/enter_email.scala.html
@@ -29,7 +29,6 @@
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
  errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
  formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
- pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
  textInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.text_input,
  submitButton:  uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
  backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/enter_sa_utr_and_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/enter_sa_utr_and_name.scala.html
@@ -43,7 +43,7 @@
 @firstNameKey = @{"firstName"}
 @lastNameKey = @{"lastName"}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
  @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/failed_iv.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/failed_iv.scala.html
@@ -31,7 +31,7 @@
 
 @title = @{messages("iv.failedIv.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/failed_matching.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/failed_matching.scala.html
@@ -31,7 +31,7 @@
 
 @title = @{messages("iv.failedMatching.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title)
  <p>@messages("iv.failedMatching.p1")</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/insufficient_evidence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/insufficient_evidence.scala.html
@@ -17,18 +17,17 @@
 @import play.api.i18n.Messages
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@()(implicit messages: Messages, viewConfig: ViewConfig)
 
 @title = @{messages("iv.insufficientEvidence.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
    @pageHeading(title)
   <p>@messages("iv.insufficientEvidence.p1"))</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/locked_out.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/locked_out.scala.html
@@ -17,18 +17,17 @@
 @import play.api.i18n.Messages
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@()(implicit messages: Messages, viewConfig: ViewConfig)
 
 @title = @{messages("iv.lockedOut.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @pageHeading(title)
   <p>@messages("iv.lockedOut.p1")</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/precondition_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/precondition_failed.scala.html
@@ -17,18 +17,17 @@
 @import play.api.i18n.Messages
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@()(implicit messages: Messages, viewConfig: ViewConfig)
 
 @title = @{messages("iv.preconditionFailed.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @pageHeading(title)
   <p>@messages("iv.preconditionFailed.p1")</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/technical_iv_issues.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/technical_iv_issues.scala.html
@@ -31,7 +31,7 @@
 
 @title = @{messages("iv.technicalIssue.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title)
  <p>@messages("iv.technicalIssue.p")</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/time_out.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/time_out.scala.html
@@ -31,7 +31,7 @@
 
 @title = @{messages("iv.timeout.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title)
  <p>@messages("iv.timeout.p1")</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/user_aborted.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/user_aborted.scala.html
@@ -31,7 +31,7 @@
 
 @title = @{messages("iv.userAborted.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title)
  <p>@messages("iv.userAborted.p1")</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/name/enter_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/name/enter_name.scala.html
@@ -43,7 +43,7 @@
 @title = @{messages("enterName.title")}
 @menu = {@if(showAccountMenu) { @accountMenu(None) }}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = !showAccountMenu, accountMenu = Some(menu)) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = !showAccountMenu, accountMenu = Some(menu)) {
 
   @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/register_your_trust.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/register_your_trust.scala.html
@@ -24,7 +24,6 @@
 @this(
        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
        pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-       buttonLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.button_link,
        backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/register_your_trust.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/register_your_trust.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,11 +26,11 @@
        backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("registerTrust.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
    @backLinkComponent(backLink)
    @pageHeading(title)
    <p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/registration/check_your_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/registration/check_your_details.scala.html
@@ -41,7 +41,7 @@
 
 @title = @{messages("registration.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title, Some(messages("registration.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/registration/select_entity_type.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/registration/select_entity_type.scala.html
@@ -46,7 +46,7 @@
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 @options = @{List(EntityType.Trust, EntityType.Individual).map(toMessage)}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
   @backLinkComponent(backLink)
   @if(hasErrors) {
@@ -58,7 +58,6 @@
       fieldId = key,
       label = pageHeading(title, Some(messages("subscription.caption"))),
       options = options,
-      labelAsHeading = true,
       errorKey = form.error(key).map(e => e.message),
       hasErrors = hasErrors,
       selected = form.value.map(entity => options.indexOf(toMessage(entity)))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/check_your_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/check_your_details.scala.html
@@ -41,7 +41,7 @@
 @affinity = @{details.name.fold(_ => "organisation", _ => "individual")}
 @title = @{messages(s"subscription.${affinity}.title")}
 
-@mainTemplate(title = title, userType = request.sessionData.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title, Some(messages("subscription.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/do_you_have_a_trn.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/do_you_have_a_trn.scala.html
@@ -39,7 +39,7 @@
 @title = @{messages("haveATrn.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
     @backLinkComponent(backLink)
 
@@ -51,7 +51,6 @@
         @yesNo(
             fieldId = key,
             label = pageHeading(title, Some(messages("subscription.caption"))),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => e.message),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/do_you_want_to_report_for_a_trust.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/do_you_want_to_report_for_a_trust.scala.html
@@ -38,7 +38,7 @@
 @title = @{messages("isReportingForATrust.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
  @backLinkComponent(backLink)
 
@@ -50,7 +50,6 @@
   @yesNo(
    fieldId = key,
    label = pageHeading(title, Some(messages("subscription.caption"))),
-   labelAsHeading = true,
    errorKey = form.error(key).map(e => e.message),
    hasErrors = hasErrors,
    selected = form.value

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/enter_trn_and_trust_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/enter_trn_and_trust_name.scala.html
@@ -43,7 +43,7 @@
 @trnKey = @{"trn"}
 @trustNameKey = @{"trustName"}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
  @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/report_with_corporate_tax.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/report_with_corporate_tax.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,10 +26,10 @@
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("reportCorpTax.title")}
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
   @backLinkComponent(backLink)
   @pageHeading(title)
   <p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/subscribed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/subscribed.scala.html
@@ -20,7 +20,6 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.accounts.homepage.routes
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -29,13 +28,13 @@
  exitSurveyLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.exit_survey
 )
 
-@(accountDetails: SubscribedDetails)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(accountDetails: SubscribedDetails)(implicit messages: Messages, appConfig: ViewConfig)
 
 @affinity = @{accountDetails.name.fold(_ => "organisation", _ => "individual")}
 
 @title = @{messages("subscribed.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
   @pageHeading(title, Some(messages("subscription.caption")))
   <p>@Html(messages(s"subscribed.${affinity}.p2", accountDetails.cgtReference.value))</p>
   <p>@messages(s"subscribed.${affinity}.p3")</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/too_many_trn_name_match_attempts.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/too_many_trn_name_match_attempts.scala.html
@@ -18,18 +18,17 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
         pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@()(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("enterTrn.tooManyAttempts.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
     @pageHeading(title)
     <p>
     @messages("enterTrn.tooManyAttempts.p1")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/too_many_name_match_attempts.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/too_many_name_match_attempts.scala.html
@@ -18,7 +18,6 @@
 @import play.api.mvc.Call
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
   mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -26,11 +25,11 @@
   backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("enterSaUtr.tooManyAttempts.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/we_need_more_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/we_need_more_details.scala.html
@@ -18,7 +18,6 @@
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.NeedMoreDetailsDetails
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -26,7 +25,7 @@
  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading
 )
 
-@(details: NeedMoreDetailsDetails)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(details: NeedMoreDetailsDetails)(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("weNeedMoreDetails.title")}
 @affinity = @{details.affinityGroup match {
@@ -34,7 +33,7 @@
   case _ => "individual"
 }}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
  @pageHeading(title, Some(messages("weNeedMoreDetails.caption")))
  <p>
   @messages("weNeedMoreDetails.p")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/we_only_support_gg.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/we_only_support_gg.scala.html
@@ -19,18 +19,17 @@
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.routes
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@()(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("weOnlySupportGG.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/wrong_gg_account_for_trust.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/wrong_gg_account_for_trust.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,11 +26,11 @@
  backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("wrongAccountForTrusts.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
   @backLinkComponent(backLink)
   @pageHeading(title)
   <p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/wrong_gg_account_for_trust.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/wrong_gg_account_for_trust.scala.html
@@ -24,7 +24,6 @@
 @this(
  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
- buttonLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.button_link,
  backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_date.scala.html
@@ -59,7 +59,7 @@
 @title = @{messages(s"$key$userKey.title")}
 @errorKey = @{List("acquisitionDate-day", "acquisitionDate-month", "acquisitionDate-year", "acquisitionDate").map(form.error).find(_.isDefined).flatten}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
     @backLinkComponent(backLink)
 
@@ -75,7 +75,6 @@
             monthValue = form.data.get("acquisitionDate-month"),
             yearValue = form.data.get("acquisitionDate-year"),
             helpText = Some(Html(messages(s"$key$userKey.helpText"))),
-            labelAsHeading = true,
             errorKey = errorKey.map(e => s"${e.key}$userKey.${e.message}"),
             hasErrors = hasErrors
         )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_fees.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_fees.scala.html
@@ -99,7 +99,7 @@
     })
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -115,7 +115,6 @@
             label = pageHeading(title),
             selected = selectedIndex,
             error = form.error(key),
-            hasErrors = hasErrors,
             options = options,
             helpText = Some(Html(messages(s"$key$userKey$rebasingKey.helpText")))
         )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_method.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_method.scala.html
@@ -33,7 +33,6 @@
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
     errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-    radioGroup: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group,
     backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
     returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
     radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_method.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_method.scala.html
@@ -113,7 +113,7 @@
     })
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -129,7 +129,6 @@
             label = pageHeading(title),
             selected = selectedIndex,
             error = form.error(key),
-            hasErrors = hasErrors,
             options = options,
             customErrorKey = Some(s"$key$userKey")
         )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
@@ -66,7 +66,7 @@
   case _ => (messages(s"${key}NotBought$userKey.title", TimeUtils.govDisplayFormat(acquisitionDate.value)), Html(messages(s"${key}NotBought$userKey.helpText")), s"acquisitionPriceNotBought$userKey")
 }}
 
-@mainTemplate(title = titleWithHelpTextAndContext._1, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = titleWithHelpTextAndContext._1, hasErrors = hasErrors) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
@@ -31,7 +31,6 @@
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
     errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/check_your_answers.scala.html
@@ -43,7 +43,7 @@
 
 @title = @{messages("acquisitionDetails.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title, Some(messages("acquisitionDetails.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/improvement_costs.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/improvement_costs.scala.html
@@ -98,7 +98,7 @@
     })
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -114,7 +114,6 @@
             label = pageHeading(title),
             selected = selectedIndex,
             error = form.error(key),
-            hasErrors = hasErrors,
             options = options,
             helpText = Some(Html(messages(s"$key$userKey$rebasingKey.helpText", TimeUtils.govDisplayFormat(rebaseCutOffDate))))
         )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/rebased_acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/rebased_acquisition_price.scala.html
@@ -64,7 +64,7 @@
 @title = @{messages(s"$key.title", rebaseCutOffDateDisplayString)}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/rebased_acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/rebased_acquisition_price.scala.html
@@ -31,13 +31,11 @@
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
     errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
     backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
     returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
-    radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional,
     unitInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.unit_input,
     caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
     details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/should_use_rebase.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/should_use_rebase.scala.html
@@ -34,8 +34,6 @@
  formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
  backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
  returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
- radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional,
- unitInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.unit_input,
  yesNo: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.yes_no,
  caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/should_use_rebase.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/should_use_rebase.scala.html
@@ -45,7 +45,7 @@
 @title = @{messages(s"$key.title", rebaseCutOffDateDisplayString)}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
  @backLinkComponent(backLink)
 
@@ -59,7 +59,6 @@
   @yesNo(
    fieldId = key,
    label = pageHeading(title),
-   labelAsHeading = true,
    errorKey = form.error(key).map(e => e.message),
    hasErrors = hasErrors,
    selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/summary.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/summary.scala.html
@@ -32,8 +32,7 @@
 @this(
     cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
     cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
-    cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change,
-    addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.address_display
+    cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/acquisition_price.scala.html
@@ -58,7 +58,7 @@
 @title = @{messages(s"$key.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/acquisition_price.scala.html
@@ -28,7 +28,6 @@
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
     errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_date.scala.html
@@ -32,7 +32,6 @@
  errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
  formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
  dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input,
- backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
  returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
  caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_date.scala.html
@@ -48,7 +48,7 @@
 @title = @{messages(s"$key$userKey.title")}
 @errorKey = @{List("disposalDate-day", "disposalDate-month", "disposalDate-year", "disposalDate").map(form.error).find(_.isDefined).flatten}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
  @if(hasErrors) {
   @errorSummary(form)
@@ -64,7 +64,6 @@
    monthValue = form.data.get(s"$key-month"),
    yearValue = form.data.get(s"$key-year"),
    helpText = Some(Html(messages(s"$key$userKey.helpText"))),
-   labelAsHeading = true,
    errorKey = errorKey.map(e => s"${e.key}.${e.message}"),
    hasErrors = hasErrors
   )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
@@ -28,7 +28,6 @@
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
     errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
@@ -59,7 +59,7 @@
 @title = @{messages(s"$key.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/enter_uprn.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/enter_uprn.scala.html
@@ -60,7 +60,7 @@
     else messages("returns.property-details.multipleDisposals.caption")
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/enter_uprn.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/enter_uprn.scala.html
@@ -33,7 +33,6 @@
   errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
   formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
   backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
-  accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.account_menu,
   returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
   caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/has_valid_postcode.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/has_valid_postcode.scala.html
@@ -53,7 +53,7 @@
         messages("returns.property-details.multipleDisposals.caption")
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
     @backLinkComponent(backLink)
 
@@ -67,7 +67,6 @@
         @yesNo(
             fieldId = key,
             label = pageHeading(title),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => s"$journeyContext.${e.message}"),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_check_your_answers.scala.html
@@ -41,7 +41,7 @@ summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.address.mul
 
 @title = @{messages("returns.property-address.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title, Some(messages("returns.property-details.multipleDisposals.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_guidance.scala.html
@@ -27,7 +27,6 @@
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
         pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_guidance.scala.html
@@ -50,7 +50,7 @@
 }
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, withSignOutLink = true) {
     @backLinkComponent(backLink)
 
     @caption(messages("returns.property-details.multipleDisposals.caption"))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_disposal_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_disposal_check_your_answers.scala.html
@@ -35,7 +35,7 @@
 
 @title = @{messages("returns.property-address.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title, Some(messages("returns.property-address.singleDisposal.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_indirect_disposal_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_indirect_disposal_check_your_answers.scala.html
@@ -36,7 +36,7 @@
 
 @title = @{messages("companyDetails.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @caption(messages("companyDetails.caption"))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/check_all_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/check_all_answers.scala.html
@@ -30,7 +30,6 @@
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
         pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-        taskLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.taskLink,
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/check_all_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/check_all_answers.scala.html
@@ -60,7 +60,7 @@
 
 @title = @{ messages("checkAllAnswers.title") }
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @backLinkComponent(routes.TaskListController.taskList())
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/confirmation_of_submission.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/confirmation_of_submission.scala.html
@@ -86,7 +86,7 @@
   }
 }
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
 <div class="govuk-box-highlight">
      <p id="user-details-name">

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/confirmation_of_submission.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/confirmation_of_submission.scala.html
@@ -32,7 +32,6 @@
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-        pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
         exitSurveyLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.exit_survey,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/check_your_answers.scala.html
@@ -44,7 +44,7 @@
 
 @title = @{messages("returns.disposal-details.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title, Some(messages("returns.disposal-details.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_fees.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_fees.scala.html
@@ -61,7 +61,7 @@
 @title = @{messages(s"$key$userKey$indirectKey.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_fees.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_fees.scala.html
@@ -22,14 +22,12 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{DisposalMethod, ShareOfProperty}
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.components.AutoCompleteType
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{PersonalRepresentative, Capacitor}
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
     errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
@@ -42,8 +40,6 @@
 @(
     form: Form[BigDecimal],
     backLink: Call,
-    disposalMethod: DisposalMethod,
-    shareOfProperty: ShareOfProperty,
     isATrust: Boolean,
     representativeType: Option[Either[PersonalRepresentative.type, Capacitor.type]],
     isIndirectDisposal: Boolean

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_price.scala.html
@@ -22,14 +22,13 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{DisposalMethod, ShareOfProperty}
+@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalMethod
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.components.AutoCompleteType
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{PersonalRepresentative, Capacitor}
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
     errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
@@ -43,7 +42,6 @@
     form: Form[BigDecimal],
     backLink: Call,
     disposalMethod: DisposalMethod,
-    shareOfProperty: ShareOfProperty,
     isATrust: Boolean,
     representativeType: Option[Either[PersonalRepresentative.type, Capacitor.type]],
     isIndirectDisposal: Boolean

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_price.scala.html
@@ -67,7 +67,7 @@
 @title = @{ messages(s"$key$userKey$indirectKey$disposalMethodKey.title") }
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/how_much_did_you_own.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/how_much_did_you_own.scala.html
@@ -101,7 +101,7 @@
     })
   }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -118,7 +118,6 @@
         label = pageHeading(title),
         selected = selectedIndex,
         error = form.error(key),
-        hasErrors = hasErrors,
         options = options,
         customErrorKey = Some(s"$key$userKey")
       )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/annual_exempt_amount.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/annual_exempt_amount.scala.html
@@ -76,7 +76,7 @@ details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
     annualExemptAmountString
 ) )) }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = false) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = false) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/annual_exempt_amount.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/annual_exempt_amount.scala.html
@@ -30,7 +30,6 @@
 
 @this(
 mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
 submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
 errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
 formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/check_your_answers.scala.html
@@ -45,7 +45,7 @@
     messages("exemptionsAndLosses.cya.title")
 }
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title, Some(messages("exemptionAndLosses.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/in_year_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/in_year_losses.scala.html
@@ -38,8 +38,7 @@ backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.component
 returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
 unitInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.unit_input,
 caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
-radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional,
-details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/in_year_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/in_year_losses.scala.html
@@ -101,7 +101,7 @@ radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compo
     })
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -117,7 +117,6 @@ radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compo
             label = pageHeading(title),
             selected = selectedIndex,
             error = form.error(key),
-            hasErrors = hasErrors,
             options = options,
             helpText = Some(Html(
                 messages(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/previous_years_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/previous_years_losses.scala.html
@@ -36,8 +36,7 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
         unitInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.unit_input,
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
-        radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+        radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/previous_years_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/previous_years_losses.scala.html
@@ -96,7 +96,7 @@
     })
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -112,7 +112,6 @@
             label = pageHeading(title),
             selected = selectedIndex,
             error = form.error(key),
-            hasErrors = hasErrors,
             options = options,
             helpText = Some(Html(messages(s"$residentSpecificKey.helpText"))),
             customErrorKey = Some(s"$key$userKey")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/check_your_answers.scala.html
@@ -40,7 +40,7 @@ caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
     messages("initialGainOrLoss.cya.title")
 }
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
     @caption(messages("initialGainOrLoss.caption"))
 
     @pageHeading(title, None)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/initial_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/initial_gain_or_loss.scala.html
@@ -119,7 +119,7 @@
     messages(s"$key$userKey.title")
 }
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @backLinkComponent(backLink)
 
@@ -134,7 +134,6 @@
         fieldId = key,
         label = pageHeading(title),
         selected = selectedIndex,
-        hasErrors = form.error(key).isDefined,
         error = form.error(key),
         options = options,
         customErrorKey = customErrorKey,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/initial_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/initial_gain_or_loss.scala.html
@@ -36,11 +36,9 @@
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
-        returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
         unitInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.unit_input,
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
         radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional,
-        radioGroup: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group,
         details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/period_of_admin_not_handled.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/period_of_admin_not_handled.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,12 +26,12 @@
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, viewConfig: ViewConfig)
 
 @key = @{"periodOfAdminNotHandled"}
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/check_your_answers.scala.html
@@ -39,7 +39,7 @@
 
 @title = @{messages("reliefDetails.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title, Some(messages("reliefDetails.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/lettings_relief.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/lettings_relief.scala.html
@@ -95,7 +95,7 @@
 })
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
 @backLinkComponent(backLink)
 
@@ -111,7 +111,6 @@
         label = pageHeading(title),
         selected = selectedIndex,
         error = form.error(key),
-        hasErrors = hasErrors,
         options = options,
         helpText = Some(Html(messages(s"$key$userKey.helpText"))),
         customErrorKey = Some(customErrorKey)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/other_reliefs.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/other_reliefs.scala.html
@@ -127,7 +127,7 @@
     })
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -143,7 +143,6 @@
             label = pageHeading(title),
             selected = selectedIndex,
             error = form.error(key),
-            hasErrors = hasErrors,
             options = options,
             helpText = Some(Html(messages(s"$key$userKey.helpText", ""))),
             customErrorKey = Some(s"$key$userKey")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/private_residents_relief.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/private_residents_relief.scala.html
@@ -95,7 +95,7 @@
  })
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
 @backLinkComponent(backLink)
 
@@ -111,7 +111,6 @@
   label = pageHeading(title),
   selected = selectedIndex,
   error = form.error(key),
-  hasErrors = hasErrors,
   options = options,
   helpText = Some(Html(messages(s"$key$userKey.helpText"))),
   customErrorKey = Some(customErrorKey)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/change_contact_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/change_contact_name.scala.html
@@ -57,7 +57,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
     messages(s"$key.change.title")
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_contact_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_contact_details.scala.html
@@ -44,7 +44,7 @@
 @key = @{ "representeeContactDetails" }
 @title = @{messages(s"$key.title") }
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @caption(messages("representee.caption"))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_your_answers.scala.html
@@ -41,7 +41,7 @@
 
 @title = @{messages("representee.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_your_answers.scala.html
@@ -27,7 +27,6 @@
         pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-        returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
         summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.representee.summary,
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
@@ -36,7 +35,6 @@
 @(
         answers: CompleteRepresenteeAnswers,
         representativeType: Either[PersonalRepresentative.type, Capacitor.type],
-        displayReturnToSummaryLink: Boolean,
         backLink: Call
 )(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/confirm_person.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/confirm_person.scala.html
@@ -69,7 +69,7 @@ backLink: Call
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 @formTitle = @{messages("representeeConfirmPerson.formTitle")}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
     @backLinkComponent(backLink)
 
     @if(hasErrors) {
@@ -87,7 +87,6 @@ backLink: Call
         @yesNo(
             fieldId = key,
             label = Html(s"<h2>$formTitle</h2>"),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => e.message),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/confirm_person.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/confirm_person.scala.html
@@ -35,7 +35,6 @@
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative}
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.representee.routes
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeReferenceId
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.IndividualName
@@ -57,7 +56,6 @@
 @(
 id: RepresenteeReferenceId,
 name: IndividualName,
-representativeType: Either[PersonalRepresentative.type, Capacitor.type],
 displayReturnToSummaryLink: Boolean,
 form: Form[Boolean],
 backLink: Call
@@ -83,7 +81,7 @@ backLink: Call
 
     @warning(messages("representeeConfirmPerson.warning"))
 
-    @summary_for_confirmation(id, name, representativeType)
+    @summary_for_confirmation(id, name)
 
     @formWrapper(routes.RepresenteeController.confirmPersonSubmit(), 'novalidate -> "novalidate") {
         @yesNo(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_date_of_death.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_date_of_death.scala.html
@@ -42,7 +42,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
 @title = @{messages(s"$key.title")}
 @errorKey = @{List(s"$key-day", s"$key-month", s"$key-year", key).map(form.error).find(_.isDefined).flatten}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
 
 @backLinkComponent(backLink)
@@ -59,7 +59,6 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
   monthValue = form.data.get(s"$key-month"),
   yearValue = form.data.get(s"$key-year"),
   helpText = Some(Html(messages(s"$key.helpText"))),
-  labelAsHeading = true,
   errorKey = errorKey.map(e => s"${e.key}.${e.message}"),
   hasErrors = hasErrors
  )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_date_of_death.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_date_of_death.scala.html
@@ -32,7 +32,6 @@ errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.err
 formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
 dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input,
 backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
-caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
 returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_name.scala.html
@@ -52,7 +52,7 @@
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 @title = @{messages(s"$key$representativeTypeInterpolator.title")}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_reference_number.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_reference_number.scala.html
@@ -111,7 +111,7 @@
 }
 
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -127,7 +127,6 @@
             label = pageHeading(title),
             selected = selectedIndex,
             error = form.error(key),
-            hasErrors = hasErrors,
             options = options,
             helpText = Some(Html(messages(s"$key.helpText")))
         )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/name_match_error.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/name_match_error.scala.html
@@ -33,7 +33,7 @@
 @key = @{ "representeeNameMatchError" }
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @caption(messages("representee.caption"))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/summary_for_confirmation.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/summary_for_confirmation.scala.html
@@ -16,8 +16,6 @@
 
 @import play.api.i18n.Messages
 @import play.twirl.api.Html
-
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative}
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.NINO
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.SAUTR
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.CgtReference
@@ -31,19 +29,17 @@
 @this(
 cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
 cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
-cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change
 )
 
 @(
         id: RepresenteeReferenceId,
-        name: IndividualName,
-        representativeType: Either[PersonalRepresentative.type, Capacitor.type]
+        name: IndividualName
 )(implicit messages: Messages)
 @isDisplayedWithLabelAndId = @{
     {
         id match {
-            case RepresenteeNino(NINO(value)) => (false, "", "")
-            case RepresenteeSautr(SAUTR(value)) => (false, "", "")
+            case RepresenteeNino(NINO(_)) => (false, "", "")
+            case RepresenteeSautr(SAUTR(_)) => (false, "", "")
             case RepresenteeCgtReference(CgtReference(value)) => (true, messages("representeeConfirmPerson.summaryLine2.cgtReferenceId"), value)
             case NoReferenceId => (false, "", "")
         }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/too_many_name_match_failures.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/too_many_name_match_failures.scala.html
@@ -17,7 +17,6 @@
 @import play.api.i18n.Messages
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -25,12 +24,12 @@
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )
 
-@()(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+@()(implicit messages:Messages, viewConfig: ViewConfig)
 
 @key = @{ "representeeTooManyNameMatchFailures" }
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @caption(messages("representee.caption"))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/return_saved.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/return_saved.scala.html
@@ -36,7 +36,7 @@ warning: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning
 @title = @{messages("draftReturnSaved.title")}
 @isAnAgent = @{ request.userType.contains(UserType.Agent)}
 @warningMessageKey = @{ s"draftReturnSaved${if(isAnAgent) ".agent" else if (isATrust) ".trust" else ""}.warning" }
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @backLinkComponent(returns.routes.TaskListController.taskList())
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/submit_return_error.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/submit_return_error.scala.html
@@ -23,7 +23,6 @@
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
         pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-        backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/submit_return_error.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/submit_return_error.scala.html
@@ -32,7 +32,7 @@
 @key = @{"submitReturnError"}
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/subsequent_return_exit.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/subsequent_return_exit.scala.html
@@ -18,7 +18,6 @@
 @import play.api.mvc.Call
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -26,12 +25,12 @@
     backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, viewConfig: ViewConfig)
 
 @key=@{"subsequentReturnExit"}
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/check_your_answers.scala.html
@@ -35,7 +35,7 @@
 
     @title = @{messages(s"$key.title")}
 
-    @mainTemplate(title = title, userType = request.userType) {
+    @mainTemplate(title = title) {
 
         @pageHeading(title, Some(messages(s"$key.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/do_you_want_to_upload.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/do_you_want_to_upload.scala.html
@@ -42,7 +42,7 @@
     @title = @{messages(s"$key.title")}
     @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-    @mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+    @mainTemplate(title = title, hasErrors = hasErrors) {
 
         @backLinkComponent(backLink)
 
@@ -57,7 +57,6 @@
             @yesNo(
                 fieldId = key,
                 label = pageHeading(title),
-                labelAsHeading = true,
                 errorKey = form.error(key).map(e => e.message),
                 hasErrors = hasErrors,
                 selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/expired.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/expired.scala.html
@@ -35,7 +35,7 @@
 @key = @{"supporting-evidence.expired"}
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @caption(messages(s"$key.caption"))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/expired.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/expired.scala.html
@@ -26,10 +26,7 @@
     pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-    summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.supportingevidence.summary,
     cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
-    cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
-    cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change,
     caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_failed.scala.html
@@ -33,7 +33,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
     @key = @{"supporting-evidence.scan-failed"}
     @title = @{messages(s"$key.title")}
 
-    @mainTemplate(title = title, userType = request.userType) {
+    @mainTemplate(title = title) {
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_progress.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_progress.scala.html
@@ -35,7 +35,7 @@
     @key = @{"supporting-evidence.scan-progress"}
     @title = @{messages(s"$key.title")}
 
-    @mainTemplate(title = title, userType = request.userType) {
+    @mainTemplate(title = title) {
 
         @caption(messages(s"$key.caption"))
         @pageHeading(title)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_progress.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_progress.scala.html
@@ -25,7 +25,6 @@
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
     pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-    errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
     formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
     caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
     returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload.scala.html
@@ -24,11 +24,7 @@
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-    errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
-    formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-    yesNo: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.yes_no,
     caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
     returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
     backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.components.AutoCompleteType
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.UpscanUpload
 
 @this(
@@ -31,7 +30,7 @@
     fileInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.file_input
 )
 
-@(upscanUpload : UpscanUpload, backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(upscanUpload : UpscanUpload, backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
     @key = @{"supporting-evidence.upload"}
     @field = @{"file"}
@@ -39,7 +38,7 @@
     @meta = @{upscanUpload.upscanUploadMeta.uploadRequest.fields}
     @href = @{upscanUpload.upscanUploadMeta.uploadRequest.href}
 
-    @mainTemplate(title = title, userType = request.userType) {
+    @mainTemplate(title = title) {
 
         @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload_failed.scala.html
@@ -33,7 +33,7 @@
     @key = @{"supporting-evidence.upload-failed"}
     @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/multiple_disposals_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/multiple_disposals_task_list.scala.html
@@ -16,7 +16,6 @@
 
 @import play.api.i18n.Messages
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DraftMultipleDisposalsReturn
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative}
@@ -31,7 +30,7 @@
         warning: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning
 )
 
-@(draftReturn: DraftMultipleDisposalsReturn)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(draftReturn: DraftMultipleDisposalsReturn)(implicit messages: Messages, viewConfig: ViewConfig)
 
 @title = @{messages("service.title")}
 @representeeState = @{
@@ -90,7 +89,7 @@
 }
 
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_disposal_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_disposal_task_list.scala.html
@@ -17,7 +17,6 @@
 @import play.api.i18n.Messages
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DraftSingleDisposalReturn
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.returns.TaskListStatus
@@ -39,7 +38,7 @@
         taskLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.taskLink
 )
 
-@(draftReturn: DraftSingleDisposalReturn)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(draftReturn: DraftSingleDisposalReturn)(implicit messages: Messages, viewConfig: ViewConfig)
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Country
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers
@@ -127,7 +126,7 @@
     }
 }
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
 @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_indirect_disposal_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_indirect_disposal_task_list.scala.html
@@ -16,7 +16,6 @@
 
 @import play.api.i18n.Messages
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DraftSingleIndirectDisposalReturn
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative}
@@ -31,7 +30,7 @@
         warning: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning
 )
 
-@(draftReturn: DraftSingleIndirectDisposalReturn)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(draftReturn: DraftSingleIndirectDisposalReturn)(implicit messages: Messages, viewConfig: ViewConfig)
 
 @title = @{messages("service.title")}
 
@@ -85,7 +84,7 @@
 }
 
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_mixed_use_disposal_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_mixed_use_disposal_task_list.scala.html
@@ -16,7 +16,6 @@
 
 @import play.api.i18n.Messages
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DraftSingleMixedUseDisposalReturn
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative}
@@ -31,7 +30,7 @@
         warning: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning
 )
 
-@(draftReturn: DraftSingleMixedUseDisposalReturn)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(draftReturn: DraftSingleMixedUseDisposalReturn)(implicit messages: Messages, viewConfig: ViewConfig)
 
 @title = @{messages("service.title")}
 @representeeState = @{
@@ -83,7 +82,7 @@
 }
 
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/asset_type_not_yet_implemented.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/asset_type_not_yet_implemented.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
 mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,13 +26,13 @@ pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page
 backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @key = @{ "assetTypeNotYetImplemented" }
 
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
 @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/capcitors_personal_representatives_not_handled.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/capcitors_personal_representatives_not_handled.scala.html
@@ -35,7 +35,7 @@
 @key = @{"capacitorsPersonalRepresentativesNotHandled"}
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @backLinkComponent(triage.routes.CommonTriageQuestionsController.whoIsIndividualRepresenting())
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
@@ -41,7 +41,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
 @title = @{messages(s"$key.title")}
 @errorKey = @{List(s"$key-day", s"$key-month", s"$key-year", key).map(form.error).find(_.isDefined).flatten}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
 
 @backLinkComponent(backLink)
@@ -58,7 +58,6 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
   monthValue = form.data.get(s"$key-month"),
   yearValue = form.data.get(s"$key-year"),
   helpText = Some(Html(messages(s"$key.helpText"))),
-  labelAsHeading = true,
   errorKey = errorKey.map(e => s"${e.key}.${e.message}"),
   hasErrors = hasErrors
  )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
@@ -31,7 +31,6 @@ errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.err
 formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
 dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input,
 backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
-caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
 returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_non_uk_residents.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,12 +26,12 @@
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @key = @{"disposalDateTooEarly"}
 @title = @{messages(s"$key.non-uk.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_uk_residents.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,12 +26,12 @@
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @key = @{"disposalDateTooEarly"}
 @title = @{messages(s"$key.uk.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/how_many_properties.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/how_many_properties.scala.html
@@ -58,7 +58,7 @@
     ).map(messageKey =>Html(messages(messageKey)))
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = false) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = false) {
 
     @backLink.map(backLinkComponent(_))
 
@@ -72,7 +72,6 @@
             options = options,
             selected = form.value.map(optionIndex),
             label = pageHeading(title, Some(messages("triage.caption"))),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => e.message),
             hasErrors = hasErrors,
             helpText = Some(Html(messages("numberOfProperties.helpText")))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/asset_type_for_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/asset_type_for_non_uk_residents.scala.html
@@ -93,7 +93,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
     )
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -111,9 +111,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
             selected = form.value.map(_.map(toIndex)).getOrElse(List.empty),
             helpText = Some(Html(messages(s"$key.helpText"))),
             label = pageHeading(title),
-            labelAsHeading = true,
             error = form.error(key),
-            hasErrors = hasErrors
         )
 
         @submitButton(messages(if (hasCreatedDraftReturn) "button.saveAndContinue" else "button.continue"))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/asset_type_for_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/asset_type_for_non_uk_residents.scala.html
@@ -33,7 +33,6 @@ pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page
 submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
 errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
 formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional,
 backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
 caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
 checkboxGroup: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.checkbox_group,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/check_you_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/check_you_answers.scala.html
@@ -24,7 +24,6 @@
 @this(
 mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
 pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details,
 formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
 submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
 caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/check_you_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/check_you_answers.scala.html
@@ -39,7 +39,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
 
 @title = @{messages("multipleDisposals.triage.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, withSignOutLink = true) {
 
  @caption(messages("triage.caption"))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/completion_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/completion_date.scala.html
@@ -44,7 +44,7 @@ details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
 @title = @{messages(s"$key.title")}
 @errorKey = @{List(s"$key-day", s"$key-month", s"$key-year", key).map(form.error).find(_.isDefined).flatten}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
  @backLinkComponent(backLink)
 
@@ -62,7 +62,6 @@ details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
    monthValue = form.data.get(s"$key-month"),
    yearValue = form.data.get(s"$key-year"),
    helpText = Some(Html(messages(s"$key.helpText"))),
-   labelAsHeading = true,
    errorKey = errorKey.map(e => s"${e.key}.${e.message}"),
    hasErrors = hasErrors
   )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/country_of_residence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/country_of_residence.scala.html
@@ -58,7 +58,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
 }
 @title = @{messages(s"multipleDisposalsCountryOfResidence$userKey.title")}
 
-@mainTemplate(title = title, hasErrors = hasErrors, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/guidance.scala.html
@@ -53,7 +53,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
 
 
 @title = @{messages(s"multiple-disposals.guidance$userKey.title")}
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, withSignOutLink = true) {
  @backLinkComponent(backLink)
 
     @caption(messages("triage.caption"))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/how_many_properties.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/how_many_properties.scala.html
@@ -42,7 +42,7 @@
 @title = @{messages(s"$key.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, hasErrors = hasErrors, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/summary.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/summary.scala.html
@@ -27,14 +27,9 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TimeUtils
 
 @this(
-mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
 cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
 cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
-cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change,
-submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link
+cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/tax_year_exchanged.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/tax_year_exchanged.scala.html
@@ -56,7 +56,7 @@
     ).map(messageKey =>Html(messages(messageKey)))
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -73,7 +73,6 @@
             options = options,
             selected = form.value.map(optionIndex),
             label = pageHeading(title),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => e.message),
             hasErrors = hasErrors,
             helpText = None

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_all_properties_residential.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_all_properties_residential.scala.html
@@ -42,7 +42,7 @@
 @title = @{messages(s"$key.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -56,7 +56,6 @@
         @yesNo(
             fieldId = key,
             label = pageHeading(title),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => e.message),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_you_a_uk_resident.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_you_a_uk_resident.scala.html
@@ -64,7 +64,7 @@ caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 @title = @{messages(s"$key$userKey.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -78,7 +78,6 @@ caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
         @yesNo(
             fieldId = key,
             label = pageHeading(title),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => s"$userErrorKey${e.message}"),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/asset_type_for_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/asset_type_for_non_uk_residents.scala.html
@@ -95,7 +95,7 @@
     )
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -109,9 +109,7 @@
             options = options,
             selected = selectedIndex,
             label = pageHeading(title, Some(messages("triage.caption"))),
-            labelAsHeading = true,
             error = form.error(key),
-            hasErrors = hasErrors,
             customErrorKey = Some(s"$key$userKey")
         )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/check_your_answers.scala.html
@@ -40,7 +40,7 @@
 
 @title = @{messages("triage.check-your-answers.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title, Some(messages("triage.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/completion_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/completion_date.scala.html
@@ -60,7 +60,7 @@
 @hasErrors = @{form.hasErrors}
 @errorKey = @{List("completionDate-day", "completionDate-month", "completionDate-year", "completionDate").map(form.error).find(_.isDefined).flatten}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
  @backLinkComponent(backLink)
 
@@ -76,7 +76,6 @@
    monthValue = form.data.get("completionDate-month"),
    yearValue = form.data.get("completionDate-year"),
    helpText = Some(Html(messages(s"$key$userKey.helpText"))),
-   labelAsHeading = true,
    errorKey = errorKey.map(e => s"${e.key}.${e.message}"),
    hasErrors = hasErrors
   )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/country_of_residence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/country_of_residence.scala.html
@@ -61,7 +61,7 @@
 @title = @{messages(s"$messageKey$userKey.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, hasErrors = hasErrors, userType = request.userType, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
@@ -69,7 +69,7 @@
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -81,7 +81,6 @@
         @yesNo(
             fieldId = key,
             label = pageHeading(title, Some(messages("triage.caption"))),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => s"$userErrorPrefix${e.message}"),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
@@ -31,7 +31,6 @@
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-        radioGroup: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group,
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
         yesNo: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.yes_no,
         details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date.scala.html
@@ -60,7 +60,7 @@
 @title = @{messages(s"$key$userKey.title")}
 @hasErrors = @{form.hasErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
  @backLinkComponent(backLink)
 
@@ -76,7 +76,6 @@
    monthValue = form.data.get("disposalDate-month"),
    yearValue = form.data.get("disposalDate-year"),
    helpText = Some(Html(messages(s"$key$userKey.helpText"))),
-   labelAsHeading = true,
    errorKey = form.error(key).map(e => s"${e.key}.${e.message}"),
    hasErrors = hasErrors
   )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date.scala.html
@@ -24,7 +24,6 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AssetType
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative}
 
@@ -43,7 +42,6 @@
   form: Form[LocalDate],
   backLink: Call,
   displayReturnToSummaryLink: Boolean,
-  assetType: AssetType,
   isATrust: Boolean,
   representativeType: Option[Either[PersonalRepresentative.type,Capacitor.type]]
 )(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/how_did_you_dispose.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/how_did_you_dispose.scala.html
@@ -82,7 +82,7 @@
     ).map(messageKey =>Html(messages(messageKey)))
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -96,7 +96,6 @@
             options = options,
             selected = form.value.map(optionIndex),
             label = pageHeading(title, Some(messages("triage.caption"))),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => s"$userErrorPrefix${e.message}"),
             hasErrors = hasErrors
         )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/summary.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/summary.scala.html
@@ -26,14 +26,9 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AssetType
 
 @this(
-        mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-        pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
         cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
         cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
-        cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change,
-        submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-        formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-        returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link
+        cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/were_you_a_uk_resident.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/were_you_a_uk_resident.scala.html
@@ -67,7 +67,7 @@
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 
@@ -79,7 +79,6 @@
         @yesNo(
             fieldId = key,
             label = pageHeading(title, Some(messages("triage.caption"))),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => s"$userTypeErrorPrefix${e.message}"),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/uk_resident_can_only_dispose_residential.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/uk_resident_can_only_dispose_residential.scala.html
@@ -19,7 +19,6 @@
 @import play.twirl.api.Html
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
@@ -27,12 +26,12 @@
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit messages: Messages, appConfig: ViewConfig)
 
 @key = @{"ukResidentCanOnlyReportResidential"}
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
   @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/who_are_you_reporting_for.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/who_are_you_reporting_for.scala.html
@@ -66,7 +66,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
    messageKeys.map(messageKey =>Html(messages(messageKey)))
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = false) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = false) {
 
     @backLink.map(backLinkComponent(_))
 
@@ -80,7 +80,6 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
             options = options,
             selected = form.value.map(optionIndex),
             label = pageHeading(title, Some(messages("triage.caption"))),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => e.message),
             hasErrors = hasErrors
         )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
@@ -64,7 +64,7 @@
 
 @key= @{ "viewReturn" }
 
-@mainTemplate(title = title, userType = request.userType, withSignOutLink = false, accountMenu=Some(accountMenu(None))) {
+@mainTemplate(title = title, withSignOutLink = false, accountMenu=Some(accountMenu(None))) {
 
   @returnHeading(title, returnSummary, subscribedDetails, request.userType)
   

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
@@ -31,10 +31,6 @@
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
         accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.account_menu,
-        pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-        taskLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.taskLink,
-        submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-        formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
         addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.address_display,
         returnHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_banner,
         returnCharges: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_charges,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_check_your_answers.scala.html
@@ -43,7 +43,7 @@ summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.ytdliabilit
 
 @title = @{messages("ytdLiability.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title, Some(messages("ytdLiability.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_summary.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_summary.scala.html
@@ -28,8 +28,7 @@
 @this(
 cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
 cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
-cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change,
-addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.address_display,
+cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/estimated_income.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/estimated_income.scala.html
@@ -63,7 +63,7 @@ details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
 @title = @{messages(s"$key$userKey$nrKey.title", taxYearStartYear, taxYearEndYear)}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = false) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = false) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/estimated_income.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/estimated_income.scala.html
@@ -29,7 +29,6 @@
 
 @this(
 mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
 submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
 errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
 formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/expired_mandatory_evidence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/expired_mandatory_evidence.scala.html
@@ -26,9 +26,7 @@
         pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
         cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
-        cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
-        cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change,
-        submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button
+        cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row
 )
 
 @(expired : MandatoryEvidence)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/expired_mandatory_evidence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/expired_mandatory_evidence.scala.html
@@ -18,7 +18,6 @@
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.yeartodatelliability.routes
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MandatoryEvidence
 
 @this(
@@ -29,12 +28,12 @@
         cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row
 )
 
-@(expired : MandatoryEvidence)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@(expired : MandatoryEvidence)(implicit messages: Messages, viewConfig: ViewConfig)
 
 @key = @{ "mandatoryEvidenceExpired" }
 @title = @{ messages(s"$key.title") }
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
     @caption(messages("ytdLiability.caption"))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/has_estimated_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/has_estimated_details.scala.html
@@ -57,7 +57,7 @@ backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.component
 }
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
     @backLinkComponent(backLink)
 
@@ -71,7 +71,6 @@ backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.component
         @yesNo(
             fieldId = key,
             label = pageHeading(title),
-            labelAsHeading = true,
             errorKey = form.error(key).map(e => e.message),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/mandatory_evidence_scan_progress.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/mandatory_evidence_scan_progress.scala.html
@@ -34,7 +34,7 @@
     @key = @{"mandatoryEvidence.scan-progress"}
     @title = @{messages(s"$key.title")}
 
-    @mainTemplate(title = title, userType = request.userType) {
+    @mainTemplate(title = title) {
 
     @caption(messages(s"$key.caption"))
     @pageHeading(title)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_check_your_answers.scala.html
@@ -40,7 +40,7 @@ summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.ytdliabilit
 
 @title = @{messages("ytdLiability.cya.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(title = title) {
 
  @pageHeading(title, Some(messages("ytdLiability.caption")))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_enter_tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_enter_tax_due.scala.html
@@ -41,7 +41,7 @@
 @title = @{messages(s"$key.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = true) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = true) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_enter_tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_enter_tax_due.scala.html
@@ -26,15 +26,13 @@
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-        pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
         unitInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.unit_input,
-        caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+        caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )
 
 @(form: Form[BigDecimal], backLink: Call)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_summary.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_summary.scala.html
@@ -29,8 +29,7 @@
 @this(
 cyaSection: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_section,
 cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row,
-cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change,
-addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.address_display,
+cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/gain_after_losses_workings.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/gain_after_losses_workings.scala.html
@@ -22,8 +22,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLossesAnswers.CompleteExemptionAndLossesAnswers
 
 @this(
-        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum
 )
 
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/gain_or_loss_after_reliefs_workings.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/gain_or_loss_after_reliefs_workings.scala.html
@@ -22,8 +22,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.components.SumPartDisplay
 
 @this(
-        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/initial_gain_or_loss_workings.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/initial_gain_or_loss_workings.scala.html
@@ -24,8 +24,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.Source
 
 @this(
-        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum
 )
 
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/tax_owed_workings.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/tax_owed_workings.scala.html
@@ -21,13 +21,11 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.components.SumPartDisplay
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TaxYear
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AssetType
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 
 @this(
-        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum
 )
 
 @(
@@ -35,7 +33,6 @@
         personalAllowance: AmountInPence,
         calculatedTax: CalculatedTaxDue,
         taxYear: TaxYear,
-        assetType: AssetType,
         isATrust: Boolean
 )(implicit request: RequestWithSessionData[_], messages: Messages)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/taxable_gain_workings.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/taxable_gain_workings.scala.html
@@ -22,8 +22,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLossesAnswers.CompleteExemptionAndLossesAnswers
 
 @this(
-        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+        calcSum: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_sum
 )
 
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/personal_allowance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/personal_allowance.scala.html
@@ -64,7 +64,7 @@
 @title = @{messages(s"$key$userKey.title", taxYearStartYear, taxYearEndYear)}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = false) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = false) {
 
     @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/personal_allowance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/personal_allowance.scala.html
@@ -30,7 +30,6 @@
 
 @this(
         mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-        pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
         formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/tax_due.scala.html
@@ -80,7 +80,7 @@
       else ""
 }
 
-@mainTemplate(title = title, hasErrors = hasErrors, userType = request.userType) {
+@mainTemplate(title = title, hasErrors = hasErrors) {
 
    @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/tax_due.scala.html
@@ -42,7 +42,6 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
         backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
-        caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
         unitInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.unit_input,
         calcRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.calculation_row,
         initialGainOrLossWorkings: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.ytdliability.partials.initial_gain_or_loss_workings,
@@ -72,7 +71,6 @@
 @title = @{messages(s"$key.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 @taxYear = @{ triageAnswers.disposalDate.taxYear }
-@assetType = @{ triageAnswers.assetType }
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 @userKey = @{
   if (representativeType.exists(_.isLeft)) ".personalRep"
@@ -137,7 +135,7 @@
         @calcRow(calculatedTax.amountOfTaxDue, messages(s"$key.amountOfTaxDue"), showGainType = false)
         @details(
           messages("calculator.showWorkings"),
-          taxOwedWorkings(estimatedIncome, personalAllowance, calculatedTax, taxYear, assetType, isATrust),
+          taxOwedWorkings(estimatedIncome, personalAllowance, calculatedTax, taxYear, isATrust),
           Some(messages(s"$key.assistive.amountOfTaxDue"))
         )
       </li>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/taxable_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/taxable_gain_or_loss.scala.html
@@ -36,8 +36,7 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
         unitInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.unit_input,
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
-        radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+        radioGroupConditional: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_conditional
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/taxable_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/taxable_gain_or_loss.scala.html
@@ -110,7 +110,7 @@
 }
 
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors, withSignOutLink = false) {
+@mainTemplate(title = title, hasErrors = hasErrors, withSignOutLink = false) {
 
     @backLinkComponent(backLink)
 
@@ -126,7 +126,6 @@
             label = pageHeading(title),
             selected = selectedIndex,
             error = form.error(key),
-            hasErrors = hasErrors,
             options = options,
             helpText = Some(Html(messages(s"$key$userKey.helpText"))),
             customErrorKey = Some(s"$key$userKey$multipleKey")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence.scala.html
@@ -24,15 +24,11 @@
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-    errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
-    formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
     backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
     returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
     fileInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.file_input,
-    caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
-    details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+    caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )
 
 @(upscanUpload: UpscanUpload, backLink: Call)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence.scala.html
@@ -18,7 +18,6 @@
 @import play.api.mvc.Call
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.UpscanUpload
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.components.AutoCompleteType
 
@@ -31,7 +30,7 @@
     caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption
 )
 
-@(upscanUpload: UpscanUpload, backLink: Call)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+@(upscanUpload: UpscanUpload, backLink: Call)(implicit messages:Messages, appConfig: ViewConfig)
 
     @key = @{ "mandatoryEvidence" }
     @fieldId = @{ "file" }
@@ -39,7 +38,7 @@
     @meta = @{upscanUpload.upscanUploadMeta.uploadRequest.fields}
     @href = @{upscanUpload.upscanUploadMeta.uploadRequest.href}
 
-    @mainTemplate(title = title, userType = request.userType, withSignOutLink = false) {
+    @mainTemplate(title = title, withSignOutLink = false) {
 
         @backLinkComponent(backLink)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence_failed.scala.html
@@ -33,7 +33,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
     @key = @{"mandatoryEvidence.failed"}
     @title = @{messages(s"$key.title")}
 
-    @mainTemplate(title = title, userType = request.userType) {
+    @mainTemplate(title = title) {
 
     @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence_scan_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence_scan_failed.scala.html
@@ -33,7 +33,7 @@
     @key = @{"mandatoryEvidence.scan-failed"}
     @title = @{messages(s"$key.title")}
 
-    @mainTemplate(title = title, userType = request.userType) {
+    @mainTemplate(title = title) {
 
         @pageHeading(title)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/testonly/set_return_state.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/testonly/set_return_state.scala.html
@@ -47,7 +47,7 @@ submitButton:  uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.su
  )
 }
 
-@mainTemplate(title = title, userType = None, withSignOutLink = false) {
+@mainTemplate(title = title, withSignOutLink = false) {
 
  @if(hasErrors) {
   @errorSummary(form)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/testonly/set_return_state.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/testonly/set_return_state.scala.html
@@ -26,7 +26,6 @@
 
 @this(
 mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
 formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
 textInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.text_input,
 errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/timed_out.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/timed_out.scala.html
@@ -30,7 +30,7 @@
 
 @title = @{messages("timed-out.title")}
 
-@mainTemplate(title = title, userType = None, withSignOutLink = false) {
+@mainTemplate(title = title, withSignOutLink = false) {
 
   @pageHeading(title)
 

--- a/build.sbt
+++ b/build.sbt
@@ -83,4 +83,18 @@ dependencyOverrides += "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
 scalacOptions ++= Seq("-Ywarn-unused:params",
   "-Ywarn-unused:privates",
   "-Ywarn-unused:locals",
-  "-Ywarn-unused:patvars")
+  "-Ywarn-unused:patvars",
+  "-Ywarn-dead-code",                  // Warn when dead code is identified.
+  "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+  "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
+  "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
+  "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+  "-Ywarn-numeric-widen",              // Warn when numerics are widened.
+  "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+  "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+  "-Ywarn-unused:locals",              // Warn if a local definition is unused.
+  "-Ywarn-unused:params",              // Warn if a value parameter is unused.
+  "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+  "-Ywarn-unused:privates",            // Warn if a private member is unused.
+  "-Ywarn-value-discard")              // Warn when non-Unit expression results are unused.

--- a/build.sbt
+++ b/build.sbt
@@ -79,3 +79,8 @@ dependencyOverrides += "com.typesafe.akka" %% "akka-protobuf"  % akkaVersion
 dependencyOverrides += "com.typesafe.akka" %% "akka-slf4j"     % akkaVersion
 dependencyOverrides += "com.typesafe.akka" %% "akka-actor"     % akkaVersion
 dependencyOverrides += "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
+
+scalacOptions ++= Seq("-Ywarn-unused:params",
+  "-Ywarn-unused:privates",
+  "-Ywarn-unused:locals",
+  "-Ywarn-unused:patvars")


### PR DESCRIPTION
- For the FE I've cleaned up the warnings generated by the flags (there was 123 in the beginning), except the one I explain below
- ```/Users/user/Documents/workspaces/cgt-property-disposals-frontend/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/config/ErrorHandler.scala:47:5: parameter value userType in method errorResult is never used```
On the above warning, if I remove there will be conflict with another method with the same name, and once I change the signature - since not private - many places will fail in the code.
This might be left with a suppresswarnings equivalent.
