### PR TITLE
DLS-4577 Migration

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/date_input_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/date_input_govuk.scala.html
@@ -46,9 +46,7 @@
 <div class="@classes">
   <fieldset class="govuk-fieldset" id="@fieldId"@if(describedByKeys.nonEmpty) { aria-describedby="@describedByKeys" }>
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading">
-            @label
-        </h1>
+      @label
     </legend>
     @if(helpText.isDefined) {
       <span id="@{fieldId}-form-hint" class="govuk-hint">

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/error_summary.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/error_summary.scala.html
@@ -23,7 +23,7 @@
 
 <div
   class="error-summary"
-  id="error-summary-display"
+  data-spec="errorSummaryDisplay"
   role="alert"
   aria-labelledby="error-summary-heading"
   tabindex="-1">

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/error_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/error_summary_govuk.scala.html
@@ -26,7 +26,8 @@
 
 
 @govukErrorSummary(ErrorSummary(
-  title = Text("Hello, " + messages("error.summary.heading")),
+  title = Text(messages("error.summary.heading")),
+  attributes = Map("data-spec" -> "errorSummaryDisplay"),
   errorList = form.errors.map { error =>
       ErrorLink(
       href = Some(s"#${error.key}"),

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/error_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/error_summary_govuk.scala.html
@@ -16,41 +16,21 @@
 
 @import play.api.i18n.Messages
 @import play.api.data.Form
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 
-@this()
+@this(
+  govukErrorSummary : GovukErrorSummary
+)
 
 @(form: Form[_], customErrorKey: Option[String] = None, userKeyOnly: String = "")(implicit messages: Messages)
 
-<div
-  class="govuk-error-summary"
-  id="error-summary-display"
-  role="alert"
-  aria-labelledby="error-summary-heading"
-  tabindex="-1">
 
-  <h2
-    id="error-summary-heading"
-    class="govuk-error-summary__title">
-    @messages("error.summary.heading")
-  </h2>
-
-  <ul class="govuk-list govuk-error-summary__list">
-    @if(form.globalErrors.nonEmpty) {
-      @form.globalErrors.map { error =>
-        <li>
-          <a class="govuk-body">@messages(s"${error.message}", error.args: _*)</a>
-        </li>
-      }
-    } else {
-      @form.errors.map { error =>
-        <li>
-          <a class="govuk-body" href="#@error.key" data-focuses="@error.key">
-            @messages(s"${customErrorKey.getOrElse(error.key)}$userKeyOnly.${error.message}", error.args: _*)
-          </a>
-        </li>
-      }
-    }
-
-  </ul>
-
-</div>
+@govukErrorSummary(ErrorSummary(
+  title = Text("Hello, " + messages("error.summary.heading")),
+  errorList = form.errors.map { error =>
+      ErrorLink(
+      href = Some(s"#${error.key}"),
+      content = Text(messages(s"${customErrorKey.getOrElse(error.key)}$userKeyOnly.${error.message}", error.args: _*))
+      )
+  }
+))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/yes_no_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/yes_no_govuk.scala.html
@@ -50,9 +50,9 @@
       @label
     </legend>
     @hintIdWithHintText.map { case (id, text) =>
-      <span id="@id" class="govuk-hint">
+      <div id="@id" class="govuk-hint">
         @text
-      </span>
+      </div>
     }
 
     @errorIdWithMessageKey.map { case (id, key) =>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/self_assessment_already_submitted.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/self_assessment_already_submitted.scala.html
@@ -25,9 +25,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative, PersonalRepresentativeInPeriodOfAdmin}
 
 @this(
-    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-    backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
+    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
 @(
@@ -55,21 +53,20 @@
 
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(pageTitle = title, isWelshTranslationAvailable = true, withSignOutLink = true, backLinkUrl = Some(backLink.url)) {
 
-@backLinkComponent(backLink)
 
-@pageHeading(title)
+    <h1 class="govuk-heading-xl">@title</h1>
 
-<p>@messages(s"$key$userKey.p1", taxYearStart.toString, (taxYearStart+1).toString)</p>
+    <p class="govuk-body">@messages(s"$key$userKey.p1", taxYearStart.toString, (taxYearStart+1).toString)</p>
 
-<h2 class="heading-medium">@messages(s"$key.whatNext")</h2>
-<p>@Html(messages(
-        s"$key$userKey.p2",
-        viewConfig.selfAssessmentTaxReturnsCorrections,
-        taxYearStart.toString,
-        (taxYearStart+1).toString
-    ))
-</p>
+    <h2 class="govuk-heading-m">@messages(s"$key.whatNext")</h2>
+    <p class="govuk-body">@Html(messages(
+            s"$key$userKey.p2",
+            viewConfig.selfAssessmentTaxReturnsCorrections,
+            taxYearStart.toString,
+            (taxYearStart+1).toString
+        ))
+    </p>
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
@@ -26,12 +26,12 @@
 
 @this(
    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout,
-   pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-   submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-   errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
+   pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading_govuk,
+   submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button_govuk,
+   errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary_govuk,
    formHelper: FormWithCSRF,
-   dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input,
-   returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link
+   dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input_govuk,
+   returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
 
 @(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
@@ -19,41 +19,53 @@
 @import play.api.mvc.Call
 @import play.twirl.api.Html
 
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ShareDisposalDate
+@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+
 
 @this(
-   mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
+   mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout,
    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
    submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
    errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
-   formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
+   formHelper: FormWithCSRF,
    dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input,
-   backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
    returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link
 )
 
-@(form: Form[ShareDisposalDate], backLink: Call, displayReturnToSummaryLink: Boolean, submit: Call, isAmend: Boolean)(implicit request:RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(
+   form: Form[ShareDisposalDate],
+   backLink: Call,
+   displayReturnToSummaryLink: Boolean,
+   submit: Call,
+   isAmend: Boolean
+)(implicit request:RequestWithSessionData[_], messages: Messages)
 
 @key = @{ "sharesDisposalDate" }
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
-@title = @{messages(s"$key.title")}
+
+@inPageTitle = @{messages(s"$key.title")}
+@title = @{
+   if(hasErrors){
+      messages("generic.errorPrefix") + " " + inPageTitle
+   } else inPageTitle
+}
+
+
 @errorKey = @{List(s"$key-day", s"$key-month", s"$key-year", key).map(form.error).find(_.isDefined).flatten}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
+ @mainTemplate(pageTitle = title, withSignOutLink = true, isWelshTranslationAvailable = true, backLinkUrl = Some(backLink.url)) {
 
-
-@backLinkComponent(backLink)
 
 @if(hasErrors) {
 @errorSummary(form)
 }
 
-@formWrapper(submit, 'novalidate -> "novalidate") {
+@formHelper(submit, 'novalidate -> "novalidate") {
  @dateInput(
   fieldId = key,
-  label = pageHeading(title, Some(messages("triage.caption"))),
+  label = pageHeading(inPageTitle, Some(messages("triage.caption"))),
   dayValue = form.data.get(s"$key-day"),
   monthValue = form.data.get(s"$key-month"),
   yearValue = form.data.get(s"$key-year"),

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/have_you_already_sent_self_assesment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/have_you_already_sent_self_assesment.scala.html
@@ -71,10 +71,11 @@
 }
 
 @hasErrors = @{form.hasErrors}
+@inPageTitle = @{messages(s"$key$userKey.title", taxYearStartYear.toString, (taxYearStartYear+1).toString)}
 @title = @{
     if(hasErrors){
-        messages("generic.errorPrefix") + " " + messages(s"$key$userKey.title", taxYearStartYear.toString, (taxYearStartYear+1).toString)
-    } else messages(s"$key$userKey.title", taxYearStartYear.toString, (taxYearStartYear+1).toString)
+        messages("generic.errorPrefix") + " " + inPageTitle
+    } else inPageTitle
 }
 
 @mainTemplate(pageTitle = title, withSignOutLink = true, isWelshTranslationAvailable = true, backLinkUrl = Some(backLink.url)) {
@@ -86,7 +87,7 @@
     @formHelper(controllers.returns.triage.routes.CommonTriageQuestionsController.haveYouAlreadySentSelfAssessmentSubmit(), 'novalidate -> "novalidate") {
         @yesNo(
             fieldId = key,
-            label = pageHeading(title, Some(messages("triage.caption"))),
+            label = pageHeading(inPageTitle, Some(messages("triage.caption"))),
             errorKey = form.error(key).map(e => s"$userErrorKey${e.message}"),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/completion_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/completion_date.scala.html
@@ -29,15 +29,14 @@
 
 @this(
   mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout,
-  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-  submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-  errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
+  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading_govuk,
+  submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button_govuk,
+  errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary_govuk,
   formHelper: FormWithCSRF,
   govukDetails : GovukDetails,
   dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input_govuk,
-  returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
+  returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk,
   caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
-  details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details,
 )
 
 @(
@@ -83,12 +82,6 @@
       content = HtmlContent(s"<p>${messages(s"$key.details.p1", viewConfig.tranferringOwnershipHelp)}</p>")
   ))
 
-
-   @details(messages(s"$key.details.summary"), Html(
-     s"""
-      |<p>${messages(s"$key.details.p1", viewConfig.tranferringOwnershipHelp)}</p>
-    |""".stripMargin
-   ))
 
   @submitButton(messages(if(isAmend) "button.continue" else if (hasCreatedDraftReturn) "button.saveAndContinue" else "button.continue"))
  }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/completion_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/completion_date.scala.html
@@ -23,30 +23,42 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompletionDate
+@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
 
 @this(
-mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
-formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input,
-backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
-returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
-caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
-details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
+  mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout,
+  pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
+  submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
+  errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
+  formHelper: FormWithCSRF,
+  govukDetails : GovukDetails,
+  dateInput: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.date_input_govuk,
+  returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
+  caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
+  details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details,
 )
 
-@(form: Form[CompletionDate], backLink: Call, hasCreatedDraftReturn: Boolean, isAmend: Boolean)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+@(
+  form: Form[CompletionDate],
+  backLink: Call,
+  hasCreatedDraftReturn: Boolean,
+  isAmend: Boolean
+)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
 
 @key = @{"multipleDisposalsCompletionDate"}
 @hasErrors = @{form.hasErrors}
-@title = @{messages(s"$key.title")}
+@inPageTitle = @{messages(s"$key.title")}
+@title = @{
+   if(hasErrors){
+      messages("generic.errorPrefix") + " " + inPageTitle
+   } else inPageTitle
+}
+
 @errorKey = @{List(s"$key-day", s"$key-month", s"$key-year", key).map(form.error).find(_.isDefined).flatten}
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
-
- @backLinkComponent(backLink)
+@mainTemplate(pageTitle = title, withSignOutLink = true, isWelshTranslationAvailable = true, backLinkUrl = Some(backLink.url)) {
 
  @if(hasErrors) {
   @errorSummary(form)
@@ -54,10 +66,10 @@ details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
 
   @caption(messages("triage.caption"))
 
- @formWrapper(controllers.returns.triage.routes.MultipleDisposalsTriageController.completionDateSubmit(), 'novalidate -> "novalidate") {
+ @formHelper(controllers.returns.triage.routes.MultipleDisposalsTriageController.completionDateSubmit(), 'novalidate -> "novalidate") {
   @dateInput(
    fieldId = key,
-   label = pageHeading(title),
+   label = pageHeading(inPageTitle),
    dayValue = form.data.get(s"$key-day"),
    monthValue = form.data.get(s"$key-month"),
    yearValue = form.data.get(s"$key-year"),
@@ -65,6 +77,12 @@ details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
    errorKey = errorKey.map(e => messages(s"${e.key}.${e.message}")),
    hasErrors = hasErrors
   )
+
+  @govukDetails(Details(
+      summary = Text(messages(s"$key.details.summary")),
+      content = HtmlContent(s"<p>${messages(s"$key.details.p1", viewConfig.tranferringOwnershipHelp)}</p>")
+  ))
+
 
    @details(messages(s"$key.details.summary"), Html(
      s"""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/exchanged_different_tax_years.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/exchanged_different_tax_years.scala.html
@@ -17,28 +17,23 @@
 @import play.api.i18n.Messages
 @import play.api.mvc.Call
 @import play.twirl.api.Html
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.routes
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 
 @this(
-    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-    backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
+    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
 
 @key = @{"multipleDisposalsExchangedInDifferentTaxYears"}
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(pageTitle = title, isWelshTranslationAvailable = true, withSignOutLink = true, backLinkUrl = Some(backLink.url)) {
 
-    @backLinkComponent(backLink)
-
-    @pageHeading(title)
-    <p>@messages(s"$key.p1")</p>
-    <p>@messages(s"$key.p2")</p>
-    <h2 class="heading-medium">@messages(s"$key.whatNext")</h2>
-    <p>@Html(messages(s"$key.p3", routes.StartController.start().url))</p>
+    <h1 class="govuk-heading-xl">@title</h1>
+    <p class="govuk-body">@messages(s"$key.p1")</p>
+    <p class="govuk-body">@messages(s"$key.p2")</p>
+    <h2 class="govuk-heading-m">@messages(s"$key.whatNext")</h2>
+    <p class="govuk-body">@Html(messages(s"$key.p3", routes.StartController.start().url))</p>
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/tax_year_exchanged.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/tax_year_exchanged.scala.html
@@ -25,7 +25,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components._
-
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 
 @this(
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout,
@@ -34,7 +34,7 @@
     formHelper: FormWithCSRF,
     govukRadios : GovukRadios,
     govukDetails : GovukDetails,
-    returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
+    returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk,
     caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
 )
 
@@ -55,23 +55,14 @@
 }
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
-@toValue(taxYearExchanged: TaxYearExchanged) = @{
-        taxYearExchanged match {
-            case TaxYearExchanged.TaxYear2021 => "TaxYear2021"
-            case TaxYearExchanged.TaxYear2020 => "TaxYear2020"
-            case TaxYearExchanged.TaxYearBefore2020 => "TaxYearBefore2020"
-            case TaxYearExchanged.DifferentTaxYears => "DifferentTaxYears"
-        }
-}
 
 
-@newOptions = @{
+@options = @{
     val defaultOptions = Seq(
         RadioItem(
             content = Text(messages(s"$key.taxyear.before2020")),
             value = Option("TaxYearBefore2020"),
             id = Option(s"${key}-TaxYearBefore2020"),
-            checked = "TaxYearBefore2020".equals(form.value.map(toValue).getOrElse(""))
         ),
         RadioItem(
         divider = Some("or")
@@ -80,7 +71,6 @@
             content = Text(messages(s"$key.taxyear.different")),
             value = Option("DifferentTaxYears"),
             id = Option(s"${key}-DifferentTaxYears"),
-            checked = "DifferentTaxYears".equals(form.value.map(toValue).getOrElse(""))
         )
     )
 
@@ -89,7 +79,6 @@
             content = Text(messages(s"$key.taxyear.$year")),
             value = Option(s"TaxYear$year"),
             id = Option(s"${key}-TaxYear$year"),
-            checked = s"TaxYear$year".equals(form.value.map(toValue).getOrElse(""))
         )
     }
 
@@ -117,10 +106,8 @@
                 ))
             )),
             errorMessage = if(form.hasErrors) Some(ErrorMessage(content = Text(messages(form.errors.map(e => s"$key.${e.message}"))))) else None,
-            idPrefix = Some(key),
-            name = key,
-            items = newOptions
-        ))
+            items = options
+        ).withFormField(form(key)))
 
         @govukDetails(Details(
             summary = Text(messages(s"$key.link")),

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/tax_year_exchanged.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/tax_year_exchanged.scala.html
@@ -17,25 +17,25 @@
 @import play.api.data.Form
 @import play.api.i18n.Messages
 @import play.api.mvc.Call
-@import play.twirl.api.Html
+
 
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.TaxYearExchanged
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.RequestWithSessionData
-@import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.components.RadioOption
+@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
 
 @this(
-    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-    submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button,
-    errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary,
-    formWrapper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-    backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link,
-    radioGroupWithValues: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.radio_group_with_values,
+    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout,
+    submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button_govuk,
+    errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary_govuk,
+    formHelper: FormWithCSRF,
+    govukRadios : GovukRadios,
+    govukDetails : GovukDetails,
     returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link,
     caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption,
-    details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details
 )
 
 @(
@@ -47,7 +47,12 @@
 )(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
 
 @key = @{"multipleDisposalsTaxYear"}
-@title = @{messages(s"$key.title")}
+@inPageTitle = @{messages(s"$key.title")}
+@title = @{
+    if(hasErrors){
+        messages("generic.errorPrefix") + " " + inPageTitle
+    } else inPageTitle
+}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 
 @toValue(taxYearExchanged: TaxYearExchanged) = @{
@@ -59,38 +64,39 @@
         }
 }
 
-@options = @{
-   val defaultOptions = List(
-        RadioOption(
-            label = messages(s"$key.taxyear.before2020"),
-            content = None,
-            optionHelpText = None,
-            value = "TaxYearBefore2020",
-            followedByOr = true
+
+@newOptions = @{
+    val defaultOptions = Seq(
+        RadioItem(
+            content = Text(messages(s"$key.taxyear.before2020")),
+            value = Option("TaxYearBefore2020"),
+            id = Option(s"${key}-TaxYearBefore2020"),
+            checked = "TaxYearBefore2020".equals(form.value.map(toValue).getOrElse(""))
         ),
-        RadioOption(
-            label = messages(s"$key.taxyear.different"),
-            content = None,
-            optionHelpText = None,
-            value = "DifferentTaxYears"
+        RadioItem(
+        divider = Some("or")
+        ),
+        RadioItem(
+            content = Text(messages(s"$key.taxyear.different")),
+            value = Option("DifferentTaxYears"),
+            id = Option(s"${key}-DifferentTaxYears"),
+            checked = "DifferentTaxYears".equals(form.value.map(toValue).getOrElse(""))
         )
     )
 
     val availableOptions = availableTaxYears.map{year =>
-        RadioOption(
-            label = messages(s"$key.taxyear.$year"),
-            content = None,
-            optionHelpText = None,
-            value = s"TaxYear$year"
+        RadioItem(
+            content = Text(messages(s"$key.taxyear.$year")),
+            value = Option(s"TaxYear$year"),
+            id = Option(s"${key}-TaxYear$year"),
+            checked = s"TaxYear$year".equals(form.value.map(toValue).getOrElse(""))
         )
     }
 
-    availableOptions ++ defaultOptions
+    availableOptions ++: defaultOptions
 }
 
-@mainTemplate(title = title, userType = request.userType, hasErrors = hasErrors) {
-
-    @backLinkComponent(backLink)
+@mainTemplate(pageTitle = title, withSignOutLink = true, isWelshTranslationAvailable = true, backLinkUrl = Some(backLink.url)) {
 
     @if(hasErrors) {
         @errorSummary(form)
@@ -98,25 +104,28 @@
 
     @caption(messages("triage.caption"))
 
-    @formWrapper(controllers.returns.triage.routes.MultipleDisposalsTriageController.whenWereContractsExchangedSubmit(), 'novalidate -> "novalidate") {
+    @formHelper(controllers.returns.triage.routes.MultipleDisposalsTriageController.whenWereContractsExchangedSubmit(), 'novalidate -> "novalidate") {
 
-        @radioGroupWithValues(
-            fieldId = key,
-            options = options,
-            selected = form.value.map(toValue),
-            label = pageHeading(title),
-            error = form.error(key),
-            helpText = None
-        )
 
-        @details(
-            messages(s"$key.link"),
-            Html(
-                s"""
-                | <p>${messages(s"$key.details.p1", viewConfig.tranferringOwnershipHelp)}</p>
-                |""".stripMargin
-            )
-        )
+        @govukRadios(Radios(
+            fieldset = Some(Fieldset(
+                attributes = Map("id" -> key),
+                legend = Some(Legend(
+                    content = Text(inPageTitle),
+                    classes = "govuk-fieldset__legend--l",
+                    isPageHeading = true
+                ))
+            )),
+            errorMessage = if(form.hasErrors) Some(ErrorMessage(content = Text(messages(form.errors.map(e => s"$key.${e.message}"))))) else None,
+            idPrefix = Some(key),
+            name = key,
+            items = newOptions
+        ))
+
+        @govukDetails(Details(
+            summary = Text(messages(s"$key.link")),
+            content = HtmlContent(s"<p>${messages(s"$key.details.p1", viewConfig.tranferringOwnershipHelp)}</p>")
+        ))
 
         @submitButton(messages(if(isAmend) "button.continue" else if (hasCreatedDraftReturn) "button.saveAndContinue" else "button.continue"))
     }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/self_assessment_already_submitted.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/self_assessment_already_submitted.scala.html
@@ -25,9 +25,7 @@
 @import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative, PersonalRepresentativeInPeriodOfAdmin}
 
 @this(
-    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.main_template,
-    pageHeading: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.page_heading,
-    backLinkComponent: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.back_link
+    mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
 @(
@@ -55,21 +53,19 @@
 
 @title = @{messages(s"$key.title")}
 
-@mainTemplate(title = title, userType = request.userType) {
+@mainTemplate(pageTitle = title, isWelshTranslationAvailable = true, withSignOutLink = true, backLinkUrl = Some(backLink.url)) {
 
-@backLinkComponent(backLink)
+    <h1 class="govuk-heading-xl">@title</h1>
 
-@pageHeading(title)
+    <p class="govuk-body">@messages(s"$key$userKey.p1", taxYearStart.toString, (taxYearStart+1).toString)</p>
 
-<p>@messages(s"$key$userKey.p1", taxYearStart.toString, (taxYearStart+1).toString)</p>
-
-<h2 class="heading-medium">@messages(s"$key.whatNext")</h2>
-<p>@Html(messages(
-        s"$key$userKey.p2",
-        viewConfig.selfAssessmentTaxReturnsCorrections,
-        taxYearStart.toString,
-        (taxYearStart+1).toString
-    ))
-</p>
+    <h2 class="govuk-heading-m">@messages(s"$key.whatNext")</h2>
+    <p class="govuk-body">@Html(messages(
+            s"$key$userKey.p2",
+            viewConfig.selfAssessmentTaxReturnsCorrections,
+            taxYearStart.toString,
+            (taxYearStart+1).toString
+        ))
+    </p>
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
@@ -108,7 +108,7 @@
         @details(messages(s"$key.details.summary"),
           Html(s"""|
                    |<p class="govuk-body">${messages(s"$key.details.p1")}</p>
-                   |<ul "class=govuk-list">
+                   |<ul class="govuk-list">
                    |  <li>${messages(s"$key.details.l1")}</li>
                    |  <li>${messages(s"$key.details.l2")}</li>
                    |  <li>${messages(s"$key.details.l3")}</li>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/have_you_already_sent_self_assesment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/have_you_already_sent_self_assesment.scala.html
@@ -71,10 +71,11 @@
 }
 
 @hasErrors = @{form.hasErrors}
+@inPageTitle = @{messages(s"$key$userKey.title", taxYearStartYear.toString, (taxYearStartYear+1).toString)}
 @title = @{
     if(hasErrors){
-        messages("generic.errorPrefix") + " " + messages(s"$key$userKey.title", taxYearStartYear.toString, (taxYearStartYear+1).toString)
-    } else messages(s"$key$userKey.title", taxYearStartYear.toString, (taxYearStartYear+1).toString)
+        messages("generic.errorPrefix") + " " + inPageTitle
+    } else inPageTitle
 }
 
 @mainTemplate(pageTitle = title, withSignOutLink = true, isWelshTranslationAvailable = true, backLinkUrl = Some(backLink.url)) {
@@ -86,7 +87,7 @@
     @formHelper(controllers.returns.triage.routes.CommonTriageQuestionsController.haveYouAlreadySentSelfAssessmentSubmit(), 'novalidate -> "novalidate") {
         @yesNo(
             fieldId = key,
-            label = pageHeading(title, Some(messages("triage.caption"))),
+            label = pageHeading(inPageTitle, Some(messages("triage.caption"))),
             errorKey = form.error(key).map(e => s"$userErrorKey${e.message}"),
             hasErrors = hasErrors,
             selected = form.value,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/who_are_you_reporting_for.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/who_are_you_reporting_for.scala.html
@@ -43,10 +43,11 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
 @key = @{"individualUserType"}
 
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
+@inPageTitle = @{messages("who-are-you-reporting-for.title")}
 @title = @{
     if(hasErrors){
-        messages("generic.errorPrefix") + " " + messages("who-are-you-reporting-for.title")
-    } else messages("who-are-you-reporting-for.title")
+        messages("generic.errorPrefix") + " " + inPageTitle
+    } else inPageTitle
 }
 
 @optionIndex(value: IndividualUserType) = @{
@@ -114,7 +115,7 @@ returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.compone
             fieldId = key,
             options = options,
             selected = form.value.map(optionIndex),
-            label = pageHeading(title, Some(messages("triage.caption"))),
+            label = pageHeading(inPageTitle, Some(messages("triage.caption"))),
             error = form.error(key),
         )
 

--- a/conf/messages
+++ b/conf/messages
@@ -186,7 +186,7 @@ timed-out.button=Sign in
 
 recruitment-banner.message=Help improve HMRC services on GOV.UK
 recruitment-banner.dismiss=No thanks
-recruitment-banner.link=Help make this service better by <a target="_blank" rel="noreferrer noopener" href="{0}">joining the HMRC user research panel (opens in a new window)</a>. This usually involves being interviewed for your feedback and suggestions. Research participants are normally compensated for their time.
+recruitment-banner.link=Help make this service better by <a target="_blank" rel="noreferrer noopener" href="{0}">joining the HMRC user research panel (opens in a new tab)</a>. This usually involves being interviewed for your feedback and suggestions. Research participants are normally compensated for their time.
 
 accessibilityStatement.caption=Report and pay Capital Gains Tax on UK property
 accessibilityStatement.title=Accessibility statement
@@ -208,7 +208,7 @@ accessibilityStatement.howAccessible.title=How accessible this service is
 accessibilityStatement.howAccessible.p1=HMRC is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 accessibilityStatement.howAccessible.p2=This service was tested on 15 May 2020 by the Digital Accessibility Centre. It was found to be compliant with the <a href="{0}">Web Content Accessibility Guidelines version 2.1 AAA standard</a>. Since then, it has been extended. We cannot be certain that it is fully compliant. The full service will be tested by HMRC within the next three months.
 accessibilityStatement.reportingProblems.title=Reporting accessibility problems with this service
-accessibilityStatement.reportingProblems.p1=We are always looking to improve the accessibility of this service. If you find any problems that are not listed on this page or think we are not meeting accessibility requirements, report the <a href="{0}" target="_blank">accessibility problem (opens in a new window or tab)</a>.
+accessibilityStatement.reportingProblems.p1=We are always looking to improve the accessibility of this service. If you find any problems that are not listed on this page or think we are not meeting accessibility requirements, report the <a href="{0}" target="_blank">accessibility problem (opens in a new tab)</a>.
 accessibilityStatement.notHappy.title=What to do if you are not happy with how we respond to your complaint
 accessibilityStatement.notHappy.p1=The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you are not happy with how we respond to your complaint, <a href="{0}">contact the Equality Advisory and Support Service (EASS)</a>, or the <a href="{1}">Equality Commission for Northern Ireland (ECNI)</a> if you live in Northern Ireland.
 accessibilityStatement.contactingUs.title=Contacting us by phone or getting a visit from us in person
@@ -511,9 +511,9 @@ enterTrn.tooManyAttempts.title=You’ll need to wait and try again
 enterTrn.tooManyAttempts.p1=You’ve tried to enter your Trust Registration Number and trust name too many times.
 enterTrn.tooManyAttempts.p2=You’ll need to wait 2 hours and try again.
 enterTrn.whatATrnIs=What a Trust Registration Number is
-enterTrn.whatATrnIs.p1=HMRC sends this number to the person who <a href="{0}" target="_blank">registers the trust (opens in a new window)</a>.
+enterTrn.whatATrnIs.p1=HMRC sends this number to the person who <a href="{0}" target="_blank">registers the trust (opens in a new tab)</a>.
 enterTrn.ifYouCannotFind=If you cannot find it
-enterTrn.ifYouCannotFind.p1=If you registered the trust and cannot find its Trust Registration Number number, you can <a href="{0}" target="_blank">contact HMRC (opens in a new window)</a>.
+enterTrn.ifYouCannotFind.p1=If you registered the trust and cannot find its Trust Registration Number number, you can <a href="{0}" target="_blank">contact HMRC (opens in a new tab)</a>.
 
 enterTrustName.label=Name of trust
 trustName.error.required=Enter the name of your trust
@@ -624,8 +624,8 @@ account.manageYourDetails.subtitle=Account number
 account.manageYourDetails.accountName=Account name
 account.manageYourDetails.contactHeading=Contact person’s details
 account.manageYourDetails.p=We only use these details if we need to get in contact about this service.
-account.manageYourDetails.individual.p2=If the ‘Account name’ needs to change, you’ll need to <a href="{0}" target="_blank">tell HMRC (opens in a new window)</a>.
-account.manageYourDetails.organisation.p2=If the lead trustee’s name or address changes, you’ll need to <a href="{0}" target="_blank">tell HMRC (opens in a new window)</a>.
+account.manageYourDetails.individual.p2=If the ‘Account name’ needs to change, you’ll need to <a href="{0}" target="_blank">tell HMRC (opens in a new tab)</a>.
+account.manageYourDetails.organisation.p2=If the lead trustee’s name or address changes, you’ll need to <a href="{0}" target="_blank">tell HMRC (opens in a new tab)</a>.
 account.manageYourDetails.yourName=Your name
 account.manageYourDetails.ContactName.changed=Contact name changed
 account.manageYourDetails.Email.changed=Contact email address changed
@@ -846,12 +846,12 @@ selfAssessmentAlreadySubmitted.personalRepInPeriodOfAdmin.p1=Someone has already
 
 selfAssessmentAlreadySubmitted.whatNext=What you’ll need to do next
 
-selfAssessmentAlreadySubmitted.p2=You’ll need to <a class="govuk-link" href="{0}" target="_blank">change your Self Assessment tax return</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
-selfAssessmentAlreadySubmitted.agent.p2=You’ll need to <a href="{0}" target="_blank">change your client’s Self Assessment tax return</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
-selfAssessmentAlreadySubmitted.trust.p2=You’ll need to <a href="{0}" target="_blank">change the trust’s Self Assessment: Trust and Estate tax return</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
-selfAssessmentAlreadySubmitted.capacitor.p2=You’ll need to <a href="{0}" target="_blank">change the person’s Self Assessment tax return</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
-selfAssessmentAlreadySubmitted.personalRep.p2=You’ll need to <a href="{0}" target="_blank">change the person’s Self Assessment tax return</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
-selfAssessmentAlreadySubmitted.personalRepInPeriodOfAdmin.p2=You’ll need to <a href="{0}" target="_blank">change the person’s Self Assessment tax return</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
+selfAssessmentAlreadySubmitted.p2=You’ll need to <a class="govuk-link" href="{0}" target="_blank">change your Self Assessment tax return (opens in a new tab)</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
+selfAssessmentAlreadySubmitted.agent.p2=You’ll need to <a class="govuk-link" href="{0}" target="_blank">change your client’s Self Assessment tax return (opens in a new tab)</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
+selfAssessmentAlreadySubmitted.trust.p2=You’ll need to <a class="govuk-link" href="{0}" target="_blank">change the trust’s Self Assessment: Trust and Estate tax return (opens in a new tab)</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
+selfAssessmentAlreadySubmitted.capacitor.p2=You’ll need to <a class="govuk-link" href="{0}" target="_blank">change the person’s Self Assessment tax return (opens in a new tab)</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
+selfAssessmentAlreadySubmitted.personalRep.p2=You’ll need to <a class="govuk-link" href="{0}" target="_blank">change the person’s Self Assessment tax return (opens in a new tab)</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
+selfAssessmentAlreadySubmitted.personalRepInPeriodOfAdmin.p2=You’ll need to <a class="govuk-link" href="{0}" target="_blank">change the person’s Self Assessment tax return (opens in a new tab)</a> by adding details of any UK property sales or disposals made during the tax year 6 April {1} to 5 April {2}.
 #===================================================
 #  Self-Assessment SA - END
 #===================================================
@@ -908,12 +908,12 @@ wereYouAUKResident.trust.details=If the trust was a non-resident and made an ind
 wereYouAUKResident.capacitor.details=If the person was a non-resident and made an indirect disposal of shares, the disposal date is the day the shares were sold or given away.
 wereYouAUKResident.personalRep.details=If the person was a non-resident and made an indirect disposal of shares, the disposal date is the day the shares were sold or given away.
 
-wereYouAUKResident.link=<a class="govuk-link" href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new window)</a>
-wereYouAUKResident.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status for a tax year (opens in a new window)</a>
-wereYouAUKResident.trust.link=<a href="{0}" target="_blank">Work out the trust’s residence status for a tax year (opens in a new window)</a>
-wereYouAUKResident.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new window)</a>
-wereYouAUKResident.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new window)</a>
-wereYouAUKResident.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new window)</a>
+wereYouAUKResident.link=<a class="govuk-link" href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.trust.link=<a href="{0}" target="_blank">Work out the trust’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
 
 wereYouAUKResident.error.required=Select yes if you were a UK resident when you exchanged contracts
 wereYouAUKResident.error.boolean=Select yes if you were a UK resident when you exchanged contracts
@@ -943,12 +943,12 @@ triage.enterCountry.trust.helpText=It’s usually the day the trust and the new 
 triage.enterCountry.capacitor.helpText=It’s usually the day the person and the new owner swapped contracts and they paid a deposit.
 triage.enterCountry.personalRep.helpText=It’s usually the day the person and the new owner swapped contracts and they paid a deposit.
 
-triage.enterCountry.link=<a class="govuk-link" href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new window)</a>
-triage.enterCountry.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status (opens in a new window)</a>.
-triage.enterCountry.trust.link=<a class="govuk-link" href="{0}" target="_blank">Work out the trust’s residence status (opens in a new window)</a>.
-triage.enterCountry.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new window)</a>.
-triage.enterCountry.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new window)</a>.
-triage.enterCountry.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new window)</a>.
+triage.enterCountry.link=<a class="govuk-link" href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new tab)</a>
+triage.enterCountry.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status (opens in a new tab)</a>.
+triage.enterCountry.trust.link=<a class="govuk-link" href="{0}" target="_blank">Work out the trust’s residence status (opens in a new tab)</a>.
+triage.enterCountry.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
+triage.enterCountry.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
+triage.enterCountry.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
 
 assetTypeForNonUkResidents.title=What type of property or asset did you sell or dispose of?
 assetTypeForNonUkResidents.agent.title=What type of property, land or asset did your client sell or dispose of?
@@ -1035,7 +1035,7 @@ didYouDisposeOfResidentialProperty.details.p1=Residential property includes:
 didYouDisposeOfResidentialProperty.details.l1=a building where someone lives or could live, like a house, flat or other type of dwelling
 didYouDisposeOfResidentialProperty.details.l2=a building that is being built or changed so it can be used as a place where someone could live
 didYouDisposeOfResidentialProperty.details.l3=land that’s part of a garden or grounds of a building that’s used as a place where someone lives, or could live
-didYouDisposeOfResidentialProperty.details.link=<a href="{0}" tabindex="-1" target="_blank">Read a definition of residential property (opens in a new window)</a>.
+didYouDisposeOfResidentialProperty.details.link=<a href="{0}" tabindex="-1" target="_blank">Read a definition of residential property (opens in a new tab)</a>.
 
 didYouDisposeOfResidentialProperty.error.required=Select yes if you sold or disposed of a UK residential property
 didYouDisposeOfResidentialProperty.error.boolean=Select yes if you sold or disposed of a UK residential property
@@ -1078,7 +1078,7 @@ disposalDate.capacitor.helpText=It’s usually when a buyer and seller swap cont
 disposalDate.personalRep.helpText=It’s usually when a buyer and seller swap contracts and the buyer pays a deposit. This is also called the ‘disposal’ date. For example, 25 4 2020.
 disposalDate.personalRepInPeriodOfAdmin.helpText=It’s usually when a buyer and seller swap contracts and the buyer pays a deposit. This is also called the ‘disposal’ date. For example, 25 4 2020.
 
-disposalDate.link=<a class="govuk-link" href="{0}" target="_blank">Find out what happens on the exchange date (opens in a new window)</a>
+disposalDate.link=<a class="govuk-link" href="{0}" target="_blank">Find out what happens on the exchange date (opens in a new tab)</a>
 disposalDate.error.required=Enter a contract exchange date
 disposalDate.error.invalid=Enter a real contract exchange date
 disposalDate.error.tooFarInFuture=The contract exchange date must be today or in the past
@@ -1112,7 +1112,7 @@ completionDate.capacitor.helpText=It’s usually when the money from the propert
 completionDate.personalRep.helpText=It’s usually when the money from the property sale was transferred and the new owner got the keys. For example, 25 4 2020.
 completionDate.personalRepInPeriodOfAdmin.helpText=It’s usually when the money from the property sale was transferred and the new owner got the keys. For example, 25 4 2020.
 
-completionDate.link=<a class="govuk-link" href="{0}" target="_blank">Find out what happens on the completion date (opens in a new window)</a>
+completionDate.link=<a class="govuk-link" href="{0}" target="_blank">Find out what happens on the completion date (opens in a new tab)</a>
 completionDate.error.required=Enter a completion date
 completionDate.error.invalid=Enter a real completion date
 completionDate.error.tooFarInPast=Completion date must be on or after contract exchange date, {0}
@@ -1139,7 +1139,8 @@ disposalDateTooEarly.non-uk.p3=You’ll need to complete a <a class="govuk-link"
 
 disposalDateTooEarly.uk.title=You cannot use this service
 disposalDateTooEarly.uk.p1=This is because when the property was sold or disposed of contracts were exchanged before 6 April 2020.
-disposalDateTooEarly.uk.p2=Find out how to report and pay Capital Gains Tax on <a href="{0}">UK property sales or disposals before 6 April 2020</a>.
+disposalDateTooEarly.uk.p2=Find out how to report and pay Capital Gains Tax on <a class="govuk-link" href="{0}">UK property sales or disposals before 6 April 2020</a>.
+disposalDateTooEarly.uk.p2.link=
 
 triage.check-your-answers.title=Check your answers
 triage.cyaChange.countryOfResidence=your country of residence on the day you ‘exchanged’ contracts
@@ -1170,7 +1171,7 @@ multiple-disposals.guidance.p3=You must send separate returns if the contract ex
 multiple-disposals.guidance.details.summary=What happens on ‘exchange’ and ‘completion’ dates?
 multiple-disposals.guidance.details.p1=The ‘completion’ date is usually the day the new owner gets the key to the property.
 multiple-disposals.guidance.details.p2=Contract ‘exchange’ usually happens when the buyer and seller exchange contracts. It’s usually when the new owner pays a deposit.
-multiple-disposals.guidance.details.link=<a href="{0}" target="_blank">Read about ‘exchange’ and ‘completion’ (opens in a new window)</a>.
+multiple-disposals.guidance.details.link=<a href="{0}" target="_blank">Read about ‘exchange’ and ‘completion’ (opens in a new tab)</a>.
 
 multipleDisposalsNumberOfProperties.title=How many disposals are you including in this return?
 multipleDisposalsNumberOfProperties.p1=The property disposals must all have the same ‘completion’ date. The contract ‘exchange’ dates must all be in the same tax year.
@@ -1178,7 +1179,7 @@ multipleDisposalsNumberOfProperties.p2=If you are reporting the sale of shares e
 multipleDisposalsNumberOfProperties.details.summary=What happens on ‘exchange’ and ‘completion’ dates?
 multipleDisposalsNumberOfProperties.details.p1=The ‘completion’ date is usually the day the new owner gets the key to the property,
 multipleDisposalsNumberOfProperties.details.p2=Contract ‘exchange’ usually happens when the buyer and seller exchange contracts. It’s usually when the new owner pays a deposit.
-multipleDisposalsNumberOfProperties.details.link=<a href="{0}" target="_blank">Read about ‘exchange’ and ‘completion’ (opens in a new window)</a>.
+multipleDisposalsNumberOfProperties.details.link=<a href="{0}" target="_blank">Read about ‘exchange’ and ‘completion’ (opens in a new tab)</a>.
 
 multipleDisposalsNumberOfProperties.error.invalid=Amount of disposals must be a number
 multipleDisposalsNumberOfProperties.error.required=Enter the number of disposals you are including in this return
@@ -1195,12 +1196,12 @@ multipleDisposalsWereYouAUKResident.personalRep.title=Was the person a UK reside
 multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.title=Was the person a UK resident for the tax year in which they died?
 multipleDisposalsWereYouAUKResident.helpText=Contract ‘exchange’ usually happens when a buyer and seller swap contracts and the buyer pays a deposit.
 
-multipleDisposalsWereYouAUKResident.link=<a href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new window)</a>
-multipleDisposalsWereYouAUKResident.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status (opens in a new window)</a>
-multipleDisposalsWereYouAUKResident.trust.link=<a class="govuk-link" href="{0}" target="_blank">Work out the trust’s residence status (opens in a new window)</a>
-multipleDisposalsWereYouAUKResident.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status (opens in a new window)</a>
-multipleDisposalsWereYouAUKResident.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status (opens in a new window)</a>
-multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the persons’s residence status for a tax year (opens in a new window)</a>
+multipleDisposalsWereYouAUKResident.link=<a href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.trust.link=<a class="govuk-link" href="{0}" target="_blank">Work out the trust’s residence status (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the persons’s residence status for a tax year (opens in a new tab)</a>
 
 multipleDisposalsWereYouAUKResident.error.required=Select yes if you were a UK resident on all of the contract ‘exchange’ dates
 multipleDisposalsWereYouAUKResident.error.boolean=Select yes if you were a UK resident on all of the contract ‘exchange’ dates
@@ -1250,7 +1251,7 @@ multipleDisposalsTaxYear.taxyear.2020=All between 6 April 2020 and 5 April 2021
 multipleDisposalsTaxYear.taxyear.before2020=All before 6 April 2020
 multipleDisposalsTaxYear.taxyear.different=The properties were exchanged in different tax years
 
-multipleDisposalsTaxYear.details.p1=Contract <a href="{0}" target="_blank">exchange (opens in a new window)</a> usually happens when the buyer and seller exchange contracts. It’s usually when the new owner pays a deposit.
+multipleDisposalsTaxYear.details.p1=Contract <a href="{0}" target="_blank">exchange (opens in a new tab)</a> usually happens when the buyer and seller exchange contracts. It’s usually when the new owner pays a deposit.
 multipleDisposalsTaxYear.error.required=Select when the contracts were exchanged on all the properties
 multipleDisposalsTaxYear.error.before.invalid=The exchange dates must be either in the same tax year as the date of death or a previous tax year
 multipleDisposalsTaxYear.error.after.invalid=The exchange dates must be either in the same tax year as the date of death or a later tax year
@@ -1260,7 +1261,7 @@ multipleDisposalsExchangedInDifferentTaxYears.title=You cannot use this service
 multipleDisposalsExchangedInDifferentTaxYears.p1=This is because you can only submit a return for properties that were exchanged in a single tax year.
 multipleDisposalsExchangedInDifferentTaxYears.p2=For example, if you exchanged one property in the tax year 2020 to 2021 and another in the tax year 2021 to 2022, you cannot submit them in the same return.
 multipleDisposalsExchangedInDifferentTaxYears.whatNext=What you’ll need to do next
-multipleDisposalsExchangedInDifferentTaxYears.p3=<a href="{0}">Start again</a> and submit a separate return for each tax year.
+multipleDisposalsExchangedInDifferentTaxYears.p3=<a class="govuk-link" href="{0}">Start again</a> and submit a separate return for each tax year.
 
 multipleDisposalsAssetTypeForNonUkResidents.title=What types of property or assets did you dispose of?
 multipleDisposalsAssetTypeForNonUkResidents.agent.title=What types of property or assets did your client dispose of?
@@ -1310,7 +1311,7 @@ multipleDisposalsAssetTypeForNonUkResidents.cyaChange=the types of property or a
 multipleDisposalsCompletionDate.title=What was the ‘completion’ date for all the properties?
 multipleDisposalsCompletionDate.helpText=For example, 25, 4, 2020.
 multipleDisposalsCompletionDate.details.summary=What happens on the ‘completion’ date?
-multipleDisposalsCompletionDate.details.p1=The <a href="{0}" target=_blank>‘completion’ date (opens in a new window)</a> is usually the day the new owner gets the keys to the property.
+multipleDisposalsCompletionDate.details.p1=The <a class="govuk-link" href="{0}" target="_blank">‘completion’ date (opens in a new tab)</a> is usually the day the new owner gets the keys to the property.
 multipleDisposalsCompletionDate.error.required=Enter a completion date
 multipleDisposalsCompletionDate.error.invalid=Enter a real completion date
 multipleDisposalsCompletionDate.error.tooFarInFuture=Completion date must be today or in the past
@@ -2504,7 +2505,7 @@ acquisitionFees.trust.indirect.rebased.helpText=For example, the cost of paying 
 acquisitionFees.capacitor.indirect.rebased.helpText=For example, the cost of paying a stock broker to tell you what the value of the shares was on {0}
 acquisitionFees.personalRep.indirect.rebased.helpText=For example, the cost of paying a stock broker to tell you what the value of the shares was on {0}
 
-acquisitionFees.allowableCostsLinkText=<a href="{0}" target="_blank">Find out about additional allowable costs (opens in a new window)</a>
+acquisitionFees.allowableCostsLinkText=<a href="{0}" target="_blank">Find out about additional allowable costs (opens in a new tab)</a>
 acquisitionFees.details.header=What is rebasing?
 
 acquisitionFees.details.p1=You owned the property on or before {0}.
@@ -2528,7 +2529,7 @@ acquisitionFees.indirect.agent.p2=To work out your client’s Capital Gains Tax,
 acquisitionFees.indirect.trust.details.p2=To work out the trust’s Capital Gains Tax, you must use the market value of the shares on that date. This is instead of using the actual purchase or acquisition amount.
 
 acquisitionFees.details.p3=This process is called rebasing.
-acquisitionFees.non-resident.details.p3=This process is called <a href="{0}" target="_blank">rebasing (opens in a new window)</a>.
+acquisitionFees.non-resident.details.p3=This process is called <a href="{0}" target="_blank">rebasing (opens in a new tab)</a>.
 
 acquisitionFees.cyaChange=if there were any additional acquisition costs
 acquisitionFees.rebased.cyaChange=if there were any additional rebasing costs
@@ -2601,10 +2602,10 @@ rebaseAcquisitionPrice.trust.dropdown.p2=To work out the trust’s gain or loss,
 rebaseAcquisitionPrice.capacitor.dropdown.p2=To work out the person’s gain or loss, you must use the market value of the property on that date. This is instead of using the actual purchase or acquisition amount.
 rebaseAcquisitionPrice.personalRep.dropdown.p2=To work out the person’s gain or loss, you must use the market value of the property on that date. This is instead of using the actual purchase or acquisition amount.
 
-rebaseAcquisitionPrice.indirect.dropdown.p2=<a href="{0}" target="_blank">Learn about rebasing (opens in a new window or tab)</a>
+rebaseAcquisitionPrice.indirect.dropdown.p2=<a href="{0}" target="_blank">Learn about rebasing (opens in a new tab)</a>
 
 rebaseAcquisitionPrice.dropdown.p3=This process is called rebasing.
-rebaseAcquisitionPrice.dropdown.p4=<a href="{0}" target="_blank">Find out how to ask HMRC to check a property’s market value (opens in a new window)</a>.
+rebaseAcquisitionPrice.dropdown.p4=<a href="{0}" target="_blank">Find out how to ask HMRC to check a property’s market value (opens in a new tab)</a>.
 
 rebaseAcquisitionPrice.dropdown.p5=It takes at least 3 months for HMRC to check a property’s market value. This means you should enter an estimate now and if you need to amend the amount do it later using this service. Or if you already complete a Self Assessment tax return you can provide the correct market value in your next Self Assessment.
 rebaseAcquisitionPrice.agent.dropdown.p5=It can take 3 months or more for HMRC to check a property’s market value. This means an estimate can be entered so your client can report the tax. The estimate can be confirmed later through this service, or through a Self Assessment tax return.
@@ -2772,7 +2773,7 @@ privateResidentsRelief.details.body.p2=If you did not live in the property for t
 privateResidentsRelief.details.body.li1=years you lived there
 privateResidentsRelief.details.body.li2=last <strong class="bold">9 months</strong> you owned it - even if you were not living there at the time
 privateResidentsRelief.details.body.p3=Some exceptions apply.
-privateResidentsRelief.details.body.link=Find out about Private Residence Relief (opens in a new window)
+privateResidentsRelief.details.body.link=Find out about Private Residence Relief (opens in a new tab)
 
 privateResidentsReliefValue.label=Amount of Private Residence Relief you are entitled to
 privateResidentsReliefValue.agent.label=Amount of Private Residence Relief your client is entitled to
@@ -2782,7 +2783,7 @@ privateResidentsReliefValue.personalRep.label=Amount of Private Residence Relief
 privateResidentsReliefValue.personalRepInPeriodOfAdmin.agent.label=Amount of Private Residence Relief being claimed
 privateResidentsReliefValue.personalRepInPeriodOfAdmin.label=Amount of Private Residence Relief being claimed
 
-privateResidentsRelief.furtherInfoLink=Find out about Private Residence Relief (opens in a new window)
+privateResidentsRelief.furtherInfoLink=Find out about Private Residence Relief (opens in a new tab)
 
 privateResidentsRelief.error.required=Select yes if you are entitled to Private Residence Relief
 privateResidentsRelief.agent.error.required=Select yes if your client is entitled to claim Private Residence Relief
@@ -2854,7 +2855,7 @@ lettingsRelief.details.body.p1=If you lived in your home <strong class="bold">at
 lettingsRelief.details.body.li1=the same amount you got in Private Residence Relief
 lettingsRelief.details.body.li2=£40,000
 lettingsRelief.details.body.li3=the same amount as the chargeable gain you made while letting out part of your home
-lettingsRelief.details.body.link=Find out about Letting Relief (opens in a new window)
+lettingsRelief.details.body.link=Find out about Letting Relief (opens in a new tab)
 
 lettingsRelief.error.required=Select yes if you are claiming Letting Relief
 lettingsRelief.agent.error.required=Select yes if your client is entitled to claim Letting Relief
@@ -2862,7 +2863,7 @@ lettingsRelief.trust.error.required=Select yes if the trust is entitled to claim
 lettingsRelief.capacitor.error.required=Select yes if the person is entitled to Letting Relief
 lettingsRelief.personalRep.error.required=Select yes if the person was entitled to Letting Relief
 
-lettingsRelief.furtherInfoLink=Find out about Letting Relief and how to calculate it (opens in a new window)
+lettingsRelief.furtherInfoLink=Find out about Letting Relief and how to calculate it (opens in a new tab)
 
 lettingsReliefValue.label=Amount of Letting Relief
 
@@ -2901,13 +2902,13 @@ otherReliefs.personalRep.helpText2=Do not enter the Annual Exempt Amount, called
 otherReliefs.personalRepInPeriodOfAdmin.agent.helpText2=Do not enter the Annual Exempt Amount, called the personal Capital Gains Tax tax-free allowance, or losses here.
 otherReliefs.personalRepInPeriodOfAdmin.helpText2=Do not enter the Annual Exempt Amount, called the personal Capital Gains Tax tax-free allowance, or losses here.
 
-otherReliefs.furtherInfoLink=Find out about reliefs you might qualify for (opens in a new window)
-otherReliefs.agent.furtherInfoLink=Find out about reliefs your client might qualify for (opens in a new window)
-otherReliefs.trust.furtherInfoLink=Find out about reliefs the trust might qualify for (opens in a new window)
-otherReliefs.capacitor.furtherInfoLink=Find out about reliefs the person might qualify for (opens in a new window)
-otherReliefs.personalRep.furtherInfoLink=Find out about reliefs the person might have qualified for (opens in a new window)
-otherReliefs.personalRepInPeriodOfAdmin.agent.furtherInfoLink=Find out about reliefs the person might have qualified for (opens in a new window)
-otherReliefs.personalRepInPeriodOfAdmin.furtherInfoLink=Find out about reliefs the person might have qualified for (opens in a new window)
+otherReliefs.furtherInfoLink=Find out about reliefs you might qualify for (opens in a new tab)
+otherReliefs.agent.furtherInfoLink=Find out about reliefs your client might qualify for (opens in a new tab)
+otherReliefs.trust.furtherInfoLink=Find out about reliefs the trust might qualify for (opens in a new tab)
+otherReliefs.capacitor.furtherInfoLink=Find out about reliefs the person might qualify for (opens in a new tab)
+otherReliefs.personalRep.furtherInfoLink=Find out about reliefs the person might have qualified for (opens in a new tab)
+otherReliefs.personalRepInPeriodOfAdmin.agent.furtherInfoLink=Find out about reliefs the person might have qualified for (opens in a new tab)
+otherReliefs.personalRepInPeriodOfAdmin.furtherInfoLink=Find out about reliefs the person might have qualified for (opens in a new tab)
 
 otherReliefs.error.required=Select yes if you are claiming other reliefs
 otherReliefs.agent.error.required=Select yes if your client is claiming other reliefs
@@ -3047,13 +3048,13 @@ inYearLosses.personalRep.error.invalid=Select yes if the person want to include 
 inYearLosses.personalRepInPeriodOfAdmin.error.invalid=Select yes if the person want to include any Capital Gains Tax losses you made in the tax year
 inYearLosses.personalRepInPeriodOfAdmin.agent.error.invalid=Select yes if your client wants to include any Capital Gains Tax losses the estate made in the tax year
 
-inYearLosses.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new window)</a>.
-inYearLosses.agent.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new window)</a>.
-inYearLosses.trust.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new window)</a>.
-inYearLosses.capacitor.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new window)</a>.
-inYearLosses.personalRep.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new window)</a>.
-inYearLosses.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new window)</a>.
-inYearLosses.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new window)</a>.
+inYearLosses.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new tab)</a>.
+inYearLosses.agent.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new tab)</a>.
+inYearLosses.trust.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new tab)</a>.
+inYearLosses.capacitor.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new tab)</a>.
+inYearLosses.personalRep.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new tab)</a>.
+inYearLosses.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new tab)</a>.
+inYearLosses.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Find out how losses can reduce gains (opens in a new tab)</a>.
 
 inYearLossesValue.error.invalid=Amount of Capital Gains Tax losses must be a number, like 108 or 2,940.54
 inYearLossesValue.agent.error.invalid=Amount of Capital Gains Tax losses must be a number, like 108 or 2,940.54
@@ -3177,13 +3178,13 @@ previousYearsLosses.personalRep.error.required=Select yes if you want to include
 previousYearsLosses.personalRepInPeriodOfAdmin.error.required=Select yes if you are including any other Capital Gains Tax losses the estate made in previous tax years
 previousYearsLosses.personalRepInPeriodOfAdmin.agent.error.required=Select yes if your client is including any other Capital Gains Tax losses the estate made in previous tax years
 
-previousYearsLosses.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new window)</a>.
-previousYearsLosses.agent.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new window)</a>.
-previousYearsLosses.trust.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new window)</a>.
-previousYearsLosses.capacitor.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new window)</a>.
-previousYearsLosses.personalRep.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new window)</a>.
-previousYearsLosses.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new window)</a>.
-previousYearsLosses.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new window)</a>.
+previousYearsLosses.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new tab)</a>.
+previousYearsLosses.agent.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new tab)</a>.
+previousYearsLosses.trust.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new tab)</a>.
+previousYearsLosses.capacitor.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new tab)</a>.
+previousYearsLosses.personalRep.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new tab)</a>.
+previousYearsLosses.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new tab)</a>.
+previousYearsLosses.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new tab)</a>.
 
 previousYearsLossesValue.label=Amount of losses from previous tax years
 previousYearsLossesValue.agent.label=Amount of losses from previous tax years
@@ -3260,7 +3261,7 @@ previousYearsLosses.furtherReturn.personalRep.helpText=You can include previous 
 previousYearsLosses.furtherReturn.personalRepInPeriodOfAdmin.helpText=You can include previous losses in this return that the estate has already reported to HMRC and has not already used. For example, losses on shares or other UK property.
 previousYearsLosses.furtherReturn.personalRepInPeriodOfAdmin.agent.helpText=You can include previous losses in this return that the estate has already reported to HMRC and has not already used. For example, losses on shares or other UK property.
 
-previousYearsLosses.furtherReturn.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new window)</a>.
+previousYearsLosses.furtherReturn.link=<a href="{0}" target="_blank">Find out how to report losses (opens in a new tab)</a>.
 
 annualExemptAmount.title=How much of your Capital Gains Tax Annual Exempt Amount do you want to use?
 annualExemptAmount.agent.title=How much of your client’s Capital Gains Tax Annual Exempt Amount do they want to use?
@@ -3283,15 +3284,15 @@ annualExemptAmount.furtherReturn.agent.helpText=Include the amount your client w
 annualExemptAmount.furtherReturn.trust.helpText=Include the amount the trust wants to use for the whole tax year. Use its whole Annual Exempt Amount even if it included any of it in previous returns.<br><br>In the tax year {0} to {1}, most trustees only have to pay Capital Gains Tax on gains above {2}. This is called the Annual Exempt Amount.<br><br>The Annual Exempt Amount for trusts for vulnerable beneficiaries is {3}.
 
 annualExemptAmount.details.1.header=What is the Annual Exempt Amount?
-annualExemptAmount.details.1.body=Each tax year a trust gets an annual tax-free allowance. This is known as the <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new window)</a>. Trustees only pay Capital Gains Tax if the trust’s taxable gains for the tax year are above the Annual Exempt Amount.
+annualExemptAmount.details.1.body=Each tax year a trust gets an annual tax-free allowance. This is known as the <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new tab)</a>. Trustees only pay Capital Gains Tax if the trust’s taxable gains for the tax year are above the Annual Exempt Amount.
 annualExemptAmount.details.2.header=Who are vulnerable beneficiaries?
-annualExemptAmount.details.2.body=<a href="{0}" target="_blank">A vulnerable beneficiary (opens in a new window)</a> could be someone under 18 whose parent has died. It could also be a disabled person who is eligible for certain benefits.
+annualExemptAmount.details.2.body=<a href="{0}" target="_blank">A vulnerable beneficiary (opens in a new tab)</a> could be someone under 18 whose parent has died. It could also be a disabled person who is eligible for certain benefits.
 annualExemptAmount.details.3.header=What is the Annual Exempt Amount?
-annualExemptAmount.details.3.body=The <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new window)</a> is an annual tax-free allowance. It is available to certain people who need to pay Capital Gains Tax. Most people only have to pay Capital Gains Tax on their gains for the tax year above the Annual Exempt Amount. Any losses or reliefs must have been subtracted from the gain already.
+annualExemptAmount.details.3.body=The <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new tab)</a> is an annual tax-free allowance. It is available to certain people who need to pay Capital Gains Tax. Most people only have to pay Capital Gains Tax on their gains for the tax year above the Annual Exempt Amount. Any losses or reliefs must have been subtracted from the gain already.
 
-annualExemptAmount.link=<a href="{0}" target="_blank">Find out about the Annual Exempt Amount (opens in a new window)</a>.
-annualExemptAmount.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Find out about the Annual Exempt Amount during the period of administration (opens in a new window)</a>.
-annualExemptAmount.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Find out about the Annual Exempt Amount during the period of administration (opens in a new window)</a>.
+annualExemptAmount.link=<a href="{0}" target="_blank">Find out about the Annual Exempt Amount (opens in a new tab)</a>.
+annualExemptAmount.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Find out about the Annual Exempt Amount during the period of administration (opens in a new tab)</a>.
+annualExemptAmount.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Find out about the Annual Exempt Amount during the period of administration (opens in a new tab)</a>.
 
 annualExemptAmount.error.tooLarge=Annual Exempt Amount must be {0} or less
 annualExemptAmount.agent.error.tooLarge=Annual Exempt Amount must be {0} or less
@@ -3621,7 +3622,7 @@ personalAllowance.non-resident.helpText=We’ll use this amount to work out the 
 personalAllowance.agent.non-resident.helpText=We’ll use this amount to work out the rate of Capital Gains Tax your client should pay.<br/><br/>You’ll need to check the double tax agreement for the country your client is resident in and the UK. This will tell you if they are entitled to a Personal Allowance.
 personalAllowance.capacitor.non-resident.helpText=We’ll use this amount to work out the rate of Capital Gains Tax the person should pay.<br/><br/>The person will need to check the double tax agreement for the country the person is resident in and the UK. This will tell the person if they are entitled to a Personal Allowance.
 personalAllowance.personalRep.non-resident.helpText=We’ll use this amount to work out the rate of Capital Gains Tax that should be paid.<br/><br/>You will need to check the double tax agreement for the country the person was resident in and the UK. This will tell you if the person was entitled to a Personal Allowance.
-personalAllowance.link=<a href="{0}" target="_blank">Find out about Personal Allowances (opens in a new window)</a>.
+personalAllowance.link=<a href="{0}" target="_blank">Find out about Personal Allowances (opens in a new tab)</a>.
 personalAllowance.error.required=Enter how much of your Personal Allowance you want to apply
 personalAllowance.agent.error.required=Enter your client’s Personal Allowance for the tax year
 personalAllowance.capacitor.error.required=Enter the person’s Personal Allowance for the tax year
@@ -3771,7 +3772,7 @@ taxDue.personalRep.helpText.p1=If you agree with these workings enter <strong cl
 taxDue.helpText.p2=If you want to enter a different amount you will be asked to upload a file later showing your workings.
 taxDue.helpText.p3=If the trust is for vulnerable beneficiaries, you’ll need to work out and enter the amount of tax due.
 taxDue.trustDetails.label=Help for trusts for vulnerable beneficiaries
-taxDue.trustDetails.content=Trusts for vulnerable beneficiaries get special tax treatment. The workings out on this page do not apply to this type of trust. Find out how to <a href="{0}" target="_blank">work out the amount of Capital Gains Tax due (opens in a new window)</a> for this type of trust.
+taxDue.trustDetails.content=Trusts for vulnerable beneficiaries get special tax treatment. The workings out on this page do not apply to this type of trust. Find out how to <a href="{0}" target="_blank">work out the amount of Capital Gains Tax due (opens in a new tab)</a> for this type of trust.
 taxDue.error.required=Enter the amount of Capital Gains Tax due for this return
 taxDue.error.invalid=Amount of Capital Gains Tax due must be an amount of money, for example 493 or 2,040.59
 taxDue.error.tooSmall=Amount of Capital Gains Tax due must be an amount of money between 0 and 50,000,000,000
@@ -3844,9 +3845,9 @@ calculator.total.taxOwed=Capital Gains Tax due for this return
 calculator.noTaxToPay=No tax is due for this return
 
 nonCalculatedTaxDue.title=Enter the amount of Capital Gains Tax due for this return
-nonCalculatedTaxDue.ukResident.link=Find out how to work out tax when property is sold (opens in a new window)
-nonCalculatedTaxDue.trust.link=Find out how to work out Capital Gains Tax for a trust (opens in a new window)
-nonCalculatedTaxDue.nonResident.link=Find out how to work out tax when property is sold or for indirect disposals (opens in a new window)
+nonCalculatedTaxDue.ukResident.link=Find out how to work out tax when property is sold (opens in a new tab)
+nonCalculatedTaxDue.trust.link=Find out how to work out Capital Gains Tax for a trust (opens in a new tab)
+nonCalculatedTaxDue.nonResident.link=Find out how to work out tax when property is sold or for indirect disposals (opens in a new tab)
 
 nonCalculatedTaxDue.helpText=You’ll need to work out and enter the amount.
 nonCalculatedTaxDue.error.required=Enter the amount of Capital Gains Tax due for this return
@@ -4219,7 +4220,7 @@ confirmationOfSubmission.trust.ifSa=If the trust needs to send a Self Assessment
 confirmationOfSubmission.capacitor.ifSa=Self Assessment
 confirmationOfSubmission.personalRep.ifSa=If you need to do a Self Assessment tax return for the person
 
-confirmationOfSubmission.ifSa.p1=You’ll need to provide details from this return in your next <a href="{0}" target="_blank">Self Assessment tax return (opens in a new window)</a>.
+confirmationOfSubmission.ifSa.p1=You’ll need to provide details from this return in your next <a href="{0}" target="_blank">Self Assessment tax return (opens in a new tab)</a>.
 confirmationOfSubmission.agent.ifSa.p1=If your client needs to send a Self Assessment tax return they’ll need to provide details from this return in their next Self Assessment tax return.
 confirmationOfSubmission.trust.ifSa.p1=You’ll need to provide details from this return in the trust’s next Self Assessment tax return.
 confirmationOfSubmission.capacitor.ifSa.p1=If the person needs to file a Self Assessment tax return, they will need to provide details from this return in their next Self Assessment tax return.
@@ -4485,7 +4486,7 @@ multipleDisposalsDisposalDate.personalRep.helpText=It’s usually when a buyer a
 multipleDisposalsDisposalDate.personalRepInPeriodOfAdmin.helpText=It’s usually when a buyer and seller swap contracts and the buyer pays a deposit. This is also called the ‘disposal’ date. For example, 25 4 2020.
 multipleDisposalsDisposalDate.personalRepInPeriodOfAdmin.agent.helpText=It’s usually when a buyer and seller swap contracts and the buyer pays a deposit. This is also called the ‘disposal’ date. For example, 25 4 2020.
 
-multipleDisposalsDisposalDate.link=<a href="{0}" target="_blank">Find out what happens on the exchange date (opens in a new window)</a>.
+multipleDisposalsDisposalDate.link=<a href="{0}" target="_blank">Find out what happens on the exchange date (opens in a new tab)</a>.
 
 multipleDisposalsDisposalDate.error.required=Enter a contract exchange date
 multipleDisposalsDisposalDate.error.invalid=Enter a real contract exchange date
@@ -5260,12 +5261,12 @@ furtherReturnGuidance.stage-a.step-a2.li1=Add together all the <strong class="bo
 furtherReturnGuidance.stage-a.step-a2.li2=Subtract any in-year Capital Gains Tax losses that can be deducted.
 furtherReturnGuidance.stage-a.step-a2.li3=Subtract any allowable previous tax years’ Capital Gains Tax losses.
 
-furtherReturnGuidance.stage-a.step-a2.li4=Subtract your <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new window)</a> you want to use on residential property gains to get your <strong class="bold">net gain</strong>.
-furtherReturnGuidance.agent.stage-a.step-a2.li4=Subtract your client’s <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new window)</a> to be used on residential property gains to get the <strong class="bold">net gain</strong>.
-furtherReturnGuidance.capacitor.stage-a.step-a2.li4=Subtract the person’s <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new window)</a> to be used on residential property gains to get the <strong class="bold">net gain</strong>.
-furtherReturnGuidance.trust.stage-a.step-a2.li4=Subtract the <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new window)</a> to be used on residential property gains to get the <strong class="bold">net gain</strong>.
-furtherReturnGuidance.personalRep.stage-a.step-a2.li4=Subtract the person’s <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new window)</a> to be used on residential property gains to get the <strong class="bold">net gain</strong>.
-furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-a.step-a2.li4=Subtract the <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new window)</a> to be used on the residential property gains to get the <strong class="bold">net gain</strong>.
+furtherReturnGuidance.stage-a.step-a2.li4=Subtract your <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new tab)</a> you want to use on residential property gains to get your <strong class="bold">net gain</strong>.
+furtherReturnGuidance.agent.stage-a.step-a2.li4=Subtract your client’s <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new tab)</a> to be used on residential property gains to get the <strong class="bold">net gain</strong>.
+furtherReturnGuidance.capacitor.stage-a.step-a2.li4=Subtract the person’s <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new tab)</a> to be used on residential property gains to get the <strong class="bold">net gain</strong>.
+furtherReturnGuidance.trust.stage-a.step-a2.li4=Subtract the <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new tab)</a> to be used on residential property gains to get the <strong class="bold">net gain</strong>.
+furtherReturnGuidance.personalRep.stage-a.step-a2.li4=Subtract the person’s <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new tab)</a> to be used on residential property gains to get the <strong class="bold">net gain</strong>.
+furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-a.step-a2.li4=Subtract the <a href="{0}" target="_blank">Annual Exempt Amount (opens in a new tab)</a> to be used on the residential property gains to get the <strong class="bold">net gain</strong>.
 
 furtherReturnGuidance.stage-a.step-a2.li5=This result is what the Capital Gains Tax you should be paying now is based on.
 furtherReturnGuidance.agent.stage-a.step-a2.li5=This result is what the Capital Gains Tax that should be paid now is based on.
@@ -5521,11 +5522,11 @@ furtherReturnGuidance.agent.stage-b.step-b1=Step B1 - Work out your client’s t
 furtherReturnGuidance.capacitor.stage-b.step-b1=Step B1 - Work out the person’s taxable income
 furtherReturnGuidance.personalRep.stage-b.step-b1=Step B1 - Work out the person’s taxable income
 
-furtherReturnGuidance.stage-b.step-b1.p1=Do this to help work out your taxable income to find out how much of your net gain (if any) should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new window)</a>.
-furtherReturnGuidance.agent.stage-b.step-b1.p1=Do this to help work out your client’s taxable income to find out how much of their net gain (if any) should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new window)</a>.
-furtherReturnGuidance.capacitor.stage-b.step-b1.p1=Do this to help work out the person’s taxable income to find out how much of the net gain (if any) should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new window)</a>.
-furtherReturnGuidance.personalRep.stage-b.step-b1.p1=Do this to help work out the person’s taxable income to find out how much of the net gain (if any) should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new window)</a>.
-furtherReturnGuidance.trust.stage-b.step-b1.p1=Multiply the trust’s <strong class="bold">net gain</strong> for the year by the relevant <a href="{0}" target="_blank">rate of tax for the tax year for the type of trust (opens in a new window)</a> to work out the trust’s <strong class="bold">overall Capital Gains Tax liability on its UK property-related disposals</strong>.
+furtherReturnGuidance.stage-b.step-b1.p1=Do this to help work out your taxable income to find out how much of your net gain (if any) should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new tab)</a>.
+furtherReturnGuidance.agent.stage-b.step-b1.p1=Do this to help work out your client’s taxable income to find out how much of their net gain (if any) should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new tab)</a>.
+furtherReturnGuidance.capacitor.stage-b.step-b1.p1=Do this to help work out the person’s taxable income to find out how much of the net gain (if any) should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new tab)</a>.
+furtherReturnGuidance.personalRep.stage-b.step-b1.p1=Do this to help work out the person’s taxable income to find out how much of the net gain (if any) should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new tab)</a>.
+furtherReturnGuidance.trust.stage-b.step-b1.p1=Multiply the trust’s <strong class="bold">net gain</strong> for the year by the relevant <a href="{0}" target="_blank">rate of tax for the tax year for the type of trust (opens in a new tab)</a> to work out the trust’s <strong class="bold">overall Capital Gains Tax liability on its UK property-related disposals</strong>.
 
 
 furtherReturnGuidance.stage-b.step-b1.li1=Start with your expected taxable <strong class="bold">gross annual income (excluding any capital gains)</strong>.
@@ -5541,10 +5542,10 @@ furtherReturnGuidance.personalRep.stage-b.step-b1.li2=Subtract the person’s in
 
 furtherReturnGuidance.stage-b.step-b2=Step B2 - Work out what basic rate band can be used against the net gain
 
-furtherReturnGuidance.stage-b.step-b2.p1=Do this to see how much of your net gain should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new window)</a>. If your taxable income is higher than the basic rate band threshold then none of your net gain will be taxed at the basic rate.
-furtherReturnGuidance.agent.stage-b.step-b2.p1=Do this to see how much of your client’s net gain should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new window)</a>. If their taxable income is higher than the basic rate band threshold then none of the net gain will be taxed at the basic rate.
-furtherReturnGuidance.capacitor.stage-b.step-b2.p1=Do this to see how much of the net gain should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new window)</a>. If the person’s taxable income is higher than the basic rate band threshold then none of their net gain will be taxed at the basic rate.
-furtherReturnGuidance.personalRep.stage-b.step-b2.p1=Do this to see how much of the net gain should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new window)</a>. If the person’s taxable income is higher than the basic rate band threshold then none of their net gain will be taxed at the basic rate.
+furtherReturnGuidance.stage-b.step-b2.p1=Do this to see how much of your net gain should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new tab)</a>. If your taxable income is higher than the basic rate band threshold then none of your net gain will be taxed at the basic rate.
+furtherReturnGuidance.agent.stage-b.step-b2.p1=Do this to see how much of your client’s net gain should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new tab)</a>. If their taxable income is higher than the basic rate band threshold then none of the net gain will be taxed at the basic rate.
+furtherReturnGuidance.capacitor.stage-b.step-b2.p1=Do this to see how much of the net gain should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new tab)</a>. If the person’s taxable income is higher than the basic rate band threshold then none of their net gain will be taxed at the basic rate.
+furtherReturnGuidance.personalRep.stage-b.step-b2.p1=Do this to see how much of the net gain should be charged at the <a href="{0}" target="_blank">basic rate (opens in a new tab)</a>. If the person’s taxable income is higher than the basic rate band threshold then none of their net gain will be taxed at the basic rate.
 
 furtherReturnGuidance.stage-b.step-b2.li1=Start with your <strong class="bold">taxable income</strong>.
 furtherReturnGuidance.agent.stage-b.step-b2.li1=Start with your client’s <strong class="bold">taxable income</strong>.
@@ -5568,12 +5569,12 @@ furtherReturnGuidance.agent.stage-b.step-b3.p1=Do this to get your client’s la
 furtherReturnGuidance.capacitor.stage-b.step-b3.p1=Do this to get the person’s latest overall Capital Gains Tax liability on their UK property-related disposals. This calculation will take into account the disposals in this return.
 furtherReturnGuidance.personalRep.stage-b.step-b3.p1=Do this to get the person’s latest overall Capital Gains Tax liability on their UK property-related disposals. This calculation will take into account the disposals in this return.
 
-furtherReturnGuidance.stage-b.step-b3.li1=Multiply the amount of <strong class="bold">net gain</strong> to be taxed at the <a href="{0}" target="_blank">basic rate of tax (opens in a new window)</a> for the UK property-related disposal for that tax year.
-furtherReturnGuidance.agent.stage-b.step-b3.li1=Multiply the amount of <strong class="bold">net gain</strong> to be taxed at the <a href="{0}" target="_blank">basic rate of tax (opens in a new window)</a> for the UK property-related disposal for that tax year.
-furtherReturnGuidance.capacitor.stage-b.step-b3.li1=Multiply the amount of <strong class="bold">net gain</strong> to be taxed at the <a href="{0}" target="_blank">basic rate of tax (opens in a window)</a> for the UK property-related disposals for that tax year.
-furtherReturnGuidance.personalRep.stage-b.step-b3.li1=Multiply the amount of <strong class="bold">net gain</strong> to be taxed at the <a href="{0}" target="_blank">basic rate of tax (opens in a window)</a> for the UK property-related disposals for that tax year.
+furtherReturnGuidance.stage-b.step-b3.li1=Multiply the amount of <strong class="bold">net gain</strong> to be taxed at the <a href="{0}" target="_blank">basic rate of tax (opens in a new tab)</a> for the UK property-related disposal for that tax year.
+furtherReturnGuidance.agent.stage-b.step-b3.li1=Multiply the amount of <strong class="bold">net gain</strong> to be taxed at the <a href="{0}" target="_blank">basic rate of tax (opens in a new tab)</a> for the UK property-related disposal for that tax year.
+furtherReturnGuidance.capacitor.stage-b.step-b3.li1=Multiply the amount of <strong class="bold">net gain</strong> to be taxed at the <a href="{0}" target="_blank">basic rate of tax (opens in a new tab)</a> for the UK property-related disposals for that tax year.
+furtherReturnGuidance.personalRep.stage-b.step-b3.li1=Multiply the amount of <strong class="bold">net gain</strong> to be taxed at the <a href="{0}" target="_blank">basic rate of tax (opens in a new tab)</a> for the UK property-related disposals for that tax year.
 
-furtherReturnGuidance.stage-b.step-b3.li2=Multiply the <strong class="bold">amount to be taxed at the</strong> <a href="{0}" target="_blank">higher rate of tax (opens in a new window)</a> <strong class="bold">for property-related disposals</strong> for that tax year.
+furtherReturnGuidance.stage-b.step-b3.li2=Multiply the <strong class="bold">amount to be taxed at the</strong> <a href="{0}" target="_blank">higher rate of tax (opens in a new tab)</a> <strong class="bold">for property-related disposals</strong> for that tax year.
 
 furtherReturnGuidance.stage-b.step-b3.li3=Add these amounts together to get your <strong class="bold">overall Capital Gains Tax liability on your UK property-related disposals</strong>.
 furtherReturnGuidance.agent.stage-b.step-b3.li3=Add these amounts together to get your client’s <strong class="bold">overall Capital Gains Tax liability on their UK property-related disposals</strong>.
@@ -5697,7 +5698,7 @@ furtherReturnGuidance.trust.stage-b.example3.table1.total.value={0}
 
 
 
-furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.p1=Multiply the estate’s net gain for the year by the relevant <a href="{0}" target="_blank">rate of tax for the tax year for the estate (opens in a new window)</a> to work out its overall Capital Gains Tax liability on its UK property-related disposals.
+furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.p1=Multiply the estate’s net gain for the year by the relevant <a href="{0}" target="_blank">rate of tax for the tax year for the estate (opens in a new tab)</a> to work out its overall Capital Gains Tax liability on its UK property-related disposals.
 furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.example4.link=Personal representative Akash sold 2 properties for Taylor family estate
 
 furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.example4.headingText=Akash works out Taylor family estate’s overall Capital Gains Tax liability for residential property in tax year {0} to {1}.

--- a/conf/messages
+++ b/conf/messages
@@ -762,7 +762,7 @@ previousReturnExistsWithSameCompletionDate.amend.title=You cannot change this re
 
 previousReturnExistsWithSameCompletionDate.amend.p1=You must <a class="govuk-link" href="{0}">contact HMRC</a>.
 previousReturnExistsWithSameCompletionDate.amend.trust.p1=You must <a class="govuk-link" href="{0}">contact HMRC</a>.
-previousReturnExistsWithSameCompletionDate.amend.agent.p1=You must <a href="{0}">contact HMRC</a>.
+previousReturnExistsWithSameCompletionDate.amend.agent.p1=You must <a class="govuk-link" href="{0}">contact HMRC</a>.
 previousReturnExistsWithSameCompletionDate.amend.p2=This is because sales or disposals with the same completion date must all be in the same return.
 previousReturnExistsWithSameCompletionDate.amend.p3=Tell HMRC you need to change:
 previousReturnExistsWithSameCompletionDate.amend.li1=A previous return
@@ -909,11 +909,11 @@ wereYouAUKResident.capacitor.details=If the person was a non-resident and made a
 wereYouAUKResident.personalRep.details=If the person was a non-resident and made an indirect disposal of shares, the disposal date is the day the shares were sold or given away.
 
 wereYouAUKResident.link=<a class="govuk-link" href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new tab)</a>
-wereYouAUKResident.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status for a tax year (opens in a new tab)</a>
-wereYouAUKResident.trust.link=<a href="{0}" target="_blank">Work out the trust’s residence status for a tax year (opens in a new tab)</a>
-wereYouAUKResident.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
-wereYouAUKResident.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
-wereYouAUKResident.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.agent.link=<a class="govuk-link" href="{0}" target="_blank">Work out your client’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.trust.link=<a class="govuk-link" href="{0}" target="_blank">Work out the trust’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.capacitor.link=<a class="govuk-link" href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.personalRep.link=<a class="govuk-link" href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
+wereYouAUKResident.personalRepInPeriodOfAdmin.link=<a class="govuk-link" href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>
 
 wereYouAUKResident.error.required=Select yes if you were a UK resident when you exchanged contracts
 wereYouAUKResident.error.boolean=Select yes if you were a UK resident when you exchanged contracts
@@ -944,11 +944,11 @@ triage.enterCountry.capacitor.helpText=It’s usually the day the person and the
 triage.enterCountry.personalRep.helpText=It’s usually the day the person and the new owner swapped contracts and they paid a deposit.
 
 triage.enterCountry.link=<a class="govuk-link" href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new tab)</a>
-triage.enterCountry.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status (opens in a new tab)</a>.
+triage.enterCountry.agent.link=<a class="govuk-link" href="{0}" target="_blank">Work out your client’s residence status (opens in a new tab)</a>.
 triage.enterCountry.trust.link=<a class="govuk-link" href="{0}" target="_blank">Work out the trust’s residence status (opens in a new tab)</a>.
-triage.enterCountry.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
-triage.enterCountry.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
-triage.enterCountry.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
+triage.enterCountry.capacitor.link=<a class="govuk-link" href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
+triage.enterCountry.personalRep.link=<a class="govuk-link" href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
+triage.enterCountry.personalRepInPeriodOfAdmin.link=<a class="govuk-link" href="{0}" target="_blank">Work out the person’s residence status for a tax year (opens in a new tab)</a>.
 
 assetTypeForNonUkResidents.title=What type of property or asset did you sell or dispose of?
 assetTypeForNonUkResidents.agent.title=What type of property, land or asset did your client sell or dispose of?
@@ -1196,12 +1196,12 @@ multipleDisposalsWereYouAUKResident.personalRep.title=Was the person a UK reside
 multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.title=Was the person a UK resident for the tax year in which they died?
 multipleDisposalsWereYouAUKResident.helpText=Contract ‘exchange’ usually happens when a buyer and seller swap contracts and the buyer pays a deposit.
 
-multipleDisposalsWereYouAUKResident.link=<a href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new tab)</a>
-multipleDisposalsWereYouAUKResident.agent.link=<a href="{0}" target="_blank">Work out your client’s residence status (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.link=<a class="govuk-link" href="{0}" target="_blank">Work out your residence status for a tax year (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.agent.link=<a class="govuk-link" href="{0}" target="_blank">Work out your client’s residence status (opens in a new tab)</a>
 multipleDisposalsWereYouAUKResident.trust.link=<a class="govuk-link" href="{0}" target="_blank">Work out the trust’s residence status (opens in a new tab)</a>
-multipleDisposalsWereYouAUKResident.capacitor.link=<a href="{0}" target="_blank">Work out the person’s residence status (opens in a new tab)</a>
-multipleDisposalsWereYouAUKResident.personalRep.link=<a href="{0}" target="_blank">Work out the person’s residence status (opens in a new tab)</a>
-multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Work out the persons’s residence status for a tax year (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.capacitor.link=<a class="govuk-link" href="{0}" target="_blank">Work out the person’s residence status (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.personalRep.link=<a class="govuk-link" href="{0}" target="_blank">Work out the person’s residence status (opens in a new tab)</a>
+multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.link=<a class="govuk-link" href="{0}" target="_blank">Work out the persons’s residence status for a tax year (opens in a new tab)</a>
 
 multipleDisposalsWereYouAUKResident.error.required=Select yes if you were a UK resident on all of the contract ‘exchange’ dates
 multipleDisposalsWereYouAUKResident.error.boolean=Select yes if you were a UK resident on all of the contract ‘exchange’ dates

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -5,7 +5,7 @@ who-are-you-reporting-for-exit-page.helpText=Rhaid i chi <a href="{0}">gysylltu 
 previousReturnExistsWithSameCompletionDate.amend.title=Ni allwch newid y Ffurflen Dreth hon ar-lein
 previousReturnExistsWithSameCompletionDate.amend.p1=Rhaid i chi <a class="govuk-link" href="{0}">gysylltu â CThEM</a>.
 previousReturnExistsWithSameCompletionDate.amend.trust.p1=Rhaid i chi <a class="govuk-link" href="{0}">gysylltu â CThEM</a>.
-previousReturnExistsWithSameCompletionDate.amend.agent.p1=Rhaid i chi <a href="{0}">gysylltu â CThEM</a>.
+previousReturnExistsWithSameCompletionDate.amend.agent.p1=Rhaid i chi <a class="govuk-link" href="{0}">gysylltu â CThEM</a>.
 previousReturnExistsWithSameCompletionDate.amend.p2=Mae hyn oherwydd bod rhaid i werthiannau neu warediadau sydd â’r un dyddiad cwblhau fod ar yr un Ffurflen Dreth.
 previousReturnExistsWithSameCompletionDate.amend.p3=Rhowch wybod i CThEM fod angen i chi newid:
 previousReturnExistsWithSameCompletionDate.amend.li1=Ffurflen Dreth flaenorol
@@ -191,7 +191,7 @@ timed-out.p2=Bydd yn rhaid i chi fewngofnodi er mwyn cael mynediad at eich cyfri
 timed-out.button=Mewngofnodi
 recruitment-banner.message=Helpwch i wella GOV.UK
 recruitment-banner.dismiss=Dim diolch
-recruitment-banner.link=<a target="_blank" rel="noreferrer noopener" href="{0}">Byddwch yn rhan o wneud gwasanaethau’r llywodraeth yn well (yn agor ffenestr newydd)</a>
+recruitment-banner.link=<a target="_blank" rel="noreferrer noopener" href="{0}">Byddwch yn rhan o wneud gwasanaethau’r llywodraeth yn well (yn agor tab newydd)</a>
 accessibilityStatement.caption=Rhoi gwybod am a thalu Treth Enillion Cyfalaf ar eiddo yn y DU
 accessibilityStatement.title=Datganiad hygyrchedd
 accessibilityStatement.p1=Mae’r datganiad hygyrchedd hwn yn esbonio pa mor hygyrch yw’r gwasanaeth hwn, beth i’w wneud os ydych yn cael anhawster wrth ei ddefnyddio, a sut i roi gwybod am broblemau hygyrchedd gyda’r gwasanaeth.
@@ -379,7 +379,7 @@ subscribed.p4=Rydym wedi anfon e-bost cadarnhau i <strong class="bold">{0}</stro
 subscribed.buttonText=Ewch i’r cyfrif
 registerTrust.title=Bydd angen i chi gofrestru’r ymddiriedolaeth
 registerTrust.p=I ddefnyddio’r gwasanaeth hwn, bydd angen i chi:
-registerTrust.bullet1=<a href="{0}" target="_blank">Cofrestru’r ymddiriedolaeth (yn agor ffenestr newydd)</a>.
+registerTrust.bullet1=<a href="{0}" target="_blank">Cofrestru’r ymddiriedolaeth (yn agor tab newydd)</a>.
 registerTrust.bullet2=Mewngofnodi i’r gwasanaeth hwn gan ddefnyddio’r Dynodydd Defnyddiwr (ID) a chyfrinair ar gyfer Porth y Llywodraeth a ddefnyddiwyd gennych i gofrestru’r ymddiriedolaeth.
 reportCorpTax.title=Rydych wedi ceisio mewngofnodi fel sefydliad
 reportCorpTax.p1=Ymddiriedolaethau yw’r unig sefydliad sy’n gallu defnyddio’r gwasanaeth hwn i roi gwybod am Dreth Enillion Cyfalaf ar eiddo yn y DU.
@@ -469,9 +469,9 @@ enterTrn.tooManyAttempts.title=Bydd angen i chi aros a rhoi cynnig arall arni
 enterTrn.tooManyAttempts.p1=Rydych wedi ceisio nodi eich Rhif Cofrestru Ymddiriedolaeth ac enw’r ymddiriedolaeth gormod o weithiau.
 enterTrn.tooManyAttempts.p2=Bydd angen i chi aros am 2 awr a rhoi cynnig arall arni.
 enterTrn.whatATrnIs=Beth yw Rhif Cofrestru Ymddiriedolaeth?
-enterTrn.whatATrnIs.p1=Mae CThEM yn anfon y rhif hwn i’r person sy’n <a href="{0}" target="_blank">cofrestru’r ymddiriedolaeth (yn agor ffenestr newydd)</a>.
+enterTrn.whatATrnIs.p1=Mae CThEM yn anfon y rhif hwn i’r person sy’n <a href="{0}" target="_blank">cofrestru’r ymddiriedolaeth (yn agor tab newydd)</a>.
 enterTrn.ifYouCannotFind=Os na allwch ddod o hyd iddo
-enterTrn.ifYouCannotFind.p1=Os gwnaethoch gofrestru’r ymddiriedolaeth a ni allwch ddod o hyd i’w Rhif Cofrestru Ymddiriedolaeth, gallwch <a href="{0}" target="_blank">gysylltu â CThEM (yn agor ffenestr newydd)</a>.
+enterTrn.ifYouCannotFind.p1=Os gwnaethoch gofrestru’r ymddiriedolaeth a ni allwch ddod o hyd i’w Rhif Cofrestru Ymddiriedolaeth, gallwch <a href="{0}" target="_blank">gysylltu â CThEM (yn agor tab newydd)</a>.
 enterTrustName.label=Enw’r ymddiriedolaeth
 trustName.error.required=Nodwch enw’ch ymddiriedolaeth
 trustName.error.tooLong=Mae’n rhaid i enw’ch ymddiriedolaeth fod yn llai na 105 o gymeriadau
@@ -570,8 +570,8 @@ account.manageYourDetails.subtitle=Rhif y cyfrif
 account.manageYourDetails.accountName=Enw’r cyfrif
 account.manageYourDetails.contactHeading=Manylion y person cyswllt
 account.manageYourDetails.p=Byddwn dim ond yn defnyddio’r manylion cyswllt hyn os oes angen i ni gysylltu â chi ynghylch y gwasanaeth hwn.
-account.manageYourDetails.individual.p2=Os oes angen i ‘Enw’r cyfrif’ newid, bydd angen i chi <a href="{0}" target="_blank">roi gwybod i CThEM (yn agor ffenestr newydd)</a>.
-account.manageYourDetails.organisation.p2=Os bydd enw neu gyfeiriad y prif ymddiriedolwr yn newid, bydd angen i chi <a href="{0}" target="_blank">roi gwybod i CThEM (yn agor ffenestr newydd)</a>.
+account.manageYourDetails.individual.p2=Os oes angen i ‘Enw’r cyfrif’ newid, bydd angen i chi <a href="{0}" target="_blank">roi gwybod i CThEM (yn agor tab newydd)</a>.
+account.manageYourDetails.organisation.p2=Os bydd enw neu gyfeiriad y prif ymddiriedolwr yn newid, bydd angen i chi <a href="{0}" target="_blank">roi gwybod i CThEM (yn agor tab newydd)</a>.
 account.manageYourDetails.yourName=Eich enw
 account.manageYourDetails.ContactName.changed=Mae’r enw cyswllt wedi newid
 account.manageYourDetails.Email.changed=Mae’r cyfeiriad e-bost cyswllt wedi newid
@@ -729,12 +729,12 @@ selfAssessmentAlreadySubmitted.personalRepInPeriodOfAdmin.p1=Mae rhywun eisoes w
 
 selfAssessmentAlreadySubmitted.whatNext=Beth fydd angen i chi ei wneud nesaf
 
-selfAssessmentAlreadySubmitted.p2=Bydd angen i <a class="govuk-link" href="{0}" target="_blank"> chi newid eich Ffurflen Dreth Hunanasesiad</a> trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
-selfAssessmentAlreadySubmitted.agent.p2=Bydd angen i <a href="{0}" target="_blank">chi newid Ffurflen Dreth Hunanasesiad</a> eich cleient trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
-selfAssessmentAlreadySubmitted.trust.p2=Bydd angen i <a href="{0}" target="_blank">chi newid Hunanasesiad yr ymddiriedolaeth: Ffurflen Dreth Ymddiriedolaeth ac Ystâd</a> yr ymddiriedolaeth trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
-selfAssessmentAlreadySubmitted.capacitor.p2=Bydd angen i <a href="{0}" target="_blank">chi newid Ffurflen Dreth Hunanasesiad</a> yr unigolyn trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
-selfAssessmentAlreadySubmitted.personalRep.p2=Bydd angen i <a href="{0}" target="_blank">chi newid Ffurflen Dreth Hunanasesiad</a> yr unigolyn trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
-selfAssessmentAlreadySubmitted.personalRepInPeriodOfAdmin.p2=Bydd angen i <a href="{0}" target="_blank">chi newid Ffurflen Dreth Hunanasesiad</a> yr unigolyn trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
+selfAssessmentAlreadySubmitted.p2=Bydd angen i <a class="govuk-link" href="{0}" target="_blank"> chi newid eich Ffurflen Dreth Hunanasesiad (yn agor tab newydd)</a> trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
+selfAssessmentAlreadySubmitted.agent.p2=Bydd angen i <a class="govuk-link" href="{0}" target="_blank">chi newid Ffurflen Dreth Hunanasesiad (yn agor tab newydd)</a> eich cleient trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
+selfAssessmentAlreadySubmitted.trust.p2=Bydd angen i <a class="govuk-link" href="{0}" target="_blank">chi newid Hunanasesiad yr ymddiriedolaeth: Ffurflen Dreth Ymddiriedolaeth ac Ystâd (yn agor tab newydd)</a> yr ymddiriedolaeth trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
+selfAssessmentAlreadySubmitted.capacitor.p2=Bydd angen i <a class="govuk-link" href="{0}" target="_blank">chi newid Ffurflen Dreth Hunanasesiad (yn agor tab newydd)</a> yr unigolyn trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
+selfAssessmentAlreadySubmitted.personalRep.p2=Bydd angen i <a class="govuk-link" href="{0}" target="_blank">chi newid Ffurflen Dreth Hunanasesiad (yn agor tab newydd)</a> yr unigolyn trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
+selfAssessmentAlreadySubmitted.personalRepInPeriodOfAdmin.p2=Bydd angen i <a class="govuk-link" href="{0}" target="_blank">chi newid Ffurflen Dreth Hunanasesiad (yn agor tab newydd)</a> yr unigolyn trwy ychwanegu manylion unrhyw werthiannau neu warediadau eiddo yn y DU a wnaed yn ystod y flwyddyn dreth 6 Ebrill {1} i 5 Ebrill {2}.
 
 #===================================================
 #  Self-Assessment SA - END
@@ -787,12 +787,12 @@ wereYouAUKResident.personalRep.title=A oedd y person yn breswylydd yn y DU ar y 
 wereYouAUKResident.agent.title=A oedd eich cleient yn breswylydd yn y DU ar y dyddiad gwaredu?
 wereYouAUKResident.personalRepInPeriodOfAdmin.title=A oedd y person yn breswylydd yn y DU am y flwyddyn dreth y bu farw ynddi?
 wereYouAUKResident.helpText=Y dyddiad gwaredu ar gyfer eiddo yn y DU yw’r dyddiad cyfnewid contractau. Mae cyfnewid contractau fel arfer yn digwydd pan fydd prynwr a gwerthwr yn rhoi contract i’w gilydd a phan fydd y prynwr yn talu blaendal.
-wereYouAUKResident.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan eich statws preswylio am flwyddyn dreth (yn agor ffenestr newydd)</a>
-wereYouAUKResident.agent.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’ch cleient am flwyddyn dreth (yn agor ffenestr newydd)</a>
-wereYouAUKResident.trust.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’r ymddiriedolaeth am flwyddyn dreth (yn agor ffenestr newydd)</a>
-wereYouAUKResident.capacitor.link=<a href="{0}" target="_blank">Pennu statws preswylio’r person am y flwyddyn dreth (yn agor ffenestr newydd)</a>
-wereYouAUKResident.personalRep.link=<a href="{0}" target="_blank">Pennu statws preswylio’r person am y flwyddyn dreth (yn agor ffenestr newydd)</a>
-wereYouAUKResident.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Pennu statws preswylio’r person am y flwyddyn dreth (yn agor ffenestr newydd)</a>
+wereYouAUKResident.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan eich statws preswylio am flwyddyn dreth (yn agor tab newydd)</a>
+wereYouAUKResident.agent.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’ch cleient am flwyddyn dreth (yn agor tab newydd)</a>
+wereYouAUKResident.trust.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r ymddiriedolaeth am flwyddyn dreth (yn agor tab newydd)</a>
+wereYouAUKResident.capacitor.link=<a class="govuk-link" href="{0}" target="_blank">Pennu statws preswylio’r person am y flwyddyn dreth (yn agor tab newydd)</a>
+wereYouAUKResident.personalRep.link=<a class="govuk-link" href="{0}" target="_blank">Pennu statws preswylio’r person am y flwyddyn dreth (yn agor tab newydd)</a>
+wereYouAUKResident.personalRepInPeriodOfAdmin.link=<a class="govuk-link" href="{0}" target="_blank">Pennu statws preswylio’r person am y flwyddyn dreth (yn agor tab newydd)</a>
 wereYouAUKResident.error.required=Dewiswch ‘Iawn’ os oeddech yn breswylydd yn y DU pan wnaethoch gyfnewid contractau
 wereYouAUKResident.error.boolean=Dewiswch ‘Iawn’ os oeddech yn breswylydd yn y DU pan wnaethoch gyfnewid contractau
 wereYouAUKResident.agent.error.required=Dewiswch ‘Iawn’ os oedd eich cleient yn breswylydd yn y DU pan wnaeth gyfnewid contractau
@@ -817,12 +817,12 @@ triage.enterCountry.agent.helpText=Fel arfer, dyma’r diwrnod y gwnaeth eich cl
 triage.enterCountry.trust.helpText=Fel arfer, dyma’r diwrnod y gwnaeth yr ymddiriedolaeth a’r perchennog newydd roi contract i’w gilydd a’r diwrnod y gwnaeth dalu blaendal.
 triage.enterCountry.capacitor.helpText=Fel arfer, dyma’r diwrnod y gwnaeth y person a’r perchennog newydd roi contract i’w gilydd a’r diwrnod y gwnaeth dalu blaendal.
 triage.enterCountry.personalRep.helpText=Fel arfer, dyma’r diwrnod y gwnaeth y person a’r perchennog newydd roi contract i’w gilydd a’r diwrnod y gwnaeth dalu blaendal.
-triage.enterCountry.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan eich statws preswylio am flwyddyn dreth (yn agor ffenestr newydd)</a>.
-triage.enterCountry.agent.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’ch cleient (yn agor ffenestr newydd)</a>.
-triage.enterCountry.trust.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r ymddiriedolaeth (yn agor ffenestr newydd)</a>.
-triage.enterCountry.capacitor.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person am flwyddyn dreth (yn agor ffenestr newydd)</a>.
-triage.enterCountry.personalRep.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person am flwyddyn dreth (yn agor ffenestr newydd)</a>.
-triage.enterCountry.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person am flwyddyn dreth (yn agor ffenestr newydd)</a>.
+triage.enterCountry.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan eich statws preswylio am flwyddyn dreth (yn agor tab newydd)</a>.
+triage.enterCountry.agent.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’ch cleient (yn agor tab newydd)</a>.
+triage.enterCountry.trust.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r ymddiriedolaeth (yn agor tab newydd)</a>.
+triage.enterCountry.capacitor.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person am flwyddyn dreth (yn agor tab newydd)</a>.
+triage.enterCountry.personalRep.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person am flwyddyn dreth (yn agor tab newydd)</a>.
+triage.enterCountry.personalRepInPeriodOfAdmin.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person am flwyddyn dreth (yn agor tab newydd)</a>.
 assetTypeForNonUkResidents.title=Pa fath o eiddo neu ased y gwnaethoch ei werthu neu ei waredu?
 assetTypeForNonUkResidents.agent.title=Pa fath o eiddo, tir neu ased y gwnaeth eich cleient ei werthu neu ei waredu?
 assetTypeForNonUkResidents.trust.title=Pa fath o eiddo, tir neu ased y gwnaeth yr ymddiriedolaeth ei werthu neu ei waredu?
@@ -898,7 +898,7 @@ didYouDisposeOfResidentialProperty.details.p1=Mae eiddo preswyl yn cynnwys:
 didYouDisposeOfResidentialProperty.details.l1=adeilad lle mae rhywun yn byw neu lle gallai fyw, fel tŷ, fflat neu fath arall o annedd
 didYouDisposeOfResidentialProperty.details.l2=adeilad sy’n cael ei adeiladu neu ei newid fel y gellir ei ddefnyddio fel man lle gallai rhywun fyw
 didYouDisposeOfResidentialProperty.details.l3=tir sy’n rhan o ardd neu dir adeilad sy’n cael ei ddefnyddio fel man lle mae rhywun yn byw, neu lle gallai fyw
-didYouDisposeOfResidentialProperty.details.link=<a href="{0}" tabindex="-1" target="_blank">Darllenwch ddiffiniad o eiddo preswyl (yn agor ffenestr newydd)</a>.
+didYouDisposeOfResidentialProperty.details.link=<a href="{0}" tabindex="-1" target="_blank">Darllenwch ddiffiniad o eiddo preswyl (yn agor tab newydd)</a>.
 didYouDisposeOfResidentialProperty.error.required=Dewiswch ‘Iawn’ os gwnaethoch werthu neu waredu eiddo preswyl yn y DU
 didYouDisposeOfResidentialProperty.error.boolean=Dewiswch ‘Iawn’ os gwnaethoch werthu neu waredu eiddo preswyl yn y DU
 didYouDisposeOfResidentialProperty.agent.error.required=Dewiswch ‘Iawn’ os gwnaeth eich cleient waredu eiddo preswyl yn y DU
@@ -914,7 +914,7 @@ didYouDisposeOfResidentialProperty.personalRepInPeriodOfAdmin.error.boolean=Dewi
 didYouDisposeOfResidentialProperty.cyaChange=p’un a gafodd eiddo preswyl yn y DU ei waredu
 ukResidentCanOnlyReportResidential.title=Ni allwch ddefnyddio’r gwasanaeth hwn
 ukResidentCanOnlyReportResidential.p1=Gwnaethoch ddweud wrthym eich bod yn breswylydd yn y DU ar y diwrnod y gwnaethoch werthu neu waredu eiddo yn y DU. Dim ond i roi gwybod am eiddo preswyl yn y DU y gallwch ddefnyddio’r gwasanaeth hwn.
-ukResidentCanOnlyReportResidential.p2=Dysgwch sut i roi gwybod am a thalu Treth Enillion Cyfalaf ar <a href="{0}">werthiannau neu warediadau eiddo dibreswyl yn y DU</a>.
+ukResidentCanOnlyReportResidential.p2=Dysgwch sut i roi gwybod am a thalu Treth Enillion Cyfalaf ar <a class="govuk-link" href="{0}">werthiannau neu warediadau eiddo dibreswyl yn y DU</a>.
 disposalDate.title=Ar ba ddyddiad y gwnaethoch gyfnewid contractau wrth waredu’r eiddo?
 disposalDate.agent.title=Pan waredwyd yr eiddo, ar ba ddyddiad y cyfnewidiwyd contractau?
 disposalDate.trust.title=Pan waredwyd yr eiddo, ar ba ddyddiad y cyfnewidiwyd contractau?
@@ -928,7 +928,7 @@ disposalDate.trust.helpText=Mae hyn fel arfer pan fydd prynwr a gwerthwr yn rhoi
 disposalDate.capacitor.helpText=Mae hyn fel arfer pan fydd prynwr a gwerthwr yn rhoi contract i’w gilydd ac mae''r prynwr yn talu blaendal. Gelwir hyn hefyd yn ddyddiad ‘gwaredu’. Er enghraifft, 25 4 2020.
 disposalDate.personalRep.helpText=Mae hyn fel arfer pan fydd prynwr a gwerthwr yn rhoi contract i’w gilydd ac mae''r prynwr yn talu blaendal. Gelwir hyn hefyd yn ddyddiad ‘gwaredu’. Er enghraifft, 25 4 2020.
 disposalDate.personalRepInPeriodOfAdmin.helpText=Mae hyn fel arfer pan fydd prynwr a gwerthwr yn rhoi contract i’w gilydd ac mae''r prynwr yn talu blaendal. Gelwir hyn hefyd yn ddyddiad ‘gwaredu’. Er enghraifft, 25 4 2020.
-disposalDate.link=<a class="govuk-link" href="{0}" target="_blank">Cael gwybod beth sy’n digwydd ar y dyddiad cyfnewid (yn agor ffenestr newydd)</a>.
+disposalDate.link=<a class="govuk-link" href="{0}" target="_blank">Cael gwybod beth sy’n digwydd ar y dyddiad cyfnewid (yn agor tab newydd)</a>.
 disposalDate.error.required=Nodwch ddyddiad cyfnewid contractau
 disposalDate.error.invalid=Nodwch ddyddiad cyfnewid contractau go iawn
 disposalDate.error.tooFarInFuture=Mae’n rhaid i’r dyddiad cyfnewid contractau fod heddiw neu yn y gorffennol
@@ -957,7 +957,7 @@ completionDate.trust.helpText=Mae hyn fel arfer pan drosglwyddwyd yr arian o’r
 completionDate.capacitor.helpText=Mae hyn fel arfer pan drosglwyddwyd yr arian o’r gwerthiant eiddo a bod y perchennog newydd yn cael yr allweddi. Er enghraifft, 25 4 2020.
 completionDate.personalRep.helpText=Mae hyn fel arfer pan drosglwyddwyd yr arian o’r gwerthiant eiddo a bod y perchennog newydd yn cael yr allweddi. Er enghraifft, 25 4 2020.
 completionDate.personalRepInPeriodOfAdmin.helpText=Mae hyn fel arfer pan drosglwyddwyd yr arian o’r gwerthiant eiddo a bod y perchennog newydd yn cael yr allweddi. Er enghraifft, 25 4 2020.
-completionDate.link=<a class="govuk-link" href="{0}" target="_blank">Dysgwch beth sy’n digwydd ar y dyddiad cwblhau (yn agor ffenestr newydd)</a>
+completionDate.link=<a class="govuk-link" href="{0}" target="_blank">Dysgwch beth sy’n digwydd ar y dyddiad cwblhau (yn agor tab newydd)</a>
 completionDate.error.required=Nodwch ddyddiad cwblhau
 completionDate.error.invalid=Nodwch ddyddiad cwblhau go iawn
 completionDate.error.tooFarInPast=Mae’n rhaid i’r dyddiad cwblhau fod ar neu ar ôl dyddiad cyfnewid y contract, {0}
@@ -980,7 +980,7 @@ disposalDateTooEarly.non-uk.h2=Yr hyn y bydd angen i chi ei wneud nesaf
 disposalDateTooEarly.non-uk.p3=Bydd angen i chi lenwi <a class="govuk-link" href="{0}">dibreswyl: ffurflen rhoi gwybod am a thalu Treth Enillion Cyfalaf ar eiddo neu dir yn y DU</a>.
 disposalDateTooEarly.uk.title=Ni allwch ddefnyddio’r gwasanaeth hwn
 disposalDateTooEarly.uk.p1=Mae hyn oherwydd pan gafodd yr eiddo ei werthu neu ei waredu, cyfnewidiwyd contractau cyn 6 Ebrill 2020.
-disposalDateTooEarly.uk.p2=Dysgwch sut i roi gwybod am a thalu Treth Enillion Cyfalaf ar <a href="{0}">werthiannau neu warediadau eiddo yn y DU cyn 6 Ebrill 2020</a>.
+disposalDateTooEarly.uk.p2=Dysgwch sut i roi gwybod am a thalu Treth Enillion Cyfalaf ar <a class="govuk-link" href="{0}">werthiannau neu warediadau eiddo yn y DU cyn 6 Ebrill 2020</a>.
 triage.check-your-answers.title=Gwirio’ch atebion
 triage.cyaChange.countryOfResidence=eich gwlad breswyl ar y diwrnod y gwnaethoch ‘gyfnewid’ contractau
 triage.cyaChange.assetTypeForNonUkResidents=y math o eiddo neu ased y gwnaethoch ei werthu
@@ -1010,14 +1010,14 @@ multiple-disposals.guidance.p3=Mae’n rhaid i chi anfon Ffurflenni Treth ar wah
 multiple-disposals.guidance.details.summary=Beth sy’n digwydd ar ddyddiadau ‘cyfnewid’ a ‘chwblhau’?
 multiple-disposals.guidance.details.p1=Fel arfer, y dyddiad ‘cwblhau’ yw’r diwrnod y bydd y perchennog newydd yn cael allwedd i’r eiddo.
 multiple-disposals.guidance.details.p2=Fel arfer, mae ‘cyfnewid’ contract yn digwydd pan fydd y prynwr a’r gwerthwr yn cyfnewid contractau. Mae hyn fel arfer pan fydd y perchennog newydd yn talu blaendal.
-multiple-disposals.guidance.details.link=<a href="{0}" target="_blank">Darllenwch am ‘gyfnewid a ‘chwblhau’ (yn agor ffenestr newydd)</a>.
+multiple-disposals.guidance.details.link=<a href="{0}" target="_blank">Darllenwch am ‘gyfnewid a ‘chwblhau’ (yn agor tab newydd)</a>.
 multipleDisposalsNumberOfProperties.title=Faint o warediadau ydych yn eu cynnwys yn y Ffurflen Dreth hon?
 multipleDisposalsNumberOfProperties.p1=Mae’n rhaid i’r holl warediadau eiddo fod â’r un dyddiad ‘cwblhau’. Mae’n rhaid i’r holl ddyddiadau ‘cyfnewid’ contract fod yn yr un flwyddyn dreth.
 multipleDisposalsNumberOfProperties.p2=Os ydych yn rhoi gwybod am werthiant cyfranddaliadau, nodwch nifer y cwmnïau yr oedd y cyfranddaliadau’n cael eu cadw ynddynt. Mae’n rhaid i’r holl gyfranddaliadau fod wedi’u gwerthu ar yr un dyddiad.
 multipleDisposalsNumberOfProperties.details.summary=Beth sy’n digwydd ar ddyddiadau ‘cyfnewid’ a ‘chwblhau’?
 multipleDisposalsNumberOfProperties.details.p1=Fel arfer, y dyddiad ‘cwblhau’ yw’r diwrnod y mae’r perchennog newydd yn cael yr allwedd i’r eiddo,
 multipleDisposalsNumberOfProperties.details.p2=Fel arfer, mae ‘cyfnewid’ contract yn digwydd pan fydd y prynwr a’r gwerthwr yn cyfnewid contractau. Mae hyn fel arfer pan fydd y perchennog newydd yn talu blaendal.
-multipleDisposalsNumberOfProperties.details.link=<a href="{0}" target="_blank">Darllenwch am ‘gyfnewid a ‘chwblhau’ (yn agor ffenestr newydd)</a>.
+multipleDisposalsNumberOfProperties.details.link=<a href="{0}" target="_blank">Darllenwch am ‘gyfnewid a ‘chwblhau’ (yn agor tab newydd)</a>.
 multipleDisposalsNumberOfProperties.error.invalid=Mae’n rhaid i nifer y gwarediadau fod yn rhif
 multipleDisposalsNumberOfProperties.error.required=Nodwch nifer y gwarediadau rydych yn eu cynnwys yn y Ffurflen Dreth hon
 multipleDisposalsNumberOfProperties.error.tooSmall=Mae’n rhaid i nifer y gwarediadau fod yn 2 neu fwy
@@ -1030,12 +1030,12 @@ multipleDisposalsWereYouAUKResident.capacitor.title=A oedd y person yn breswylyd
 multipleDisposalsWereYouAUKResident.personalRep.title=A oedd y person yn breswylydd yn y DU ar yr holl ddyddiadau ‘cyfnewid’ contractau?
 multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.title=A oedd y person yn breswylydd yn y DU am y flwyddyn dreth y bu farw ynddi?
 multipleDisposalsWereYouAUKResident.helpText=Mae ‘cyfnewid’ contractau fel arfer yn digwydd pan fydd prynwr a gwerthwr yn rhoi contract i’w gilydd ac mae’r prynwr yn talu blaendal.
-multipleDisposalsWereYouAUKResident.link=<a href="{0}" target="_blank">Gweithiwch allan eich statws preswylio am flwyddyn dreth (yn agor ffenestr newydd)</a>
-multipleDisposalsWereYouAUKResident.agent.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’ch cleient (yn agor ffenestr newydd)</a>
-multipleDisposalsWereYouAUKResident.trust.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r ymddiriedolaeth (yn agor ffenestr newydd)</a>
-multipleDisposalsWereYouAUKResident.capacitor.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person (yn agor ffenestr newydd)</a>
-multipleDisposalsWereYouAUKResident.personalRep.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person (yn agor ffenestr newydd)</a>
-multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person am flwyddyn dreth (yn agor ffenestr newydd)</a>.
+multipleDisposalsWereYouAUKResident.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan eich statws preswylio am flwyddyn dreth (yn agor tab newydd)</a>
+multipleDisposalsWereYouAUKResident.agent.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’ch cleient (yn agor tab newydd)</a>
+multipleDisposalsWereYouAUKResident.trust.link=<a class="govuk-link" class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r ymddiriedolaeth (yn agor tab newydd)</a>
+multipleDisposalsWereYouAUKResident.capacitor.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person (yn agor tab newydd)</a>
+multipleDisposalsWereYouAUKResident.personalRep.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person (yn agor tab newydd)</a>
+multipleDisposalsWereYouAUKResident.personalRepInPeriodOfAdmin.link=<a class="govuk-link" href="{0}" target="_blank">Gweithiwch allan statws preswylio’r person am flwyddyn dreth (yn agor tab newydd)</a>.
 multipleDisposalsWereYouAUKResident.error.required=Dewiswch ‘Iawn’ os oeddech yn breswylydd yn y DU ar yr holl ddyddiadau ‘cyfnewid’ contractau
 multipleDisposalsWereYouAUKResident.error.boolean=Dewiswch ‘Iawn’ os oeddech yn breswylydd yn y DU ar yr holl ddyddiadau ‘cyfnewid’ contractau
 multipleDisposalsWereYouAUKResident.agent.error.required=Dewiswch ‘Iawn’ os oedd eich cleient yn breswylydd yn y DU ar yr holl ddyddiadau cyfnewid contractau
@@ -1083,7 +1083,7 @@ multipleDisposalsTaxYear.taxyear.2020= Y cyfan rhwng 6 Ebrill 2020 a 5 Ebrill 20
 multipleDisposalsTaxYear.taxyear.before2020=Y cyfan cyn 6 Ebrill 2020
 multipleDisposalsTaxYear.taxyear.different=Cyfnewidiwyd yr eiddo mewn gwahanol flynyddoedd treth
 
-multipleDisposalsTaxYear.details.p1=Fel arfer, mae cyfnewid <a href="{0}" target="_blank">contractau (yn agor ffenestr newydd)</a> yn digwydd pan fydd y prynwr a’r gwerthwr yn cyfnewid contractau. Mae hyn fel arfer pan fydd y perchennog newydd yn talu blaendal.
+multipleDisposalsTaxYear.details.p1=Fel arfer, mae cyfnewid <a href="{0}" target="_blank">contractau (yn agor tab newydd)</a> yn digwydd pan fydd y prynwr a’r gwerthwr yn cyfnewid contractau. Mae hyn fel arfer pan fydd y perchennog newydd yn talu blaendal.
 multipleDisposalsTaxYear.error.required=Dewiswch bryd y cyfnewidiwyd y contractau ar yr holl eiddo
 multipleDisposalsTaxYear.error.before.invalid=Mae’n rhaid i’r dyddiadau cyfnewid fod naill ai yn ystod yr un flwyddyn dreth â dyddiad y farwolaeth neu mewn blwyddyn dreth flaenorol
 multipleDisposalsTaxYear.error.after.invalid=Mae’n rhaid i’r dyddiadau cyfnewid fod naill ai yn ystod yr un flwyddyn dreth â dyddiad y farwolaeth neu mewn blwyddyn dreth ddiweddarach
@@ -1093,7 +1093,7 @@ multipleDisposalsExchangedInDifferentTaxYears.title=Ni allwch ddefnyddio’r gwa
 multipleDisposalsExchangedInDifferentTaxYears.p1=Mae hyn oherwydd mai dim ond ar gyfer eiddo a gyfnewidiwyd mewn un flwyddyn dreth y gallwch chi gyflwyno Ffurflen Dreth.
 multipleDisposalsExchangedInDifferentTaxYears.p2=Er enghraifft, os gwnaethoch gyfnewid un eiddo yn y flwyddyn dreth 2020 i 2021 ac un arall yn y flwyddyn dreth 2021 i 2022, ni allwch eu cyflwyno yn yr un Ffurflen Dreth.
 multipleDisposalsExchangedInDifferentTaxYears.whatNext=Beth fydd angen i chi ei wneud nesaf
-multipleDisposalsExchangedInDifferentTaxYears.p3=<a href="{0}">Dechreuwch eto</a> a chyflwynwch Ffurflen Dreth ar wahân ar gyfer pob blwyddyn dreth.
+multipleDisposalsExchangedInDifferentTaxYears.p3=<a class="govuk-link" href="{0}">Dechreuwch eto</a> a chyflwynwch Ffurflen Dreth ar wahân ar gyfer pob blwyddyn dreth.
 
 multipleDisposalsAssetTypeForNonUkResidents.title=Pa fathau o eiddo neu asedion a waredwyd gennych?
 multipleDisposalsAssetTypeForNonUkResidents.agent.title=Pa fathau o eiddo neu asedion a waredwyd gan eich cleient?
@@ -1136,7 +1136,7 @@ multipleDisposalsAssetTypeForNonUkResidents.cyaChange=y mathau o eiddo neu asedi
 multipleDisposalsCompletionDate.title=Beth oedd y dyddiad ‘cwblhau’ ar gyfer yr holl eiddo?
 multipleDisposalsCompletionDate.helpText=Er enghraifft 25, 4, 2020.
 multipleDisposalsCompletionDate.details.summary=Beth sy’n digwydd ar y dyddiad ‘cwblhau’?
-multipleDisposalsCompletionDate.details.p1=Fel arfer, <a href="{0}" target=_blank>y dyddiad ‘cwblhau’ (yn agor ffenestr newydd)</a> yw’r diwrnod y mae’r perchennog newydd yn cael yr allweddi i’r eiddo.
+multipleDisposalsCompletionDate.details.p1=Fel arfer, <a class="govuk-link" href="{0}" target="_blank">y dyddiad ‘cwblhau’ (yn agor tab newydd)</a> yw’r diwrnod y mae’r perchennog newydd yn cael yr allweddi i’r eiddo.
 multipleDisposalsCompletionDate.error.required=Nodwch ddyddiad cwblhau
 multipleDisposalsCompletionDate.error.invalid=Nodwch ddyddiad cwblhau go iawn
 multipleDisposalsCompletionDate.error.tooFarInFuture=Mae’n rhaid i’r dyddiad cwblhau fod heddiw neu yn y gorffennol
@@ -2176,7 +2176,7 @@ acquisitionFees.agent.indirect.rebased.helpText=Er enghraifft, cost talu brocer 
 acquisitionFees.trust.indirect.rebased.helpText=Er enghraifft, cost talu brocer stoc i ddweud wrthych beth oedd gwerth y cyfranddaliadau ar {0}
 acquisitionFees.capacitor.indirect.rebased.helpText=Er enghraifft, cost talu brocer stoc i ddweud wrthych beth oedd gwerth y cyfranddaliadau ar {0}
 acquisitionFees.personalRep.indirect.rebased.helpText=Er enghraifft, cost talu brocer stoc i ddweud wrthych beth oedd gwerth y cyfranddaliadau ar {0}
-acquisitionFees.allowableCostsLinkText=<a href="{0}" target="_blank">Dysgwch am gostau caniataol ychwanegol (yn agor ffenestr newydd)</a>.
+acquisitionFees.allowableCostsLinkText=<a href="{0}" target="_blank">Dysgwch am gostau caniataol ychwanegol (yn agor tab newydd)</a>.
 acquisitionFees.details.header=Beth yw ail-sylfaenu?
 acquisitionFees.details.p1=Roeddech yn berchen ar yr eiddo ar neu cyn {0}.
 acquisitionFees.agent.details.p1=Roedd eich cleient yn berchen ar yr eiddo ar neu cyn {0}.
@@ -2197,7 +2197,7 @@ acquisitionFees.indirect.details.p2=Mae hyn yn golygu, wrth i chi gyfrifo’ch T
 acquisitionFees.indirect.agent.p2=I gyfrifo Treth Enillion Cyfalaf eich cleient, mae’n rhaid i chi ddefnyddio gwerth marchnadol y cyfranddaliadau ar y dyddiad hwnnw. Mae hyn yn hytrach na defnyddio’r swm prynu neu’r swm caffael gwirioneddol.
 acquisitionFees.indirect.trust.details.p2=I gyfrifo Treth Enillion Cyfalaf yr ymddiriedolaeth, mae’n rhaid i chi ddefnyddio gwerth marchnadol y cyfranddaliadau ar y dyddiad hwnnw. Mae hyn yn hytrach na defnyddio’r swm prynu neu’r swm caffael gwirioneddol.
 acquisitionFees.details.p3=Yr enw ar y broses hon yw ail-sylfaenu.
-acquisitionFees.non-resident.details.p3=Yr enw ar y broses hon yw <a href="{0}" target="_blank">ail-sylfaenu (yn agor ffenestr newydd)</a>.
+acquisitionFees.non-resident.details.p3=Yr enw ar y broses hon yw <a href="{0}" target="_blank">ail-sylfaenu (yn agor tab newydd)</a>.
 acquisitionFees.cyaChange=os oedd unrhyw gostau caffael ychwanegol
 acquisitionFees.rebased.cyaChange=os oedd unrhyw gostau ail-sylfaenu ychwanegol
 acquisitionFees.error.required=Dewiswch ‘Iawn’ os oes costau ychwanegol
@@ -2262,7 +2262,7 @@ rebaseAcquisitionPrice.capacitor.dropdown.p2=I gyfrifo enillion neu golledion y 
 rebaseAcquisitionPrice.personalRep.dropdown.p2=I gyfrifo enillion neu golledion y person, mae’n rhaid i chi ddefnyddio gwerth marchnadol yr eiddo ar y dyddiad hwnnw. Mae hyn yn hytrach na defnyddio’r swm prynu neu’r swm caffael gwirioneddol.
 rebaseAcquisitionPrice.indirect.dropdown.p2=<a href="{0}" target="_blank">Dysgwch am ail-sylfaenu (yn agor ffenestr neu dab newydd)</a>
 rebaseAcquisitionPrice.dropdown.p3=Yr enw ar y broses hon yw ail-sylfaenu.
-rebaseAcquisitionPrice.dropdown.p4=<a href="{0}" target="_blank">Dysgwch sut i ofyn i CThEM wirio gwerth marchnadol eiddo (yn agor ffenestr newydd)</a>.
+rebaseAcquisitionPrice.dropdown.p4=<a href="{0}" target="_blank">Dysgwch sut i ofyn i CThEM wirio gwerth marchnadol eiddo (yn agor tab newydd)</a>.
 rebaseAcquisitionPrice.dropdown.p5=Mae’n cymryd o leiaf 3 mis i CThEM wirio gwerth marchnadol eiddo. Mae hyn yn golygu y dylech nodi amcangyfrif nawr ac, os bydd angen i chi newid y swm, gwnewch hynny’n nes ymlaen gan ddefnyddio’r gwasanaeth hwn. Neu os ydych eisoes wedi llenwi Ffurflen Dreth Hunanasesiad, gallwch roi’r gwerth marchnadol cywir yn eich Ffurflen Dreth Hunanasesiad nesaf.
 rebaseAcquisitionPrice.agent.dropdown.p5=Gall gymryd 3 mis neu fwy i CThEM wirio gwerth marchnadol eiddo. Mae hyn yn golygu y gellir nodi amcangyfrif er mwyn i’ch cleient allu rhoi gwybod am y dreth. Gellir cadarnhau’r amcangyfrif yn nes ymlaen drwy’r gwasanaeth hwn, neu drwy Ffurflen Dreth Hunanasesiad.
 rebaseAcquisitionPrice.trust.dropdown.p5=Gall gymryd 3 mis neu fwy i CThEM wirio gwerth marchnadol eiddo. Mae hyn yn golygu y gellir nodi amcangyfrif er mwyn i’r ymddiriedolaeth allu rhoi gwybod am y dreth. Gellir cadarnhau’r amcangyfrif yn nes ymlaen drwy’r gwasanaeth hwn, neu drwy Ffurflen Dreth Hunanasesiad.
@@ -2408,7 +2408,7 @@ privateResidentsRelief.details.body.p2=Os nad oeddech yn byw yn yr eiddo drwy gy
 privateResidentsRelief.details.body.li1=y blynyddoedd yr oeddech yn byw yno
 privateResidentsRelief.details.body.li2=y <strong class="bold">naw mis</strong> olaf yr oeddech yn berchen arno – hyd yn oed os nad oeddech yn byw yno ar y pryd
 privateResidentsRelief.details.body.p3=Mae rhai eithriadau’n gymwys.
-privateResidentsRelief.details.body.link=Dysgwch am Ryddhad Preswylfa Breifat (yn agor ffenestr newydd)
+privateResidentsRelief.details.body.link=Dysgwch am Ryddhad Preswylfa Breifat (yn agor tab newydd)
 
 privateResidentsReliefValue.label=Swm y Rhyddhad Preswylfan Preifat y mae gennych hawl iddo
 privateResidentsReliefValue.agent.label=Swm y Rhyddhad Preswylfan Preifat y mae gan eich cleient hawl iddo
@@ -2417,7 +2417,7 @@ privateResidentsReliefValue.capacitor.label=Swm y Rhyddhad Preswylfan Preifat y 
 privateResidentsReliefValue.personalRep.label=Swm y Rhyddhad Preswylfan Preifat yr oedd gan y person hawl iddo
 privateResidentsReliefValue.personalRepInPeriodOfAdmin.agent.label=Swm y Rhyddhad Preswylfan Preifat sy’n cael ei hawlio
 privateResidentsReliefValue.personalRepInPeriodOfAdmin.label=Swm y Rhyddhad Preswylfan Preifat sy’n cael ei hawlio
-privateResidentsRelief.furtherInfoLink=Dysgwch ragor am Ryddhad Preswylfan Preifat (yn agor ffenestr newydd)
+privateResidentsRelief.furtherInfoLink=Dysgwch ragor am Ryddhad Preswylfan Preifat (yn agor tab newydd)
 privateResidentsRelief.error.required=Dewiswch ‘Iawn’ os oes gennych hawl i Ryddhad Preswylfan Preifat
 privateResidentsRelief.agent.error.required=Dewiswch ‘Iawn’ os oes gan eich cleient hawl i Ryddhad Preswylfan Preifat
 privateResidentsRelief.trust.error.required=Dewiswch ‘Iawn’ os oes gan yr ymddiriedolaeth hawl i Ryddhad Preswylfan Preifat
@@ -2480,14 +2480,14 @@ lettingsRelief.details.body.p1=Os oeddech yn byw yn eich cartref <strong class="
 lettingsRelief.details.body.li1=yr un swm a gawsoch mewn Rhyddhad Preswylfa Breifat
 lettingsRelief.details.body.li2=£40,000
 lettingsRelief.details.body.li3=yr un swm â’r enillion trethadwy a wnaethoch wrth roi rhan o’ch cartref ar osod
-lettingsRelief.details.body.link=Dysgwch am Ryddhad Gosod (yn agor ffenestr newydd)
+lettingsRelief.details.body.link=Dysgwch am Ryddhad Gosod (yn agor tab newydd)
 
 lettingsRelief.error.required=Dewiswch ‘Iawn’ os ydych yn hawlio Rhyddhad Gosod
 lettingsRelief.agent.error.required=Dewiswch ‘Iawn’ os oes gan eich cleient hawl i Ryddhad Gosod
 lettingsRelief.trust.error.required=Dewiswch ‘Iawn’ os oes gan yr ymddiriedolaeth hawl i Ryddhad Gosod
 lettingsRelief.capacitor.error.required=Dewiswch ‘Iawn’ os oes gan y person hawl i Ryddhad Gosod
 lettingsRelief.personalRep.error.required=Dewiswch ‘Iawn’ os oedd gan y person hawl i Ryddhad Gosod
-lettingsRelief.furtherInfoLink=Dysgwch ragor am Ryddhad Gosod a sut i’w gyfrifo (yn agor ffenestr newydd)
+lettingsRelief.furtherInfoLink=Dysgwch ragor am Ryddhad Gosod a sut i’w gyfrifo (yn agor tab newydd)
 lettingsReliefValue.label=Swm y Rhyddhad Gosod
 lettingsReliefValue.error.required=Nodwch swm y Rhyddhad Gosod, fel 108 neu 2,940.54
 lettingsReliefValue.error.tooSmall=Mae’n rhaid i swm y Rhyddhad Gosod fod yn swm o arian rhwng 0 a 50,000,000,000
@@ -2519,13 +2519,13 @@ otherReliefs.capacitor.helpText2=Peidiwch â nodi colledion na’r Swm Blynyddol
 otherReliefs.personalRep.helpText2=Peidiwch â nodi colledion na’r Swm Blynyddol sydd wedi ei Eithrio rhag Treth, a elwir yn lwfans personol sy’n rhydd o dreth ar gyfer Treth Enillion Cyfalaf, yma.
 otherReliefs.personalRepInPeriodOfAdmin.agent.helpText2=Peidiwch â nodi colledion na’r Swm Blynyddol sydd wedi ei Eithrio rhag Treth, a elwir yn lwfans personol sy’n rhydd o dreth ar gyfer Treth Enillion Cyfalaf, yma.
 otherReliefs.personalRepInPeriodOfAdmin.helpText2=Peidiwch â nodi colledion na’r Swm Blynyddol sydd wedi ei Eithrio rhag Treth, a elwir yn lwfans personol sy’n rhydd o dreth ar gyfer Treth Enillion Cyfalaf, yma.
-otherReliefs.furtherInfoLink=Dysgwch ragor am ryddhad y gallwch fod yn gymwys i’w gael (yn agor ffenestr newydd)
-otherReliefs.agent.furtherInfoLink=Dysgwch ragor am ryddhad y gall eich cleient fod yn gymwys i’w gael (yn agor ffenestr newydd)
-otherReliefs.trust.furtherInfoLink=Dysgwch ragor am ryddhad y gall yr ymddiriedolaeth fod yn gymwys i’w gael (yn agor ffenestr newydd)
-otherReliefs.capacitor.furtherInfoLink=Dysgwch ragor am ryddhad y gall y person fod yn gymwys i’w gael (yn agor ffenestr newydd)
-otherReliefs.personalRep.furtherInfoLink=Dysgwch ragor am ryddhad y gallai’r person wedi bod yn gymwys i’w gael (yn agor ffenestr newydd)
-otherReliefs.personalRepInPeriodOfAdmin.agent.furtherInfoLink=Dysgwch ragor am ryddhad y gallai’r person wedi bod yn gymwys i’w gael (yn agor ffenestr newydd)
-otherReliefs.personalRepInPeriodOfAdmin.furtherInfoLink=Dysgwch ragor am ryddhad y gallai’r person wedi bod yn gymwys i’w gael (yn agor ffenestr newydd)
+otherReliefs.furtherInfoLink=Dysgwch ragor am ryddhad y gallwch fod yn gymwys i’w gael (yn agor tab newydd)
+otherReliefs.agent.furtherInfoLink=Dysgwch ragor am ryddhad y gall eich cleient fod yn gymwys i’w gael (yn agor tab newydd)
+otherReliefs.trust.furtherInfoLink=Dysgwch ragor am ryddhad y gall yr ymddiriedolaeth fod yn gymwys i’w gael (yn agor tab newydd)
+otherReliefs.capacitor.furtherInfoLink=Dysgwch ragor am ryddhad y gall y person fod yn gymwys i’w gael (yn agor tab newydd)
+otherReliefs.personalRep.furtherInfoLink=Dysgwch ragor am ryddhad y gallai’r person wedi bod yn gymwys i’w gael (yn agor tab newydd)
+otherReliefs.personalRepInPeriodOfAdmin.agent.furtherInfoLink=Dysgwch ragor am ryddhad y gallai’r person wedi bod yn gymwys i’w gael (yn agor tab newydd)
+otherReliefs.personalRepInPeriodOfAdmin.furtherInfoLink=Dysgwch ragor am ryddhad y gallai’r person wedi bod yn gymwys i’w gael (yn agor tab newydd)
 otherReliefs.error.required=Dewiswch ‘Iawn’ os ydych yn hawlio rhyddhad arall
 otherReliefs.agent.error.required=Dewiswch ‘Iawn’ os yw’ch cleient yn hawlio rhyddhad arall
 otherReliefs.trust.error.required=Dewiswch ‘Iawn’ os yw’r ymddiriedolaeth yn hawlio rhyddhad arall
@@ -2647,13 +2647,13 @@ inYearLosses.agent.error.required=Dewiswch ‘Iawn’ os ydych am gynnwys unrhyw
 inYearLosses.trust.error.required=Dewiswch ‘Iawn’ os ydych am gynnwys unrhyw golledion Treth Enillion Cyfalaf eraill a wnaeth yr ymddiriedolaeth yn y flwyddyn dreth
 inYearLosses.agent.error.invalid=Dewiswch ‘Iawn’ os ydych am gynnwys unrhyw golledion Treth Enillion Cyfalaf eraill a wnaeth eich cleient yn y flwyddyn dreth
 inYearLosses.trust.error.invalid=Dewiswch ‘Iawn’ os ydych am gynnwys unrhyw golledion Treth Enillion Cyfalaf eraill a wnaeth yr ymddiriedolaeth yn y flwyddyn dreth
-inYearLosses.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor ffenestr newydd)</a>.
-inYearLosses.agent.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor ffenestr newydd)</a>.
-inYearLosses.trust.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor ffenestr newydd)</a>.
-inYearLosses.capacitor.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor ffenestr newydd)</a>.
-inYearLosses.personalRep.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor ffenestr newydd)</a>.
-inYearLosses.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor ffenestr newydd)</a>.
-inYearLosses.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor ffenestr newydd)</a>.
+inYearLosses.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor tab newydd)</a>.
+inYearLosses.agent.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor tab newydd)</a>.
+inYearLosses.trust.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor tab newydd)</a>.
+inYearLosses.capacitor.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor tab newydd)</a>.
+inYearLosses.personalRep.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor tab newydd)</a>.
+inYearLosses.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor tab newydd)</a>.
+inYearLosses.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Dysgwch sut mae colledion yn gallu gostwng enillion (yn agor tab newydd)</a>.
 inYearLossesValue.error.invalid=Mae’n rhaid i swm y colledion Treth Enillion Cyfalaf fod yn rhif, megis 108 neu 2,940.54
 inYearLossesValue.agent.error.invalid=Mae’n rhaid i swm y colledion Treth Enillion Cyfalaf fod yn rhif, megis 108 neu 2,940.54
 inYearLossesValue.trust.error.invalid=Mae’n rhaid i swm y colledion Treth Enillion Cyfalaf fod yn rhif, megis 108 neu 2,940.54
@@ -2761,13 +2761,13 @@ previousYearsLosses.capacitor.error.required=Dewiswch ‘Iawn’ os yw’r perso
 previousYearsLosses.personalRep.error.required=Dewiswch ‘Iawn’ os ydych am gynnwys unrhyw golledion Treth Enillion Cyfalaf a wnaeth y person mewn blynyddoedd treth blaenorol
 previousYearsLosses.personalRepInPeriodOfAdmin.error.required=Dewiswch ‘Iawn’ os ydych yn cynnwys unrhyw golledion Treth Enillion Cyfalaf eraill a wnaeth yr ystâd mewn blynyddoedd treth blaenorol
 previousYearsLosses.personalRepInPeriodOfAdmin.agent.error.required=Dewiswch ‘Iawn’ os yw’ch cleient yn cynnwys unrhyw golledion Treth Enillion Cyfalaf eraill a wnaeth yr ystâd mewn blynyddoedd treth blaenorol
-previousYearsLosses.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor ffenestr newydd)</a>.
-previousYearsLosses.agent.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor ffenestr newydd)</a>.
-previousYearsLosses.trust.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor ffenestr newydd)</a>.
-previousYearsLosses.capacitor.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor ffenestr newydd)</a>.
-previousYearsLosses.personalRep.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor ffenestr newydd)</a>.
-previousYearsLosses.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor ffenestr newydd)</a>.
-previousYearsLosses.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor ffenestr newydd)</a>.
+previousYearsLosses.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor tab newydd)</a>.
+previousYearsLosses.agent.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor tab newydd)</a>.
+previousYearsLosses.trust.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor tab newydd)</a>.
+previousYearsLosses.capacitor.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor tab newydd)</a>.
+previousYearsLosses.personalRep.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor tab newydd)</a>.
+previousYearsLosses.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor tab newydd)</a>.
+previousYearsLosses.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor tab newydd)</a>.
 previousYearsLossesValue.label=Swm y colledion o flynyddoedd treth blaenorol
 previousYearsLossesValue.agent.label=Swm y colledion o flynyddoedd treth blaenorol
 previousYearsLossesValue.trust.label=Swm y colledion o flynyddoedd treth blaenorol
@@ -2833,7 +2833,7 @@ previousYearsLosses.furtherReturn.capacitor.helpText=Gallwch gynnwys colledion b
 previousYearsLosses.furtherReturn.personalRep.helpText=Gallwch gynnwys colledion blaenorol yn y Ffurflen Dreth hon y mae’r person eisoes wedi rhoi gwybod i CThEM amdanynt ac nad yw eisoes wedi’u defnyddio. Er enghraifft, colledion ar gyfranddaliadau neu eiddo arall yn y DU.
 previousYearsLosses.furtherReturn.personalRepInPeriodOfAdmin.helpText=Gallwch gynnwys colledion blaenorol yn y Ffurflen Dreth hon y mae’r ystâd eisoes wedi rhoi gwybod i CThEM amdanynt ac nad yw eisoes wedi’u defnyddio. Er enghraifft, colledion ar gyfranddaliadau neu eiddo arall yn y DU.
 previousYearsLosses.furtherReturn.personalRepInPeriodOfAdmin.agent.helpText=Gallwch gynnwys colledion blaenorol yn y Ffurflen Dreth hon y mae’r ystâd eisoes wedi rhoi gwybod i CThEM amdanynt ac nad yw eisoes wedi’u defnyddio. Er enghraifft, colledion ar gyfranddaliadau neu eiddo arall yn y DU.
-previousYearsLosses.furtherReturn.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor ffenestr newydd)</a>.
+previousYearsLosses.furtherReturn.link=<a href="{0}" target="_blank">Dysgwch sut i roi gwybod am golledion (yn agor tab newydd)</a>.
 annualExemptAmount.title=Faint o’ch Swm Blynyddol sydd wedi ei Eithrio rhag Treth Enillion Cyfalaf rydych am ei ddefnyddio?
 annualExemptAmount.agent.title=Faint o Swm Blynyddol eich cleient, sydd wedi ei Eithrio rhag Treth Enillion Cyfalaf, y mae am ei ddefnyddio?
 annualExemptAmount.trust.title=Faint o Swm Blynyddol yr ymddiriedolaeth, sydd wedi ei Eithrio rhag Treth Enillion Cyfalaf, y mae am ei ddefnyddio?
@@ -2849,14 +2849,14 @@ annualExemptAmount.personalRep.helpText=Ym mlwyddyn dreth {0} i {1}, dim ond ar 
 annualExemptAmount.personalRepInPeriodOfAdmin.helpText=Yn ystod y cyfnod gweinyddu, gall yr holl Swm Blynyddol sydd wedi ei Eithrio rhag Treth gael ei gynnwys yn Ffurflen Dreth yr ystâd. Dyma’r achos hyd yn oed os oedd y cyfnod rhwng 6 Ebrill a’r diwrnod y bu farw’r person yn fyr iawn.
 annualExemptAmount.personalRepInPeriodOfAdmin.agent.helpText=Yn ystod y cyfnod gweinyddu, gall yr holl Swm Blynyddol sydd wedi ei Eithrio rhag Treth gael ei gynnwys yn Ffurflen Dreth yr ystâd. Dyma’r achos hyd yn oed os oedd y cyfnod rhwng 6 Ebrill a’r diwrnod y bu farw’r person yn fyr iawn.
 annualExemptAmount.details.1.header=Beth yw’r Swm Blynyddol sydd wedi ei Eithrio rhag Treth?
-annualExemptAmount.details.1.body=Bob blwyddyn dreth, mae ymddiriedolaeth yn cael lwfans rhydd o dreth blynyddol. Gelwir hyn yn <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a>. Mae ymddiriedolwyr ond yn talu Treth Enillion Cyfalaf os yw enillion trethadwy’r ymddiriedolaeth ar gyfer y flwyddyn dreth dros y Swm Blynyddol sydd wedi ei Eithrio rhag Treth.
+annualExemptAmount.details.1.body=Bob blwyddyn dreth, mae ymddiriedolaeth yn cael lwfans rhydd o dreth blynyddol. Gelwir hyn yn <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a>. Mae ymddiriedolwyr ond yn talu Treth Enillion Cyfalaf os yw enillion trethadwy’r ymddiriedolaeth ar gyfer y flwyddyn dreth dros y Swm Blynyddol sydd wedi ei Eithrio rhag Treth.
 annualExemptAmount.details.2.header=Pwy yw buddiolwyr sy’n agored i niwed?
-annualExemptAmount.details.2.body=<a href="{0}" target="_blank">Gallai buddiolwr sy’n agored i niwed (yn agor ffenestr newydd)</a> fod yn rhywun o dan 18 oed y mae ei rieni wedi marw. Gallai hefyd fod yn berson ag anabledd sy’n gymwys ar gyfer budd-daliadau penodol.
+annualExemptAmount.details.2.body=<a href="{0}" target="_blank">Gallai buddiolwr sy’n agored i niwed (yn agor tab newydd)</a> fod yn rhywun o dan 18 oed y mae ei rieni wedi marw. Gallai hefyd fod yn berson ag anabledd sy’n gymwys ar gyfer budd-daliadau penodol.
 annualExemptAmount.details.3.header=Beth yw’r Swm Blynyddol sydd wedi ei Eithrio rhag Treth?
-annualExemptAmount.details.3.body=Mae’r <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a> yn lwfans rhydd o dreth blynyddol. Mae ar gael i rai pobl sydd angen talu Treth Enillion Cyfalaf. Dim ond ar eu henillion ar gyfer y flwyddyn dreth sydd dros y Swm Blynyddol sydd wedi ei Eithrio rhag Treth y mae’n rhaid i’r rhan fwyaf o bobl dalu Treth Enillion Cyfalaf. Mae’n rhaid i unrhyw golledion neu ryddhad fod wedi’u tynnu oddi ar yr enillion eisoes.
-annualExemptAmount.link=<a href="{0}" target="_blank">Dysgwch am y Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a>.
-annualExemptAmount.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Dysgwch am y Swm Blynyddol sydd wedi ei Eithrio rhag Treth yn ystod y cyfnod gweinyddu (yn agor ffenestr newydd)</a>.
-annualExemptAmount.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Dysgwch am y Swm Blynyddol sydd wedi ei Eithrio rhag Treth yn ystod y cyfnod gweinyddu (yn agor ffenestr newydd)</a>.
+annualExemptAmount.details.3.body=Mae’r <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a> yn lwfans rhydd o dreth blynyddol. Mae ar gael i rai pobl sydd angen talu Treth Enillion Cyfalaf. Dim ond ar eu henillion ar gyfer y flwyddyn dreth sydd dros y Swm Blynyddol sydd wedi ei Eithrio rhag Treth y mae’n rhaid i’r rhan fwyaf o bobl dalu Treth Enillion Cyfalaf. Mae’n rhaid i unrhyw golledion neu ryddhad fod wedi’u tynnu oddi ar yr enillion eisoes.
+annualExemptAmount.link=<a href="{0}" target="_blank">Dysgwch am y Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a>.
+annualExemptAmount.personalRepInPeriodOfAdmin.link=<a href="{0}" target="_blank">Dysgwch am y Swm Blynyddol sydd wedi ei Eithrio rhag Treth yn ystod y cyfnod gweinyddu (yn agor tab newydd)</a>.
+annualExemptAmount.personalRepInPeriodOfAdmin.agent.link=<a href="{0}" target="_blank">Dysgwch am y Swm Blynyddol sydd wedi ei Eithrio rhag Treth yn ystod y cyfnod gweinyddu (yn agor tab newydd)</a>.
 annualExemptAmount.error.tooLarge=Mae’n rhaid i’r Swm Blynyddol sydd wedi ei Eithrio rhag Treth fod yn {0} neu lai
 annualExemptAmount.agent.error.tooLarge=Mae’n rhaid i’r Swm Blynyddol sydd wedi ei Eithrio rhag Treth fod yn {0} neu lai
 annualExemptAmount.trust.error.tooLarge=Mae’n rhaid i’r Swm Blynyddol sydd wedi ei Eithrio rhag Treth fod yn {0} neu lai
@@ -3157,7 +3157,7 @@ personalAllowance.non-resident.helpText=Byddwn yn defnyddio’r swm hwn i gyfrif
 personalAllowance.agent.non-resident.helpText=Byddwn yn defnyddio’r swm hwn i gyfrifo cyfradd y Dreth Enillion Cyfalaf y dylai’ch cleient ei thalu. <br/><br/>Bydd angen i chi wirio’r cytundeb trethiant dwbl ar gyfer y wlad mae’ch cleient yn preswylio ynddi a’r DU. Bydd hyn yn rhoi gwybod i chi a oes ganddo hawl i Lwfans Personol.
 personalAllowance.capacitor.non-resident.helpText=Byddwn yn defnyddio’r swm hwn i gyfrifo cyfradd y Dreth Enillion Cyfalaf y dylai’r person ei thalu. <br/><br/>Bydd angen i’r person wirio’r cytundeb trethiant dwbl ar gyfer y wlad y mae’r person yn preswylio ynddi a’r DU. Bydd hyn yn rhoi gwybod i’r person a oes ganddo hawl i Lwfans Personol.
 personalAllowance.personalRep.non-resident.helpText=Byddwn yn defnyddio’r swm hwn i gyfrifo cyfradd y Dreth Enillion Cyfalaf y dylid ei thalu. <br/><br/>Bydd angen i chi wirio’r cytundeb trethiant dwbl ar gyfer y wlad yr oedd y person yn preswylio ynddi a’r DU. Bydd hyn yn rhoi gwybod i chi a oedd gan y person hawl i Lwfans Personol.
-personalAllowance.link=<a href="{0}" target="_blank">Dysgwch am Lwfansau Personol (yn agor ffenestr newydd)</a>.
+personalAllowance.link=<a href="{0}" target="_blank">Dysgwch am Lwfansau Personol (yn agor tab newydd)</a>.
 personalAllowance.error.required=Nodwch faint o’ch Lwfans Personol rydych am ei ddefnyddio
 personalAllowance.agent.error.required=Nodwch Lwfans Personol eich cleient ar gyfer y flwyddyn dreth
 personalAllowance.capacitor.error.required=Nodwch Lwfans Personol y person ar gyfer y flwyddyn dreth
@@ -3297,7 +3297,7 @@ taxDue.personalRep.helpText.p1=Os ydych yn cytuno â’r gwaith cyfrifo hwn, nod
 taxDue.helpText.p2=Os hoffech nodi swm gwahanol, gofynnir i chi uwchlwytho ffeil yn ddiweddarach sy’n dangos eich gwaith cyfrifo.
 taxDue.helpText.p3=Os yw’r ymddiriedolaeth ar gyfer buddiolwyr sy’n agored i niwed, bydd angen i chi gyfrifo a nodi swm y dreth sy’n ddyledus.
 taxDue.trustDetails.label=Cymorth i ymddiriedolaethau ar gyfer buddiolwyr sy’n agored i niwed
-taxDue.trustDetails.content=Mae ymddiriedolaethau ar gyfer buddiolwyr sy’n agored i niwed yn cael triniaeth dreth arbennig. Nid yw’r gwaith cyfrifo ar y dudalen hon yn berthnasol i’r math hwn o ymddiriedolaeth. Dysgwch sut i <a href="{0}" target="_blank">gyfrifo swm y Dreth Enillion Cyfalaf sy’n ddyledus (yn agor ffenestr newydd)</a> ar gyfer y math hwn o ymddiriedolaeth.
+taxDue.trustDetails.content=Mae ymddiriedolaethau ar gyfer buddiolwyr sy’n agored i niwed yn cael triniaeth dreth arbennig. Nid yw’r gwaith cyfrifo ar y dudalen hon yn berthnasol i’r math hwn o ymddiriedolaeth. Dysgwch sut i <a href="{0}" target="_blank">gyfrifo swm y Dreth Enillion Cyfalaf sy’n ddyledus (yn agor tab newydd)</a> ar gyfer y math hwn o ymddiriedolaeth.
 taxDue.error.required=Nodwch swm y Dreth Enillion Cyfalaf sy’n ddyledus ar gyfer y Ffurflen Dreth hon
 taxDue.error.invalid=Mae’n rhaid i swm y Dreth Enillion Cyfalaf sy’n ddyledus fod yn swm o arian, er enghraifft 493 neu 2,040.59
 taxDue.error.tooSmall=Mae’n rhaid i swm y Dreth Enillion Cyfalaf sy’n ddyledus fod yn swm o arian rhwng 0 a 50,000,000,000
@@ -3360,9 +3360,9 @@ calculator.total.amountDueAtHigherRate=Swm y dreth sy’n ddyledus ar y gyfradd 
 calculator.total.taxOwed=Treth Enillion Cyfalaf sy’n ddyledus ar gyfer y Ffurflen Dreth hon
 calculator.noTaxToPay=Does dim treth yn ddyledus ar gyfer y Ffurflen Dreth hon
 nonCalculatedTaxDue.title=Nodwch swm y Dreth Enillion Cyfalaf sy’n ddyledus ar gyfer y Ffurflen Dreth hon
-nonCalculatedTaxDue.ukResident.link=Rhagor o wybodaeth am sut i gyfrifo treth pan gaiff eiddo ei werthu (yn agor ffenestr newydd)
-nonCalculatedTaxDue.trust.link=Rhagor o wybodaeth am sut i gyfrifo Treth Enillion Cyfalaf ar gyfer ymddiriedolaeth (yn agor ffenestr newydd)
-nonCalculatedTaxDue.nonResident.link=Rhagor o wybodaeth am sut i gyfrifo treth pan gaiff eiddo ei werthu neu ar gyfer gwarediadau anuniongyrchol (yn agor ffenestr newydd)
+nonCalculatedTaxDue.ukResident.link=Rhagor o wybodaeth am sut i gyfrifo treth pan gaiff eiddo ei werthu (yn agor tab newydd)
+nonCalculatedTaxDue.trust.link=Rhagor o wybodaeth am sut i gyfrifo Treth Enillion Cyfalaf ar gyfer ymddiriedolaeth (yn agor tab newydd)
+nonCalculatedTaxDue.nonResident.link=Rhagor o wybodaeth am sut i gyfrifo treth pan gaiff eiddo ei werthu neu ar gyfer gwarediadau anuniongyrchol (yn agor tab newydd)
 nonCalculatedTaxDue.helpText=Bydd angen i chi gyfrifo’r swm a’i nodi.
 nonCalculatedTaxDue.error.required=Nodwch swm y Dreth Enillion Cyfalaf sy’n ddyledus ar gyfer y Ffurflen Dreth hon
 nonCalculatedTaxDue.error.tooSmall=Mae’n rhaid i swm y Dreth Enillion Cyfalaf sy’n ddyledus fod yn 0 neu fwy
@@ -3701,7 +3701,7 @@ confirmationOfSubmission.personalRepInPeriodOfAdmin.agent.ifSa=Os oes angen i’
 confirmationOfSubmission.trust.ifSa=Os oes angen i’r ymddiriedolaeth anfon Ffurflen Dreth Hunanasesiad
 confirmationOfSubmission.capacitor.ifSa=Hunanasesiad
 confirmationOfSubmission.personalRep.ifSa=Os oes angen i chi lenwi Ffurflen Dreth Hunanasesiad ar gyfer y person
-confirmationOfSubmission.ifSa.p1=Bydd angen i chi ddarparu manylion o’r Ffurflen Dreth hon yn eich <a href="{0}" target="_blank">Ffurflen Dreth Hunanasesiad nesaf (yn agor ffenestr newydd)</a>.
+confirmationOfSubmission.ifSa.p1=Bydd angen i chi ddarparu manylion o’r Ffurflen Dreth hon yn eich <a href="{0}" target="_blank">Ffurflen Dreth Hunanasesiad nesaf (yn agor tab newydd)</a>.
 confirmationOfSubmission.agent.ifSa.p1=Os oes angen i’ch cleient anfon Ffurflen Dreth Hunanasesiad, bydd angen iddo ddarparu manylion o’r Ffurflen Dreth hon yn ei Ffurflen Dreth Hunanasesiad nesaf.
 confirmationOfSubmission.trust.ifSa.p1=Bydd angen i chi ddarparu manylion o’r Ffurflen Dreth hon yn Ffurflen Dreth Hunanasesiad nesaf yr ymddiriedolaeth.
 confirmationOfSubmission.capacitor.ifSa.p1=Os oes angen i’r person gyflwyno Ffurflen Dreth Hunanasesiad, bydd angen iddo ddarparu manylion o’r Ffurflen Dreth hon yn ei Ffurflen Dreth Hunanasesiad nesaf.
@@ -3936,7 +3936,7 @@ multipleDisposalsDisposalDate.capacitor.helpText=Mae hyn fel arfer pan fydd pryn
 multipleDisposalsDisposalDate.personalRep.helpText=Mae hyn fel arfer pan fydd prynwr a gwerthwr yn rhoi contractau i''w gilydd ac mae’r prynwr yn talu blaendal. Mae hyn hefyd yn cael ei alw’n ddyddiad ‘gwaredu’. Er enghraifft, 25 4 2020.
 multipleDisposalsDisposalDate.personalRepInPeriodOfAdmin.helpText=Mae hyn fel arfer pan fydd prynwr a gwerthwr yn rhoi contractau i''w gilydd ac mae’r prynwr yn talu blaendal. Mae hyn hefyd yn cael ei alw’n ddyddiad ‘gwaredu’. Er enghraifft, 25 4 2020.
 multipleDisposalsDisposalDate.personalRepInPeriodOfAdmin.agent.helpText=Fel arfer, dyna pan mae prynwr a gwerthwr yn cyfnewid contractau ac mae’r prynwr yn talu blaendal. Mae hyn hefyd yn cael ei alw’n ddyddiad ‘gwaredu’. Er enghraifft, 25 4 2020.
-multipleDisposalsDisposalDate.link=<a href="{0}" target="_blank">Dysgwch beth sy’n digwydd ar y dyddiad cyfnewid (yn agor ffenestr newydd)</a>.
+multipleDisposalsDisposalDate.link=<a href="{0}" target="_blank">Dysgwch beth sy’n digwydd ar y dyddiad cyfnewid (yn agor tab newydd)</a>.
 multipleDisposalsDisposalDate.error.required=Nodwch ddyddiad cyfnewid contractau
 multipleDisposalsDisposalDate.error.invalid=Nodwch ddyddiad cyfnewid contractau go iawn
 multipleDisposalsDisposalDate.error.tooFarInFuture=Mae’n rhaid i’r dyddiad cyfnewid contractau fod yr un fath neu cyn y dyddiad cwblhau
@@ -4575,7 +4575,7 @@ unmetDependency.x2.li3=uwchlwytho dogfen sy’n dangos sut y cyfrifwyd swm newyd
 disposalDateInDifferentTaxYear.title=Ni allwch ddefnyddio’r gwasanaeth hwn
 disposalDateInDifferentTaxYear.p1=Ni allwch ddefnyddio’r gwasanaeth ar-lein i newid y flwyddyn dreth ar gyfer Ffurflen Dreth sydd eisoes wedi’i hanfon
 disposalDateInDifferentTaxYear.subheading=Yr hyn y bydd angen i chi ei wneud nesaf
-disposalDateInDifferentTaxYear.p2=Bydd angen i chi <a class="govuk-link" href=”{0}”>ysgrifennu atom</a> gyda'r newid yn eich blwyddyn dreth
+disposalDateInDifferentTaxYear.p2=Bydd angen i chi <a class="govuk-link" href=”{0}”>ysgrifennu atom</a> gyda’r newid yn eich blwyddyn dreth
 
 #===================================================
 #  AMEND RETURNS - END
@@ -4654,12 +4654,12 @@ furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-a.step-a2.p1=Gwnewch hyn 
 furtherReturnGuidance.stage-a.step-a2.li1=Ychwanegwch at ei gilydd yr holl <strong class="bold">enillion ar ôl rhyddhad</strong> o warediadau sy’n gysylltiedig ag eiddo yn y DU.
 furtherReturnGuidance.stage-a.step-a2.li2=Tynnwch unrhyw golledion Treth Enillion Cyfalaf yn ystod y flwyddyn y gellir eu didynnu.
 furtherReturnGuidance.stage-a.step-a2.li3=Tynnwch unrhyw golledion Treth Enillion Cyfalaf caniataol yn ystod blynyddoedd treth blaenorol.
-furtherReturnGuidance.stage-a.step-a2.li4=Tynnwch eich <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a> yr ydych am ei ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">eich ennill net</strong>.
-furtherReturnGuidance.agent.stage-a.step-a2.li4=Tynnwch <a href="{0}" target="_blank">Swm Blynyddol eich cleient sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a> ac sydd i’w ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
-furtherReturnGuidance.capacitor.stage-a.step-a2.li4=Tynnwch <a href="{0}" target="_blank">Swm Blynyddol y person sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a> ac sydd i’w ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
-furtherReturnGuidance.trust.stage-a.step-a2.li4=Tynnwch y <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a> ac sydd i’w ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
-furtherReturnGuidance.personalRep.stage-a.step-a2.li4=Tynnwch <a href="{0}" target="_blank">Swm Blynyddol y person sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a> ac sydd i’w ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
-furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-a.step-a2.li4=Tynnwch y <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor ffenestr newydd)</a> ac sydd i’w ddefnyddio ar yr enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
+furtherReturnGuidance.stage-a.step-a2.li4=Tynnwch eich <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a> yr ydych am ei ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">eich ennill net</strong>.
+furtherReturnGuidance.agent.stage-a.step-a2.li4=Tynnwch <a href="{0}" target="_blank">Swm Blynyddol eich cleient sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a> ac sydd i’w ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
+furtherReturnGuidance.capacitor.stage-a.step-a2.li4=Tynnwch <a href="{0}" target="_blank">Swm Blynyddol y person sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a> ac sydd i’w ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
+furtherReturnGuidance.trust.stage-a.step-a2.li4=Tynnwch y <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a> ac sydd i’w ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
+furtherReturnGuidance.personalRep.stage-a.step-a2.li4=Tynnwch <a href="{0}" target="_blank">Swm Blynyddol y person sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a> ac sydd i’w ddefnyddio ar enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
+furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-a.step-a2.li4=Tynnwch y <a href="{0}" target="_blank">Swm Blynyddol sydd wedi ei Eithrio rhag Treth (yn agor tab newydd)</a> ac sydd i’w ddefnyddio ar yr enillion o eiddo preswyl i gael <strong class="bold">yr ennill net</strong>.
 furtherReturnGuidance.stage-a.step-a2.li5=Mae’r canlyniad hwn yn seiliedig ar y Dreth Enillion Cyfalaf y dylech fod yn ei thalu nawr.
 furtherReturnGuidance.agent.stage-a.step-a2.li5=Mae’r canlyniad hwn yn seiliedig ar y Dreth Enillion Cyfalaf y dylid ei thalu nawr.
 furtherReturnGuidance.capacitor.stage-a.step-a2.li5=Mae’r canlyniad hwn yn seiliedig ar y Dreth Enillion Cyfalaf y dylid ei thalu nawr.
@@ -4875,11 +4875,11 @@ furtherReturnGuidance.stage-b.step-b1=Cam B1 – Cyfrifwch eich incwm trethadwy
 furtherReturnGuidance.agent.stage-b.step-b1=Cam B1 – Cyfrifwch incwm trethadwy eich cleient
 furtherReturnGuidance.capacitor.stage-b.step-b1=Cam B1 – Cyfrifwch incwm trethadwy’r person
 furtherReturnGuidance.personalRep.stage-b.step-b1=Cam B1 – Cyfrifwch incwm trethadwy’r person
-furtherReturnGuidance.stage-b.step-b1.p1=Gwnewch hyn i helpu i gyfrifo’ch incwm trethadwy er mwyn darganfod faint o’ch ennill net (os o gwbl) y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor ffenestr newydd)</a>.
-furtherReturnGuidance.agent.stage-b.step-b1.p1=Gwnewch hyn i helpu i gyfrifo incwm trethadwy eich cleient er mwyn darganfod faint o’i ennill net (os o gwbl) y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor ffenestr newydd)</a>.
-furtherReturnGuidance.capacitor.stage-b.step-b1.p1=Gwnewch hyn i helpu i gyfrifo incwm trethadwy’r person er mwyn darganfod faint o’r ennill net (os o gwbl) y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor ffenestr newydd)</a>.
-furtherReturnGuidance.personalRep.stage-b.step-b1.p1=Gwnewch hyn i helpu i gyfrifo incwm trethadwy’r person er mwyn darganfod faint o’r ennill net (os o gwbl) y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor ffenestr newydd)</a>.
-furtherReturnGuidance.trust.stage-b.step-b1.p1=Lluoswch <strong class="bold">ennill net</strong> yr ymddiriedolaeth am y flwyddyn â’r <a href="{0}" target="_blank">gyfradd dreth berthnasol ar gyfer y flwyddyn dreth ar gyfer y math o ymddiriedolaeth (yn agor ffenestr newydd)</a> i gyfrifo <strong class="bold">rhwymedigaeth Treth Enillion Cyfalaf gyffredinol yr ymddiriedolaeth ar ei gwarediadau sy’n gysylltiedig ag eiddo yn y DU</strong>.
+furtherReturnGuidance.stage-b.step-b1.p1=Gwnewch hyn i helpu i gyfrifo’ch incwm trethadwy er mwyn darganfod faint o’ch ennill net (os o gwbl) y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor tab newydd)</a>.
+furtherReturnGuidance.agent.stage-b.step-b1.p1=Gwnewch hyn i helpu i gyfrifo incwm trethadwy eich cleient er mwyn darganfod faint o’i ennill net (os o gwbl) y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor tab newydd)</a>.
+furtherReturnGuidance.capacitor.stage-b.step-b1.p1=Gwnewch hyn i helpu i gyfrifo incwm trethadwy’r person er mwyn darganfod faint o’r ennill net (os o gwbl) y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor tab newydd)</a>.
+furtherReturnGuidance.personalRep.stage-b.step-b1.p1=Gwnewch hyn i helpu i gyfrifo incwm trethadwy’r person er mwyn darganfod faint o’r ennill net (os o gwbl) y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor tab newydd)</a>.
+furtherReturnGuidance.trust.stage-b.step-b1.p1=Lluoswch <strong class="bold">ennill net</strong> yr ymddiriedolaeth am y flwyddyn â’r <a href="{0}" target="_blank">gyfradd dreth berthnasol ar gyfer y flwyddyn dreth ar gyfer y math o ymddiriedolaeth (yn agor tab newydd)</a> i gyfrifo <strong class="bold">rhwymedigaeth Treth Enillion Cyfalaf gyffredinol yr ymddiriedolaeth ar ei gwarediadau sy’n gysylltiedig ag eiddo yn y DU</strong>.
 furtherReturnGuidance.stage-b.step-b1.li1=Dechreuwch gyda’ch <strong class="bold">incwm blynyddol gros trethadwy disgwyliedig (ac eithrio unrhyw enillion cyfalaf)</strong>.
 furtherReturnGuidance.agent.stage-b.step-b1.li1=Dechreuwch gydag <strong class="bold">incwm blynyddol gros trethadwy disgwyliedig eich cleient (ac eithrio unrhyw enillion cyfalaf)</strong>.
 furtherReturnGuidance.capacitor.stage-b.step-b1.li1=Dechreuwch gydag <strong class="bold">incwm blynyddol gros trethadwy disgwyliedig y person (ac eithrio unrhyw enillion cyfalaf)</strong>.
@@ -4889,10 +4889,10 @@ furtherReturnGuidance.agent.stage-b.step-b1.li2=Tynnwch <strong class="bold">Lwf
 furtherReturnGuidance.capacitor.stage-b.step-b1.li2=Tynnwch <strong class="bold">Lwfans Personol</strong> treth incwm y person i gael ei <strong class="bold">incwm trethadwy</strong>.
 furtherReturnGuidance.personalRep.stage-b.step-b1.li2=Tynnwch <strong class="bold">Lwfans Personol</strong> treth incwm y person i gael ei <strong class="bold">incwm trethadwy</strong>.
 furtherReturnGuidance.stage-b.step-b2=Cam B2 – Cyfrifwch pa fand cyfradd sylfaenol y gellir ei ddefnyddio yn erbyn yr ennill net
-furtherReturnGuidance.stage-b.step-b2.p1=Gwnewch hyn i ddarganfod faint o’ch ennill net y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor ffenestr newydd)</a>. Os yw’ch incwm trethadwy yn uwch na throthwy’r band cyfradd sylfaenol, yna ni fydd unrhyw ran o’ch ennill net yn cael ei threthu ar y gyfradd sylfaenol.
-furtherReturnGuidance.agent.stage-b.step-b2.p1=Gwnewch hyn i ddarganfod faint o ennill net eich cleient y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor ffenestr newydd)</a>. Os yw ei incwm trethadwy yn uwch na throthwy’r band cyfradd sylfaenol, yna ni fydd unrhyw ran o’r ennill net yn cael ei threthu ar y gyfradd sylfaenol.
-furtherReturnGuidance.capacitor.stage-b.step-b2.p1=Gwnewch hyn i ddarganfod faint o’r ennill net y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor ffenestr newydd)</a>. Os yw incwm trethadwy’r person yn uwch na throthwy’r band cyfradd sylfaenol, yna ni fydd unrhyw ran o’i ennill net yn cael ei threthu ar y gyfradd sylfaenol.
-furtherReturnGuidance.personalRep.stage-b.step-b2.p1=Gwnewch hyn i ddarganfod faint o’r ennill net y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor ffenestr newydd)</a>. Os yw incwm trethadwy’r person yn uwch na throthwy’r band cyfradd sylfaenol, yna ni fydd unrhyw ran o’i ennill net yn cael ei threthu ar y gyfradd sylfaenol.
+furtherReturnGuidance.stage-b.step-b2.p1=Gwnewch hyn i ddarganfod faint o’ch ennill net y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor tab newydd)</a>. Os yw’ch incwm trethadwy yn uwch na throthwy’r band cyfradd sylfaenol, yna ni fydd unrhyw ran o’ch ennill net yn cael ei threthu ar y gyfradd sylfaenol.
+furtherReturnGuidance.agent.stage-b.step-b2.p1=Gwnewch hyn i ddarganfod faint o ennill net eich cleient y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor tab newydd)</a>. Os yw ei incwm trethadwy yn uwch na throthwy’r band cyfradd sylfaenol, yna ni fydd unrhyw ran o’r ennill net yn cael ei threthu ar y gyfradd sylfaenol.
+furtherReturnGuidance.capacitor.stage-b.step-b2.p1=Gwnewch hyn i ddarganfod faint o’r ennill net y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor tab newydd)</a>. Os yw incwm trethadwy’r person yn uwch na throthwy’r band cyfradd sylfaenol, yna ni fydd unrhyw ran o’i ennill net yn cael ei threthu ar y gyfradd sylfaenol.
+furtherReturnGuidance.personalRep.stage-b.step-b2.p1=Gwnewch hyn i ddarganfod faint o’r ennill net y dylid ei godi ar <a href="{0}" target="_blank">y gyfradd sylfaenol (yn agor tab newydd)</a>. Os yw incwm trethadwy’r person yn uwch na throthwy’r band cyfradd sylfaenol, yna ni fydd unrhyw ran o’i ennill net yn cael ei threthu ar y gyfradd sylfaenol.
 furtherReturnGuidance.stage-b.step-b2.li1=Dechreuwch gyda’ch <strong class="bold">incwm trethadwy</strong>.
 furtherReturnGuidance.agent.stage-b.step-b2.li1=Dechreuwch gydag <person class="bold">incwm trethadwy</strong> eich cleient.
 furtherReturnGuidance.capacitor.stage-b.step-b2.li1=Dechreuwch gydag <person class="bold">incwm trethadwy</strong>’r person.
@@ -4910,11 +4910,11 @@ furtherReturnGuidance.stage-b.step-b3.p1=Gwnewch hyn i gael eich rhwymedigaeth T
 furtherReturnGuidance.agent.stage-b.step-b3.p1=Gwnewch hyn i gael rhwymedigaeth Treth Enillion Cyfalaf gyffredinol ddiweddaraf eich cleient ar ei warediadau sy’n gysylltiedig ag eiddo yn y DU. Bydd y cyfrifiad hwn yn ystyried y gwarediadau yn y Ffurflen Dreth hon.
 furtherReturnGuidance.capacitor.stage-b.step-b3.p1=Gwnewch hyn i gael rhwymedigaeth Treth Enillion Cyfalaf gyffredinol ddiweddaraf y person ar ei warediadau sy’n gysylltiedig ag eiddo yn y DU. Bydd y cyfrifiad hwn yn ystyried y gwarediadau yn y Ffurflen Dreth hon.
 furtherReturnGuidance.personalRep.stage-b.step-b3.p1=Gwnewch hyn i gael rhwymedigaeth Treth Enillion Cyfalaf gyffredinol ddiweddaraf y person ar ei warediadau sy’n gysylltiedig ag eiddo yn y DU. Bydd y cyfrifiad hwn yn ystyried y gwarediadau yn y Ffurflen Dreth hon.
-furtherReturnGuidance.stage-b.step-b3.li1=Lluoswch swm yr <strong class="bold">ennill net</strong> sydd i’w drethu ar y <a href="{0}" target="_blank">gyfradd dreth sylfaenol (yn agor ffenestr newydd)</a> ar gyfer y gwarediad sy’n gysylltiedig ag eiddo yn y DU ar gyfer y flwyddyn dreth honno.
-furtherReturnGuidance.agent.stage-b.step-b3.li1=Lluoswch swm yr <strong class="bold">ennill net</strong> sydd i’w drethu ar y <a href="{0}" target="_blank">gyfradd dreth sylfaenol (yn agor ffenestr newydd)</a> ar gyfer y gwarediad sy’n gysylltiedig ag eiddo yn y DU ar gyfer y flwyddyn dreth honno.
-furtherReturnGuidance.capacitor.stage-b.step-b3.li1=Lluoswch swm yr <strong class="bold">ennill net</strong> sydd i’w drethu ar y <a href="{0}" target="_blank">gyfradd dreth sylfaenol (yn agor ffenestr newydd)</a> ar gyfer y gwarediadau sy’n gysylltiedig ag eiddo yn y DU ar gyfer y flwyddyn dreth honno.
-furtherReturnGuidance.personalRep.stage-b.step-b3.li1=Lluoswch swm yr <strong class="bold">ennill net</strong> sydd i’w drethu ar y <a href="{0}" target="_blank">gyfradd dreth sylfaenol (yn agor ffenestr newydd)</a> ar gyfer y gwarediadau sy’n gysylltiedig ag eiddo yn y DU ar gyfer y flwyddyn dreth honno.
-furtherReturnGuidance.stage-b.step-b3.li2=Lluoswch y <strong class="bold">swm sydd i’w drethu ar y</strong> <a href="{0}"target="_blank">gyfradd dreth uwch (yn agor ffenestr newydd)</a> <strong class="bold">ar gyfer y gwarediadau sy’n gysylltiedig ag eiddo yn y DU</strong> ar gyfer y flwyddyn dreth honno.
+furtherReturnGuidance.stage-b.step-b3.li1=Lluoswch swm yr <strong class="bold">ennill net</strong> sydd i’w drethu ar y <a href="{0}" target="_blank">gyfradd dreth sylfaenol (yn agor tab newydd)</a> ar gyfer y gwarediad sy’n gysylltiedig ag eiddo yn y DU ar gyfer y flwyddyn dreth honno.
+furtherReturnGuidance.agent.stage-b.step-b3.li1=Lluoswch swm yr <strong class="bold">ennill net</strong> sydd i’w drethu ar y <a href="{0}" target="_blank">gyfradd dreth sylfaenol (yn agor tab newydd)</a> ar gyfer y gwarediad sy’n gysylltiedig ag eiddo yn y DU ar gyfer y flwyddyn dreth honno.
+furtherReturnGuidance.capacitor.stage-b.step-b3.li1=Lluoswch swm yr <strong class="bold">ennill net</strong> sydd i’w drethu ar y <a href="{0}" target="_blank">gyfradd dreth sylfaenol (yn agor tab newydd)</a> ar gyfer y gwarediadau sy’n gysylltiedig ag eiddo yn y DU ar gyfer y flwyddyn dreth honno.
+furtherReturnGuidance.personalRep.stage-b.step-b3.li1=Lluoswch swm yr <strong class="bold">ennill net</strong> sydd i’w drethu ar y <a href="{0}" target="_blank">gyfradd dreth sylfaenol (yn agor tab newydd)</a> ar gyfer y gwarediadau sy’n gysylltiedig ag eiddo yn y DU ar gyfer y flwyddyn dreth honno.
+furtherReturnGuidance.stage-b.step-b3.li2=Lluoswch y <strong class="bold">swm sydd i’w drethu ar y</strong> <a href="{0}"target="_blank">gyfradd dreth uwch (yn agor tab newydd)</a> <strong class="bold">ar gyfer y gwarediadau sy’n gysylltiedig ag eiddo yn y DU</strong> ar gyfer y flwyddyn dreth honno.
 furtherReturnGuidance.stage-b.step-b3.li3=Ychwanegwch y symiau hyn at ei gilydd i gael eich <strong class="bold">rhwymedigaeth Treth Enillion Cyfalaf gyffredinol ar eich gwarediadau sy’n gysylltiedig ag eiddo yn y DU</strong>.
 furtherReturnGuidance.agent.stage-b.step-b3.li3=Ychwanegwch y symiau hyn at ei gilydd i gael <strong class="bold">rhwymedigaeth Treth Enillion Cyfalaf gyffredinol eich cleient ar ei warediadau sy’n gysylltiedig ag eiddo yn y DU</strong>.
 furtherReturnGuidance.capacitor.stage-b.step-b3.li3=Ychwanegwch y symiau hyn at ei gilydd i gael y <strong class="bold">rhwymedigaeth Treth Enillion Cyfalaf gyffredinol ar warediadau’r person sy’n gysylltiedig ag eiddo yn y DU</strong>.
@@ -5004,7 +5004,7 @@ furtherReturnGuidance.trust.stage-b.example3.table1.row2.key=Mae hi’n lluosi e
 furtherReturnGuidance.trust.stage-b.example3.table1.row2.value={0}
 furtherReturnGuidance.trust.stage-b.example3.table1.total.key=Rhwymedigaeth Treth Enillion Cyfalaf gyffredinol newydd Ymddiriedolaeth ‘Square’ ar gyfer eiddo preswyl yn y DU
 furtherReturnGuidance.trust.stage-b.example3.table1.total.value={0}
-furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.p1=Lluoswch ennill net yr ystâd ar gyfer y flwyddyn â’r <a href="{0}" target="_blank">gyfradd dreth berthnasol ar gyfer y flwyddyn dreth ar gyfer yr ystâd (yn agor ffenestr newydd)</a> er mwyn cyfrifo’i rhwymedigaeth Treth Enillion Cyfalaf gyffredinol ar ei gwarediadau sy’n gysylltiedig ag eiddo yn y DU.
+furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.p1=Lluoswch ennill net yr ystâd ar gyfer y flwyddyn â’r <a href="{0}" target="_blank">gyfradd dreth berthnasol ar gyfer y flwyddyn dreth ar gyfer yr ystâd (yn agor tab newydd)</a> er mwyn cyfrifo’i rhwymedigaeth Treth Enillion Cyfalaf gyffredinol ar ei gwarediadau sy’n gysylltiedig ag eiddo yn y DU.
 furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.example4.link=Gwerthodd Akash, sy’n gynrychiolydd personol, 2 eiddo ar gyfer ystâd teulu Taylor
 furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.example4.headingText=Mae Akash yn cyfrifo rhwymedigaeth Treth Enillion Cyfalaf gyffredinol ystâd teulu Taylor ar gyfer eiddo preswyl ym mlwyddyn dreth {0} i {1}.
 furtherReturnGuidance.personalRepInPeriodOfAdmin.stage-b.example4.table1.row1.key=Mae’n dechrau gyda swm yr ennill net sydd i’w drethu

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -113,6 +113,7 @@ landingPage.sidebar.4=Talu’ch treth
 #===================================================
 lang=cy
 service.title=Rhoi gwybod am a thalu Treth Enillion Cyfalaf ar eiddo yn y DU
+service.name=Rhoi gwybod am a thalu Treth Enillion Cyfalaf ar eiddo yn y DU
 service.signOut=Allgofnodi
 hmrc_branding=Cyllid a Thollau EM
 exitSurvey.linkText=Rhowch wybod sut y gallwn wella’r gwasanaeth (mae’n cymryd 1 munud)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val playVersion = "play-28"
 
   val compile = Seq(
-    "uk.gov.hmrc"                %% "play-frontend-hmrc"                % s"0.88.0-$playVersion",
+    "uk.gov.hmrc"                %% "play-frontend-hmrc"                % s"3.5.0-$playVersion",
     "uk.gov.hmrc"                %% "govuk-template"                    % s"5.68.0-$playVersion",
     "uk.gov.hmrc"                %% "play-ui"                           % s"9.4.0-$playVersion",
     "uk.gov.hmrc"                %% s"bootstrap-frontend-$playVersion"  % "5.12.0",

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsControllerSpec.scala
@@ -1666,7 +1666,7 @@ class AcquisitionDetailsControllerSpec
             ),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey,
                 formattedDateOfDeath
@@ -2725,7 +2725,7 @@ class AcquisitionDetailsControllerSpec
             ),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey,
                 formattedRebaseDate
@@ -5295,7 +5295,7 @@ class AcquisitionDetailsControllerSpec
       messageFromMessageKey(pageTitleKey, titleArgs: _*),
       { doc =>
         doc
-          .select("#error-summary-display > ul > li > a")
+          .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
           errorArgs: _*

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/CompanyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/CompanyDetailsControllerSpec.scala
@@ -435,7 +435,7 @@ class CompanyDetailsControllerSpec
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -517,7 +517,7 @@ class CompanyDetailsControllerSpec
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -775,7 +775,7 @@ class CompanyDetailsControllerSpec
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -971,7 +971,7 @@ class CompanyDetailsControllerSpec
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -1533,7 +1533,7 @@ class CompanyDetailsControllerSpec
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -1716,7 +1716,7 @@ class CompanyDetailsControllerSpec
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -2307,7 +2307,7 @@ class CompanyDetailsControllerSpec
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -2791,7 +2791,7 @@ class CompanyDetailsControllerSpec
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MixedUsePropertyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MixedUsePropertyDetailsControllerSpec.scala
@@ -448,7 +448,7 @@ class MixedUsePropertyDetailsControllerSpec
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -1046,7 +1046,7 @@ class MixedUsePropertyDetailsControllerSpec
             messageFromMessageKey(s"$key$userKey.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -1462,7 +1462,7 @@ class MixedUsePropertyDetailsControllerSpec
             messageFromMessageKey(s"$key$userKey.title", titleArg),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MultipleDisposalsPropertyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MultipleDisposalsPropertyDetailsControllerSpec.scala
@@ -667,7 +667,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             messageFromMessageKey("hasValidPostcode.multipleDisposals.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 "hasValidPostcode.multipleDisposals.error.required"
               ),
@@ -856,7 +856,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             performAction(formData: _*),
             messageFromMessageKey("enterUPRN.multipleDisposals.title"),
             { doc =>
-              val errors = doc.select("#error-summary-display > ul").first()
+              val errors = doc.select("[data-spec='errorSummaryDisplay'] ul").first()
               errors.children
                 .eachText()
                 .asScala
@@ -1637,7 +1637,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey,
                 args: _*
@@ -2182,7 +2182,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -2752,7 +2752,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             expectedTitle,
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe expectedErrorMessage,
             BAD_REQUEST
           )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/SingleDisposalPropertyAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/SingleDisposalPropertyAddressControllerSpec.scala
@@ -546,7 +546,7 @@ class SingleDisposalPropertyDetailsControllerSpec
             messageFromMessageKey("hasValidPostcode.singleDisposal.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 "hasValidPostcode.singleDisposal.error.required"
               ),
@@ -741,7 +741,7 @@ class SingleDisposalPropertyDetailsControllerSpec
             performAction(formData: _*),
             messageFromMessageKey("enterUPRN.singleDisposal.title"),
             { doc =>
-              val errors = doc.select("#error-summary-display > ul").first()
+              val errors = doc.select("[data-spec='errorSummaryDisplay'] ul").first()
               errors.children
                 .eachText()
                 .asScala

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnControllerSpec.scala
@@ -236,7 +236,7 @@ class AmendReturnControllerSpec
                 .url
 
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/disposaldetails/DisposalDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/disposaldetails/DisposalDetailsControllerSpec.scala
@@ -464,7 +464,7 @@ class DisposalDetailsControllerSpec
             messageFromMessageKey(s"shareOfProperty$userMsgKey.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -1298,7 +1298,7 @@ class DisposalDetailsControllerSpec
             messageFromMessageKey(s"$key$userKey$disposalMethodKey.title"),
             doc => {
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text()       shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               )
@@ -1951,7 +1951,7 @@ class DisposalDetailsControllerSpec
             messageFromMessageKey(s"$key$userKey.indirect$disposalMethodKey.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -2689,7 +2689,7 @@ class DisposalDetailsControllerSpec
             messageFromMessageKey(s"disposalFees$userKey.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/exemptionandlosses/ExemptionAndLossesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/exemptionandlosses/ExemptionAndLossesControllerSpec.scala
@@ -2570,7 +2570,7 @@ class ExemptionAndLossesControllerSpec
       messageFromMessageKey(pageTitleKey, titleArgs: _*),
       { doc =>
         doc
-          .select("#error-summary-display > ul > li > a")
+          .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
           errorArgs: _*

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/gainorlossafterreliefs/GainOrLossAfterReliefsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/gainorlossafterreliefs/GainOrLossAfterReliefsControllerSpec.scala
@@ -892,7 +892,7 @@ class GainOrLossAfterReliefsControllerSpec
             messageFromMessageKey(pageTitleKey),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/initialgainorloss/InitialGainOrLossControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/initialgainorloss/InitialGainOrLossControllerSpec.scala
@@ -396,7 +396,7 @@ class InitialGainOrLossControllerSpec
             messageFromMessageKey(pageTitleKey, titleArgs),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey,
                 errorArgs: _*

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/reliefdetails/ReliefDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/reliefdetails/ReliefDetailsControllerSpec.scala
@@ -376,7 +376,7 @@ class ReliefDetailsControllerSpec
             messageFromMessageKey(s"$key$userKey$poaMsgKey.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -848,7 +848,7 @@ class ReliefDetailsControllerSpec
             performAction(data),
             messageFromMessageKey(s"$key$userKey.title"),
             doc =>
-              doc.select("#error-summary-display > ul > li > a").text() shouldBe
+              doc.select("[data-spec='errorSummaryDisplay'] a").text() shouldBe
                 Messages(expectedErrorMessageKey, args: _*),
             BAD_REQUEST
           )
@@ -911,7 +911,7 @@ class ReliefDetailsControllerSpec
                 messageFromMessageKey(s"$key$userKey.title"),
                 doc =>
                   doc
-                    .select("#error-summary-display > ul > li > a")
+                    .select("[data-spec='errorSummaryDisplay'] a")
                     .text() shouldBe messageFromMessageKey(
                     s"$valueKey.error.amountOverPrivateResidenceRelief"
                   ),
@@ -1364,7 +1364,7 @@ class ReliefDetailsControllerSpec
             messageFromMessageKey(s"$key$userKey.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),
@@ -1423,7 +1423,7 @@ class ReliefDetailsControllerSpec
                 case Nil             =>
                 case errorKey :: Nil =>
                   doc
-                    .select("#error-summary-display > ul > li > a")
+                    .select("[data-spec='errorSummaryDisplay'] a")
                     .text() shouldBe messageFromMessageKey(
                     errorKey
                   )
@@ -1432,7 +1432,7 @@ class ReliefDetailsControllerSpec
                     (1 to errorKeys.length).map(i =>
                       doc
                         .select(
-                          s"#error-summary-display > ul > li:nth-child($i) > a"
+                          s"[data-spec='errorSummaryDisplay'] ul > li:nth-child($i) > a"
                         )
                         .text()
                     )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/RepresenteeControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/RepresenteeControllerSpec.scala
@@ -3410,7 +3410,7 @@ class RepresenteeControllerSpec
       messageFromMessageKey(pageTitleKey),
       { doc =>
         doc
-          .select("#error-summary-display > ul > li > a")
+          .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey
         )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/supportingevidence/SupportingEvidenceControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/supportingevidence/SupportingEvidenceControllerSpec.scala
@@ -172,7 +172,7 @@ class SupportingEvidenceControllerSpec
       messageFromMessageKey(pageTitleKey, titleArgs: _*),
       { doc =>
         doc
-          .select("#error-summary-display > ul > li > a")
+          .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
           errorArgs: _*

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
@@ -2916,7 +2916,7 @@ class CommonTriageQuestionsControllerSpec
           messageFromMessageKey("selfAssessmentAlreadySubmitted.title"),
           { doc =>
             doc
-              .select("h2.heading-medium")
+              .select("main h2")
               .text() shouldBe messageFromMessageKey("selfAssessmentAlreadySubmitted.whatNext")
 
             doc.select("#back, .govuk-back-link").attr("href") shouldBe routes.CommonTriageQuestionsController
@@ -3210,7 +3210,7 @@ class CommonTriageQuestionsControllerSpec
               messageFromMessageKey("selfAssessmentAlreadySubmitted.title"),
               { doc =>
                 doc
-                  .select("h2.heading-medium")
+                  .select("main h2")
                   .text() shouldBe messageFromMessageKey("selfAssessmentAlreadySubmitted.whatNext")
 
                 doc.select("#back, .govuk-back-link").attr("href") shouldBe routes.CommonTriageQuestionsController
@@ -3554,7 +3554,7 @@ class CommonTriageQuestionsControllerSpec
               messageFromMessageKey("disposalDateTooEarly.non-uk.title"),
               { doc =>
                 doc
-                  .select("h2.govuk-heading-m")
+                  .select("main h2")
                   .text() shouldBe messageFromMessageKey("disposalDateTooEarly.non-uk.h2")
 
                 doc.select("#back, .govuk-back-link").attr("href") shouldBe routes.SingleDisposalsTriageController
@@ -3581,7 +3581,7 @@ class CommonTriageQuestionsControllerSpec
               messageFromMessageKey("disposalDateTooEarly.non-uk.title"),
               { doc =>
                 doc
-                  .select("h2.govuk-heading-m")
+                  .select("main h2")
                   .text() shouldBe messageFromMessageKey("disposalDateTooEarly.non-uk.h2")
 
                 doc.select("#back, .govuk-back-link").attr("href") shouldBe routes.MultipleDisposalsTriageController

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
@@ -597,7 +597,7 @@ class CommonTriageQuestionsControllerSpec
             messageFromMessageKey("who-are-you-reporting-for.title"),
             { doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text()                          shouldBe messageFromMessageKey(expectedErrorKey)
               doc.title()                          should startWith("Error:")
               doc.select("#submitButton").text() shouldBe messageFromMessageKey("button.continue")
@@ -1275,7 +1275,7 @@ class CommonTriageQuestionsControllerSpec
             messageFromMessageKey("numberOfProperties.title"),
             { doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(expectedErrorKey)
 
               doc
@@ -1679,7 +1679,7 @@ class CommonTriageQuestionsControllerSpec
             messageFromMessageKey("numberOfProperties.title"),
             { doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(expectedErrorKey)
 
               doc
@@ -3069,7 +3069,7 @@ class CommonTriageQuestionsControllerSpec
             ),
             { doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorKey,
                 startDateInclusive.getYear.toString,
@@ -3337,7 +3337,7 @@ class CommonTriageQuestionsControllerSpec
             ),
             { doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorKey,
                 startDateInclusive.getYear.toString,

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageControllerSpec.scala
@@ -248,7 +248,7 @@ class MultipleDisposalsTriageControllerSpec
       messageFromMessageKey(pageTitleKey, titleArgs),
       { doc =>
         doc
-          .select("#error-summary-display > ul > li > a")
+          .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
           errorArgs: _*
@@ -1215,7 +1215,7 @@ class MultipleDisposalsTriageControllerSpec
                 messageFromMessageKey(s"$key${displayType.getSubKey(separatePeriodOfAdminKey = true)}.title"),
                 doc =>
                   doc
-                    .select("#error-summary-display > ul > li > a")
+                    .select("[data-spec='errorSummaryDisplay'] a")
                     .text() shouldBe messageFromMessageKey(
                     s"$key${displayType.getSubKey(separatePeriodOfAdminKey = true)}.error.required"
                   ),
@@ -1617,7 +1617,7 @@ class MultipleDisposalsTriageControllerSpec
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 s"$key.error.required"
               ),
@@ -2189,7 +2189,7 @@ class MultipleDisposalsTriageControllerSpec
             messageFromMessageKey(s"$key.title"),
             { doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 s"$key.error.required"
               )
@@ -2733,7 +2733,7 @@ class MultipleDisposalsTriageControllerSpec
             messageFromMessageKey(s"multipleDisposalsCountryOfResidence.title"),
             { doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 s"$key.error.required"
               )
@@ -2763,7 +2763,7 @@ class MultipleDisposalsTriageControllerSpec
             messageFromMessageKey(s"multipleDisposalsCountryOfResidence.title"),
             { doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 s"$key.error.notFound"
               )
@@ -3260,7 +3260,7 @@ class MultipleDisposalsTriageControllerSpec
                 ),
                 { doc =>
                   doc
-                    .select("#error-summary-display > ul > li > a")
+                    .select("[data-spec='errorSummaryDisplay'] a")
                     .text() shouldBe messageFromMessageKey(
                     s"$key${displayType.getSubKey(separatePeriodOfAdminKey = true)}.error.required"
                   )
@@ -3517,7 +3517,7 @@ class MultipleDisposalsTriageControllerSpec
             messageFromMessageKey("multipleDisposalsCompletionDate.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey,
                 args
@@ -3934,7 +3934,7 @@ class MultipleDisposalsTriageControllerSpec
             messageFromMessageKey("sharesDisposalDate.title"),
             doc =>
               doc
-                .select("#error-summary-display > ul > li > a")
+                .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey
               ),

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/yeartodatelliability/YearToDateLiabilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/yeartodatelliability/YearToDateLiabilityControllerSpec.scala
@@ -9210,7 +9210,7 @@ class YearToDateLiabilityControllerSpec
       messageFromMessageKey(pageTitleKey, titleArgs: _*),
       { doc =>
         doc
-          .select("#error-summary-display > ul > li > a")
+          .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
           errorArgs: _*


### PR DESCRIPTION
## primary fixes
- updated error_summary_govuk component to utilise GovErrorSummary component internally
- upgraded:
  - tax_year_exchanged
  - self_assessment_already_submitted
  - exchanged_different_tax_years
  - already_sent_self_assessment
  - self_assessment_already_submitted
  - completion_date
  - disposal_date_of_shares

## secondary fixes
- updated play-frontend-hmrc library from 0.88.0 to 3.5.0
- updated h1 copy used on existing migrated pages to account for 'error' prefix (which was showing in `h1` in error state)
  - have_you_already_sent_self_assessment
  - who_are_you_reporting_for
- updated text fixtures to use data-spec attribute instead of id for error summary checks
- updated messages to include "opens in a new tab" instead of "opens in a new window" and added to existing links where missing, also updated Welsh copy
- fixed incorrectly quoted attribute on list - did_you_dispose_of_residential_property
- updated date_input_govuk to remove nested `h1`
- updated yes_no_govuk to improve spacing between hint and first radio
- added missing Welsh service name for migrated pages