### PR TITLE
CPDP-2274 qa updates

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
@@ -126,24 +126,30 @@ class CommonTriageQuestionsController @Inject() (
                   )
                 ),
               { individualUserType =>
-                val answers    = triageAnswersFomState(state)
-                val redirectTo =
-                  if (state.fold(_.isFurtherReturn, _.isFurtherReturn).contains(true))
-                    routes.CommonTriageQuestionsController.furtherReturnHelp()
-                  else redirectToCheckYourAnswers(state)
+                val answers = triageAnswersFomState(state)
 
                 val oldIndividualUserType = answers.fold(
                   _.fold(_.individualUserType, c => c.individualUserType),
                   _.fold(_.individualUserType, c => c.individualUserType)
                 )
 
+                val updatedState =
+                  updateIndividualUserType(state, individualUserType)
+
+                val redirectTo =
+                  if (
+                    updatedState
+                      .fold(_.isFurtherReturn, _.isFurtherReturn)
+                      .contains(true)
+                  )
+                    routes.CommonTriageQuestionsController.furtherReturnHelp()
+                  else redirectToCheckYourAnswers(state)
+
                 if (oldIndividualUserType.contains(individualUserType))
                   Redirect(redirectTo)
                 else {
 
-                  val updatedState =
-                    updateIndividualUserType(state, individualUserType)
-                  val result       =
+                  val result =
                     for {
                       _ <- updatedState.fold(
                              _ => EitherT.pure[Future, Error](()),

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
@@ -46,6 +46,8 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.{triage => triagePages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.representee.{routes => representeeRoutes}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.accounts.homepage.{routes => homePageRoutes}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType.Organisation
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -107,7 +109,10 @@ class CommonTriageQuestionsController @Inject() (
     authenticatedActionWithSessionData.async { implicit request =>
       withState(request) { (_, state) =>
         if (!isIndividual(state))
-          Redirect(routes.CommonTriageQuestionsController.howManyProperties())
+          if (state.fold(_.isFurtherReturn, _.isFurtherReturn).contains(true))
+            Redirect(routes.CommonTriageQuestionsController.furtherReturnHelp())
+          else
+            Redirect(routes.CommonTriageQuestionsController.howManyProperties())
         else
           whoAreYouReportingForForm(request.userType.contains(UserType.Agent))
             .bindFromRequest()
@@ -122,7 +127,10 @@ class CommonTriageQuestionsController @Inject() (
                 ),
               { individualUserType =>
                 val answers    = triageAnswersFomState(state)
-                val redirectTo = redirectToCheckYourAnswers(state)
+                val redirectTo =
+                  if (state.fold(_.isFurtherReturn, _.isFurtherReturn).contains(true))
+                    routes.CommonTriageQuestionsController.furtherReturnHelp()
+                  else redirectToCheckYourAnswers(state)
 
                 val oldIndividualUserType = answers.fold(
                   _.fold(_.individualUserType, c => c.individualUserType),
@@ -172,14 +180,16 @@ class CommonTriageQuestionsController @Inject() (
       withState(request) { (_, state) =>
         val individualUserType = getIndividualUserType(state)
         val backLink           = individualUserType match {
-          case Some(_: RepresentativeType) => representeeRoutes.RepresenteeController.isFirstReturn()
-          case _                           => routes.CommonTriageQuestionsController.whoIsIndividualRepresenting()
+          case _ if request.userType.contains(Organisation) => homePageRoutes.HomePageController.homepage()
+          case Some(_: RepresentativeType)                  => representeeRoutes.RepresenteeController.isFirstReturn()
+          case _                                            => routes.CommonTriageQuestionsController.whoIsIndividualRepresenting()
         }
         Ok(
           furtherReturnsHelpPage(
             backLink,
             state.fold(_.subscribedDetails.isATrust, _.subscribedDetails.isATrust),
-            individualUserType
+            individualUserType,
+            state.isRight
           )
         )
       }
@@ -193,7 +203,6 @@ class CommonTriageQuestionsController @Inject() (
           case _                           => Redirect(routes.CommonTriageQuestionsController.howManyProperties())
         }
       }
-
     }
 
   def howManyProperties(): Action[AnyContent] =
@@ -412,7 +421,9 @@ class CommonTriageQuestionsController @Inject() (
     val triageAnswers  = triageAnswersFomState(state)
     val isSelfUserType = isIndividualASelfUserType(triageAnswers)
 
-    if (!isIndividual(state))
+    if (isFurtherReturn)
+      Some(routes.CommonTriageQuestionsController.furtherReturnHelp())
+    else if (!isIndividual(state))
       None
     else
       Some(
@@ -420,16 +431,12 @@ class CommonTriageQuestionsController @Inject() (
           _.fold(
             _ =>
               if (!isSelfUserType) representee.routes.RepresenteeController.checkYourAnswers()
-              else if (isFurtherReturn) routes.CommonTriageQuestionsController.furtherReturnHelp()
               else routes.CommonTriageQuestionsController.whoIsIndividualRepresenting(),
             _ => routes.MultipleDisposalsTriageController.checkYourAnswers()
           ),
           _.fold(
             _ =>
-              if (isFurtherReturn)
-                routes.CommonTriageQuestionsController
-                  .furtherReturnHelp()
-              else if (isSelfUserType)
+              if (isSelfUserType)
                 routes.CommonTriageQuestionsController
                   .whoIsIndividualRepresenting()
               else representee.routes.RepresenteeController.checkYourAnswers(),

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageController.scala
@@ -52,7 +52,6 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging.LoggerOps
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.triage.{disposal_date_of_shares, multipledisposals => triagePages}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.CommonTriageQuestionsController.sharesDisposalDateForm
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.Self
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -1001,12 +1000,6 @@ class MultipleDisposalsTriageController @Inject() (
             fb => fb._2.fold(_.representeeAnswers, _.representeeAnswers)
           )
 
-        val isFurtherReturn = state
-          .fold(
-            _.isFurtherReturn.contains(true),
-            _._1.isFurtherReturn.contains(true)
-          )
-
         val representeeAnswersIncomplete = !representeeAnswers
           .map(_.fold(_ => false, _ => true))
           .getOrElse(false)
@@ -1026,22 +1019,6 @@ class MultipleDisposalsTriageController @Inject() (
             Redirect(
               routes.CommonTriageQuestionsController
                 .whoIsIndividualRepresenting()
-            )
-
-          case IncompleteMultipleDisposalsTriageAnswers(
-                Some(Self),
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None
-              ) if isFurtherReturn =>
-            Redirect(
-              routes.CommonTriageQuestionsController
-                .furtherReturnHelp()
             )
 
           case IncompleteMultipleDisposalsTriageAnswers(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
@@ -1143,12 +1143,6 @@ class SingleDisposalsTriageController @Inject() (
           .userType()
           .isRight
 
-        val isFurtherReturn = state
-          .fold(
-            _.isFurtherReturn.contains(true),
-            _._2.isFurtherReturn.contains(true)
-          )
-
         val representeeAnswers           = state
           .fold(
             _.representeeAnswers,
@@ -1188,22 +1182,6 @@ class SingleDisposalsTriageController @Inject() (
             Redirect(
               routes.CommonTriageQuestionsController
                 .whoIsIndividualRepresenting()
-            )
-
-          case IncompleteSingleDisposalTriageAnswers(
-                Some(Self),
-                false,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None
-              ) if isIndividual && isFurtherReturn =>
-            Redirect(
-              routes.CommonTriageQuestionsController
-                .furtherReturnHelp()
             )
 
           case IncompleteSingleDisposalTriageAnswers(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/further_retuns_help.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/further_retuns_help.scala.html
@@ -40,7 +40,8 @@ warning: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning
 @(
   backLink: Call,
   isATrust: Boolean,
-  representativeType: Option[IndividualUserType]
+  representativeType: Option[IndividualUserType],
+  displayReturnToSummaryLink: Boolean
 )(implicit request:RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
@@ -87,7 +88,6 @@ warning: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.warning
         @submitButton(messages("button.continue"))
     }
 
-  @returnToSummaryLink(displayReturnToSummaryLink = true)
-
+    @returnToSummaryLink(displayReturnToSummaryLink)
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
@@ -1431,10 +1431,10 @@ class HomePageControllerSpec
 
         "the subscribed user type is trust and the sent returns is non empty" in {
           val sentReturns = List(
-              sample[ReturnSummary].copy(lastUpdatedDate = Some(LocalDate.now())),
-              sample[ReturnSummary].copy(lastUpdatedDate = Some(LocalDate.now()))
-            )
-          val subscribed = sample[Subscribed].copy(
+            sample[ReturnSummary].copy(lastUpdatedDate = Some(LocalDate.now())),
+            sample[ReturnSummary].copy(lastUpdatedDate = Some(LocalDate.now()))
+          )
+          val subscribed  = sample[Subscribed].copy(
             subscribedDetails = sample[SubscribedDetails].copy(name = Left(sample[TrustName])),
             draftReturns = List.empty,
             sentReturns = sentReturns

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.RedirectT
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.ReturnsServiceSupport
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.Generators._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingNewDraftReturn}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, PreviousReturnData, StartingNewDraftReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Country
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.AgentReferenceNumber
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
@@ -103,14 +103,16 @@ class CommonTriageQuestionsControllerSpec
     ],
     name: Either[TrustName, IndividualName],
     userType: UserType = UserType.Individual,
-    representeeAnswers: Option[IncompleteRepresenteeAnswers] = None
+    representeeAnswers: Option[IncompleteRepresenteeAnswers] = None,
+    previousSentReturns: Option[PreviousReturnData] = None
   ): (SessionData, StartingNewDraftReturn) = {
     val startingNewDraftReturn =
       sample[StartingNewDraftReturn].copy(
         subscribedDetails = sample[SubscribedDetails].copy(name = name),
         newReturnTriageAnswers = triageAnswers,
         agentReferenceNumber = setAgentReferenceNumber(userType),
-        representeeAnswers = representeeAnswers
+        representeeAnswers = representeeAnswers,
+        previousSentReturns = previousSentReturns
       )
 
     val sessionData = SessionData.empty.copy(
@@ -651,7 +653,7 @@ class CommonTriageQuestionsControllerSpec
                   initialGainOrLoss = None,
                   supportingEvidenceAnswers = None
                 ),
-              routes.SingleDisposalsTriageController.checkYourAnswers()
+              routes.CommonTriageQuestionsController.furtherReturnHelp()
             )
           }
 
@@ -689,7 +691,7 @@ class CommonTriageQuestionsControllerSpec
                   initialGainOrLoss = None,
                   supportingEvidenceAnswers = None
                 ),
-              routes.SingleDisposalsTriageController.checkYourAnswers()
+              routes.CommonTriageQuestionsController.furtherReturnHelp()
             )
           }
 
@@ -724,7 +726,7 @@ class CommonTriageQuestionsControllerSpec
                   yearToDateLiabilityAnswers = None,
                   supportingEvidenceAnswers = None
                 ),
-              routes.MultipleDisposalsTriageController.checkYourAnswers()
+              routes.CommonTriageQuestionsController.furtherReturnHelp()
             )
           }
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
@@ -126,14 +126,16 @@ class CommonTriageQuestionsControllerSpec
   def sessionDataWithFillingOutReturn(
     singleDisposalTriageAnswers: SingleDisposalTriageAnswers,
     name: Either[TrustName, IndividualName] = Right(sample[IndividualName]),
-    userType: UserType = UserType.Individual
+    userType: UserType = UserType.Individual,
+    previousReturns: Option[PreviousReturnData] = None
   ): (SessionData, FillingOutReturn, DraftSingleDisposalReturn) = {
     val draftReturn      = sample[DraftSingleDisposalReturn].copy(
       triageAnswers = singleDisposalTriageAnswers
     )
     val fillingOutReturn = sample[FillingOutReturn].copy(
       draftReturn = draftReturn,
-      subscribedDetails = sample[SubscribedDetails].copy(name = name)
+      subscribedDetails = sample[SubscribedDetails].copy(name = name),
+      previousSentReturns = previousReturns
     )
 
     (
@@ -653,7 +655,7 @@ class CommonTriageQuestionsControllerSpec
                   initialGainOrLoss = None,
                   supportingEvidenceAnswers = None
                 ),
-              routes.CommonTriageQuestionsController.furtherReturnHelp()
+              routes.SingleDisposalsTriageController.checkYourAnswers()
             )
           }
 
@@ -691,7 +693,7 @@ class CommonTriageQuestionsControllerSpec
                   initialGainOrLoss = None,
                   supportingEvidenceAnswers = None
                 ),
-              routes.CommonTriageQuestionsController.furtherReturnHelp()
+              routes.SingleDisposalsTriageController.checkYourAnswers()
             )
           }
 
@@ -726,7 +728,7 @@ class CommonTriageQuestionsControllerSpec
                   yearToDateLiabilityAnswers = None,
                   supportingEvidenceAnswers = None
                 ),
-              routes.CommonTriageQuestionsController.furtherReturnHelp()
+              routes.MultipleDisposalsTriageController.checkYourAnswers()
             )
           }
 


### PR DESCRIPTION
Fixes:

Remove the further help page from the "check your answers" check and explicitly link there were needed to avoid loop in Multiple Disposals

Only show return to summary when complete

Back link for "How many properties"