### PR TITLE
DLS-8184 Prevent Late Amendments

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnController.scala
@@ -84,7 +84,7 @@ class ViewReturnController @Inject() (
     authenticatedActionWithSessionData.async { implicit request =>
       withViewingReturn() { viewingReturn =>
         if (viewingReturn.returnSummary.expired) {
-          Redirect(routes.ViewReturnController.displayReturn().url)
+          Redirect(homeRoutes.HomePageController.homepage().url)
         } else {
           val newJourneyStatus = StartingToAmendReturn(
             viewingReturn.subscribedDetails,
@@ -100,7 +100,9 @@ class ViewReturnController @Inject() (
             None
           )
 
-          updateSession(sessionStore, request)(_.copy(journeyStatus = Some(newJourneyStatus), journeyType = Some(Amend)))
+          updateSession(sessionStore, request)(
+            _.copy(journeyStatus = Some(newJourneyStatus), journeyType = Some(Amend))
+          )
             .map {
               case Left(e)  =>
                 logger.warn("Could not start amending a return", e)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ReturnSummary.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ReturnSummary.scala
@@ -32,7 +32,8 @@ final case class ReturnSummary(
   mainReturnChargeReference: Option[String],
   propertyAddress: Address,
   charges: List[Charge],
-  isRecentlyAmended: Boolean
+  isRecentlyAmended: Boolean,
+  expired: Boolean
 )
 
 object ReturnSummary {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/components/return_list_item.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/components/return_list_item.scala.html
@@ -82,10 +82,12 @@
         id="viewSentReturn-@sentReturn.submissionId"
         href="@{controllers.accounts.homepage.routes.HomePageController.viewSentReturn(sentReturn.submissionId)}"
       >
-      @if(!totalOutstanding.isZero) {
-        @messages("returns.list.viewAndPay")
-      } else {
+      @if(sentReturn.expired) {
+        @messages("returns.list.viewExpired")
+      } else if(totalOutstanding.isZero) {
         @messages("returns.list.view")
+      } else {
+        @messages("returns.list.viewAndPay")
       }
       </a>
     </div>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
@@ -180,6 +180,8 @@ if(completeReturn.isIndirectDisposal) messages(s"$key.companyAddress")
         returnSummaryClass = Some("return-summary")
     )
 
-  @changeReturnLink("amend-link-2")
+    @if(!returnSummary.expired) {
+        @changeReturnLink("amend-link-2")
+    }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
@@ -160,7 +160,14 @@ if(completeReturn.isIndirectDisposal) messages(s"$key.companyAddress")
         @messages(s"$key.summaryHeading")
     </h2>
 
-    @changeReturnLink("amend-link-1")
+    @if(returnSummary.expired) {
+        <p class="govuk-inset-text">
+            @messages("viewReturn.expired")
+        </p>
+    } else {
+        @changeReturnLink("amend-link-1")
+    }
+
 
     @completeReturnSummary(
         completeReturn,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -242,7 +242,7 @@ amend-and-further-returns-calculator {
   max-previous-returns = 10
 }
 
-returns-number-of-tax-years = 3
+returns-number-of-tax-years = 4
 
 mongo-async-driver {
   akka {

--- a/conf/messages
+++ b/conf/messages
@@ -644,6 +644,7 @@ account.manageYourDetails.changed.p=We’ll use this to contact you about your C
 
 returns.list.title=Sent returns
 returns.list.ref=Return reference:
+returns.list.viewExpired=View return
 returns.list.view=View or change return
 returns.list.viewAndPay=View, pay or change return
 returns.list.paymentDue=Tax due date
@@ -4351,7 +4352,7 @@ viewReturn.trust.warning.subtext=It takes 3 to 5 days for payments or charges to
 viewReturn.clearingNotice=It takes 24 hours for your outstanding balance to be updated in your account when you update a return. You can make a payment at any time.
 viewReturn.agent.clearingNotice=It takes 24 hours for the outstanding balance to be updated in your client’s account when you update a return. They can make a payment at any time.
 viewReturn.trust.clearingNotice=It takes 24 hours for the outstanding balance to be updated in the trust’s account when you update a return. You can make a payment at any time.
-
+viewReturn.expired=You cannot make changes to this return because the deadline to amend has passed.
 viewReturn.changeReturn=Change return
 
 #===================================================

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -591,6 +591,7 @@ account.manageYourDetails.Address.changed=Mae’r cyfeiriad cyswllt wedi newid
 account.manageYourDetails.changed.p=Byddwn yn defnyddio hwn i gysylltu â chi ynghylch eich Treth Enillion Cyfalaf ar werthiannau neu warediadau o eiddo yn y DU.
 returns.list.title=Ffurflenni Treth a anfonwyd
 returns.list.ref=Cyfeirnod Ffurflen Dreth:
+returns.list.viewExpired=Gweld y Ffurflen Dreth
 returns.list.view=Bwrw golwg dros neu newid Ffurflen Dreth
 returns.list.viewAndPay=Bwrw golwg dros, talu neu newid Ffurflen Dreth
 returns.list.paymentDue=Dyddiad cau ar gyfer talu treth
@@ -3825,6 +3826,7 @@ viewReturn.trust.warning.subtext=Mae’n cymryd 3 i 5 diwrnod i daliadau neu gos
 viewReturn.clearingNotice=Pan fyddwch yn diweddaru Ffurflen Dreth, bydd yn cymryd 24 awr i’ch balans sy’n weddill gael ei ddiweddaru yn eich cyfrif. Gallwch wneud taliad unrhyw bryd.
 viewReturn.agent.clearingNotice=Pan fyddwch yn diweddaru Ffurflen Dreth, bydd yn cymryd 24 awr i’r balans sy’n weddill gael ei ddiweddaru yng nghyfrif eich cleient. Gall eich cleient wneud taliad unrhyw bryd.
 viewReturn.trust.clearingNotice=Pan fyddwch yn diweddaru Ffurflen Dreth, bydd yn cymryd 24 awr i’r balans sy’n weddill gael ei ddiweddaru yng nghyfrif yr ymddiriedolaeth. Gallwch wneud taliad unrhyw bryd.
+viewReturn.expired=Ni allwch wneud newidiadau i’r Ffurflen Dreth hon gan fod y dyddiad cau i’w diwygio wedi mynd heibio
 viewReturn.changeReturn=Newid y Ffurflen Dreth
 
 #===================================================

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
@@ -77,11 +77,11 @@ class HomePageControllerSpec
     with ScalaCheckDrivenPropertyChecks
     with RedirectToStartBehaviour {
 
-  val mockReturnsService = mock[ReturnsService]
+  private val mockReturnsService = mock[ReturnsService]
 
-  val mockPaymentsService = mock[PaymentsService]
+  private val mockPaymentsService = mock[PaymentsService]
 
-  override val overrideBindings =
+  override val overrideBindings: List[GuiceableModule] =
     List[GuiceableModule](
       bind[AuthConnector].toInstance(mockAuthConnector),
       bind[SessionStore].toInstance(mockSessionStore),
@@ -89,7 +89,7 @@ class HomePageControllerSpec
       bind[PaymentsService].toInstance(mockPaymentsService)
     )
 
-  def mockGetDraftReturns(
+  private def mockGetDraftReturns(
     cgtReference: CgtReference,
     sentReturns: List[ReturnSummary]
   )(
@@ -102,7 +102,7 @@ class HomePageControllerSpec
       .expects(cgtReference, sentReturns, *)
       .returning(EitherT.fromEither[Future](response))
 
-  def mockUpdateCorrectTaxYearToSentReturns(
+  private def mockUpdateCorrectTaxYearToSentReturns(
     cgtReference: CgtReference,
     sentReturns: List[ReturnSummary]
   )(
@@ -115,7 +115,7 @@ class HomePageControllerSpec
       .expects(cgtReference, sentReturns, *)
       .returning(EitherT.fromEither[Future](response))
 
-  def mockGetReturnsList(cgtReference: CgtReference)(
+  private def mockGetReturnsList(cgtReference: CgtReference)(
     response: Either[Error, List[ReturnSummary]]
   ) =
     (mockReturnsService
@@ -123,7 +123,7 @@ class HomePageControllerSpec
       .expects(cgtReference, *)
       .returning(EitherT.fromEither[Future](response))
 
-  def mockDisplayReturn(cgtReference: CgtReference, submissionId: String)(
+  private def mockDisplayReturn(cgtReference: CgtReference, submissionId: String)(
     response: Either[Error, DisplayReturn]
   ) =
     (mockReturnsService
@@ -131,7 +131,7 @@ class HomePageControllerSpec
       .expects(cgtReference, submissionId, *)
       .returning(EitherT.fromEither[Future](response))
 
-  def mockStartPaymentJourney(
+  private def mockStartPaymentJourney(
     cgtReference: CgtReference,
     chargeReference: Option[String],
     amount: AmountInPence,
@@ -152,13 +152,13 @@ class HomePageControllerSpec
       .expects(cgtReference, chargeReference, amount, returnUrl, backUrl, *, *)
       .returning(EitherT.fromEither[Future](response))
 
-  lazy val controller = instanceOf[HomePageController]
+  private lazy val controller = instanceOf[HomePageController]
 
   implicit val messagesApi: MessagesApi = controller.messagesApi
 
   implicit val messages: Messages = MessagesImpl(lang, messagesApi)
 
-  def sessionDataWithSubscribed(subscribed: Subscribed) =
+  private def sessionDataWithSubscribed(subscribed: Subscribed) =
     SessionData.empty.copy(journeyStatus = Some(subscribed))
 
   "The HomePage Controller" when {

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
@@ -316,7 +316,8 @@ class HomePageControllerSpec
           charges = charges,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed             =
           sample[Subscribed].copy(
@@ -381,7 +382,8 @@ class HomePageControllerSpec
           charges = charges,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed             =
           sample[Subscribed].copy(
@@ -425,7 +427,8 @@ class HomePageControllerSpec
           charges = chargesWithChargeRaiseAndNoPayment,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed        =
           sample[Subscribed].copy(
@@ -467,7 +470,8 @@ class HomePageControllerSpec
           charges = chargesWithChargeRaiseAndNoPayment,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed        =
           sample[Subscribed].copy(
@@ -503,7 +507,8 @@ class HomePageControllerSpec
           charges = chargesWithChargeRaiseAndNoPayment,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed       =
           sample[Subscribed].copy(
@@ -930,7 +935,8 @@ class HomePageControllerSpec
           charges = chargesWithoutChargeRaiseAndNoPayment,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed = sample[Subscribed].copy(sentReturns = List(sentReturn))
 
@@ -982,7 +988,8 @@ class HomePageControllerSpec
           charges = chargesWithChargeRaiseAndNoPayment,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed = sample[Subscribed].copy(sentReturns = List(sentReturn))
 
@@ -1035,7 +1042,8 @@ class HomePageControllerSpec
           charges = chargesWithChargeRaiseAndPartialPayment,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = true
+          isRecentlyAmended = true,
+          expired = false
         )
         val subscribed = sample[Subscribed].copy(sentReturns = List(sentReturn))
 
@@ -1085,7 +1093,8 @@ class HomePageControllerSpec
           charges = chargesWithChargeRaiseAndPartialPayment,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed = sample[Subscribed].copy(sentReturns = List(sentReturn))
 
@@ -1140,7 +1149,8 @@ class HomePageControllerSpec
           charges = chargesWithChargeRaiseAndFullPayment,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
         val subscribed = sample[Subscribed].copy(sentReturns = List(sentReturn))
 
@@ -1221,7 +1231,8 @@ class HomePageControllerSpec
           charges = charges,
           mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
           submissionDate = ukResidentReturnSentDate,
-          isRecentlyAmended = false
+          isRecentlyAmended = false,
+          expired = false
         )
 
         val subscribed = sample[Subscribed].copy(sentReturns = List(sentReturn))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnControllerSpec.scala
@@ -207,7 +207,8 @@ class ViewReturnControllerSpec
         lastUpdatedDate = None,
         mainReturnChargeAmount = ukResidentMainReturnChargeAmount,
         submissionDate = ukResidentReturnSentDate,
-        isRecentlyAmended = false
+        isRecentlyAmended = false,
+        expired = false
       )
 
       val sentAmendedReturn = sample[ReturnSummary].copy(
@@ -215,7 +216,8 @@ class ViewReturnControllerSpec
         lastUpdatedDate = Some(LocalDate.now().plusMonths(2)),
         mainReturnChargeAmount = mainChargeAmountWithDelta,
         submissionDate = ukResidentReturnSentDate,
-        isRecentlyAmended = false
+        isRecentlyAmended = false,
+        expired = false
       )
 
       def validatePaymentsSection(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnControllerSpec.scala
@@ -845,6 +845,7 @@ class ViewReturnControllerSpec
           val document = Jsoup.parse(contentAsString(result))
 
           document.select("#amend-link-1").isEmpty shouldBe true
+          document.select("#amend-link-2").isEmpty shouldBe true
         }
 
       }


### PR DESCRIPTION
[Ticket](https://github.com/hmrc/cgt-property-disposals/pull/330)

 - change link text if return expired (current date is after amendment date)
 - replace amendment link with expiration notice if expired
 - redirect to homepage when using a hard link
 - Increase default visible tax years to 4