### PR TITLE
DLS-8626 | Update rebase rule for 1982 & 2019

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/config/RebasingCutoffDates.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/config/RebasingCutoffDates.scala
@@ -20,7 +20,7 @@ import java.time.LocalDate
 
 object RebasingCutoffDates {
 
-  val ukResidents: LocalDate = LocalDate.of(1982, 3, 31)
+  val allResidents: LocalDate = LocalDate.of(1982, 3, 31)
 
   val nonUkResidentsResidentialProperty: LocalDate = LocalDate.of(2015, 4, 5)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsController.scala
@@ -1397,19 +1397,16 @@ class AcquisitionDetailsController @Inject() (
     acquisitionDate: AcquisitionDate
   ): Boolean =
     if (
-      wasUkResident && RebasingCutoffDates.ukResidents.isAfter(
-        acquisitionDate.value
+      !wasUkResident && (
+        RebasingCutoffDates.nonUkResidentsResidentialProperty.isAfter(acquisitionDate.value) ||
+          RebasingCutoffDates.nonUkResidentsNonResidentialProperty.isAfter(acquisitionDate.value)
       )
     ) {
-      acquisitionDetailsAnswers
-        .fold(_.acquisitionMethod, c => Some(c.acquisitionMethod))
-        .isDefined
-    } else if (!wasUkResident) {
       acquisitionDetailsAnswers
         .fold(_.acquisitionPrice, c => Some(c.acquisitionPrice))
         .isDefined
     } else {
-      true
+      acquisitionDetailsAnswers.fold(_.acquisitionMethod, c => Some(c.acquisitionMethod)).isDefined
     }
 }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/RebasingEligibilityUtil.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/RebasingEligibilityUtil.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.acquisitiondetails
 
-import cats.syntax.eq._
 import com.google.inject.Singleton
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.RebasingCutoffDates
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.CompleteSingleDisposalReturn
@@ -43,7 +42,7 @@ class RebasingEligibilityUtil {
     wasAUkResident: Boolean,
     purchaseDate: LocalDate
   ): Boolean =
-    !wasAUkResident || purchaseDate.isAfter(RebasingCutoffDates.ukResidents)
+    !wasAUkResident || purchaseDate.isAfter(RebasingCutoffDates.allResidents)
 
   def isEligibleForRebase(
     completeReturn: CompleteSingleDisposalReturn
@@ -87,12 +86,12 @@ class RebasingEligibilityUtil {
     assetType: AssetType,
     wasUkResident: Boolean
   ): LocalDate =
-    if (wasUkResident) {
-      RebasingCutoffDates.ukResidents
-    } else if (assetType === AssetType.Residential) {
+    if (!wasUkResident && assetType == AssetType.NonResidential) {
+      RebasingCutoffDates.nonUkResidentsNonResidentialProperty
+    } else if (!wasUkResident && assetType == AssetType.Residential) {
       RebasingCutoffDates.nonUkResidentsResidentialProperty
     } else {
-      RebasingCutoffDates.nonUkResidentsNonResidentialProperty
+      RebasingCutoffDates.allResidents
     }
 
   private def extractIsUk(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
@@ -580,7 +580,7 @@ class SingleDisposalsTriageController @Inject() (
                             Redirect(
                               routes.SingleDisposalsTriageController.checkYourAnswers()
                             )
-                          case None                         =>
+                          case _                            =>
                             Redirect(
                               routes.CommonTriageQuestionsController.disposalDateTooEarly()
                             )
@@ -1212,7 +1212,7 @@ class SingleDisposalsTriageController @Inject() (
                             Redirect(
                               routes.SingleDisposalsTriageController.checkYourAnswers()
                             )
-                          case None                         =>
+                          case _                            =>
                             Redirect(
                               routes.CommonTriageQuestionsController.disposalsOfSharesTooEarly()
                             )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/yeartodatelliability/YearToDateLiabilityController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/yeartodatelliability/YearToDateLiabilityController.scala
@@ -242,9 +242,6 @@ class YearToDateLiabilityController @Inject() (
         incomplete.calculatedTaxDue match {
           case Some(c) => f(c)
 
-          case None if !calculateIfMissing =>
-            Redirect(routes.YearToDateLiabilityController.checkYourAnswers())
-
           case None if calculateIfMissing =>
             val result =
               for {
@@ -289,6 +286,8 @@ class YearToDateLiabilityController @Inject() (
                 f
               )
               .merge
+
+          case None => Redirect(routes.YearToDateLiabilityController.checkYourAnswers())
         }
 
     }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_nonUk_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_nonUk_address.scala.html
@@ -93,7 +93,7 @@
                   case Some(PersonalRepresentative)                => messages("nonUkAddress.companyDetails.personalRep.title")
                   case Some(PersonalRepresentativeInPeriodOfAdmin) => messages("nonUkAddress.companyDetails.personalRepInPeriodOfAdmin.title")
                   case Some(Capacitor)                             => messages("nonUkAddress.companyDetails.capacitor.title")
-                  case None =>
+                  case _ =>
                       if (c.isATrust)                                 messages("nonUkAddress.companyDetails.trust.title")
                       else if (request.userType.exists(_ === Agent))  messages("nonUkAddress.companyDetails.agent.title")
                       else                                            messages("nonUkAddress.companyDetails.title")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_postcode.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_postcode.scala.html
@@ -53,7 +53,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => if(isAgent) ".agent" else ".personalRep"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_uk_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_uk_address.scala.html
@@ -47,7 +47,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => if(isAgent) ".agent" else ".personalRep"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""
@@ -85,7 +85,7 @@
             case Some(PersonalRepresentative) => messages(s"$key.uk.companyDetails.personalRep.title")
             case Some(PersonalRepresentativeInPeriodOfAdmin) => messages(s"$key.uk.companyDetails.personalRepInPeriodOfAdmin.title")
             case Some(Capacitor) => messages(s"$key.uk.companyDetails.capacitor.title")
-            case None =>
+            case _ =>
                 if(c.isATrust)                                  messages(s"$key.uk.companyDetails.trust.title")
                 else if(isAgent)                                messages(s"$key.uk.companyDetails.agent.title")
                 else                                            messages(s"$key.uk.companyDetails.title")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/isUk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/isUk.scala.html
@@ -46,7 +46,7 @@
                 case Some(PersonalRepresentative) => ".companyDetails.personalRep."
                 case Some(PersonalRepresentativeInPeriodOfAdmin) => ".companyDetails.personalRep."
                 case Some(Capacitor) => ".companyDetails.capacitor."
-                case None =>
+                case _ =>
                     if (c.isATrust) ".companyDetails.trust."
                     else if (isAgent) ".companyDetails.agent."
                     else ".companyDetails."
@@ -71,7 +71,7 @@
                 case Some(PersonalRepresentative)                => messages("companyDetails.isUk.personalRep.title")
                 case Some(PersonalRepresentativeInPeriodOfAdmin) => messages("companyDetails.isUk.personalRepInPeriodOfAdmin.title")
                 case Some(Capacitor)                             => messages("companyDetails.isUk.capacitor.title")
-                case None =>
+                case _ =>
                   if (c.isATrust)                                 messages("companyDetails.isUk.trust.title")
                   else if (isAgent)                               messages("companyDetails.isUk.agent.title")
                   else                                            messages("companyDetails.isUk.title")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/select_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/select_address.scala.html
@@ -55,7 +55,7 @@
     case Some(PersonalRepresentative) => ".personalRep."
     case Some(PersonalRepresentativeInPeriodOfAdmin) => if(isAgent) ".agent." else ".personalRep."
     case Some(Capacitor) => ".capacitor."
-    case None =>
+    case _ =>
        if (isAgent) ".agent."
        else if (isATrust) ".trust."
        else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_date.scala.html
@@ -50,7 +50,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_fees.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_fees.scala.html
@@ -67,7 +67,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_method.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_method.scala.html
@@ -53,7 +53,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""
@@ -75,7 +75,7 @@
         case Some(PersonalRepresentative) => "personalRep."
         case Some(PersonalRepresentativeInPeriodOfAdmin) => "personalRep."
         case Some(Capacitor) => "capacitor."
-        case None =>
+        case _ =>
             if (isAgent) "agent."
             else if (isATrust) "trust."
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
@@ -59,7 +59,7 @@
     case Some(PersonalRepresentative) => ".personalRep"
     case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
     case Some(Capacitor) => ".capacitor"
-    case None =>
+    case _ =>
       if (isAgent) ".agent"
       else if (isATrust) ".trust"
       else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/improvement_costs.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/improvement_costs.scala.html
@@ -62,7 +62,7 @@
     case Some(PersonalRepresentative) => ".personalRep"
     case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
     case Some(Capacitor) => ".capacitor"
-    case None =>
+    case _ =>
       if (isAgent) ".agent"
       else if (isATrust) ".trust"
       else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/rebased_acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/rebased_acquisition_price.scala.html
@@ -62,7 +62,7 @@
     case Some(PersonalRepresentative) => ".personalRep"
     case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
     case Some(Capacitor) => ".capacitor"
-    case None =>
+    case _ =>
       if (isAgent) ".agent"
       else if (isATrust) ".trust"
       else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/summary_govuk.scala.html
@@ -50,7 +50,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/acquisition_price.scala.html
@@ -54,7 +54,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent)=>  ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent)=>  ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
@@ -54,7 +54,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_guidance.scala.html
@@ -45,7 +45,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent =>  ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_summary_govuk.scala.html
@@ -44,10 +44,10 @@ addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.a
 @userKey = @{
     representativeType match {
         case Some(PersonalRepresentative) => ".personalRep"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if (!isAgent) => ".personalRepInPeriodOfAdmin"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if (isAgent) => ".personalRepInPeriodOfAdmin.agent"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent => ".personalRepInPeriodOfAdmin.agent"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_acquisition_price.scala.html
@@ -51,10 +51,10 @@
 @userKey = @{
     representativeType match {
         case Some(PersonalRepresentative) => ".personalRep"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent => ".personalRepInPeriodOfAdmin.agent"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_disposal_price.scala.html
@@ -52,7 +52,7 @@
   case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
   case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
   case Some(Capacitor) => ".capacitor"
-  case None =>
+  case _ =>
    if (isAgent) ".agent"
    else if (isATrust) ".trust"
    else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/have_you_already_sent_self_assesment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/have_you_already_sent_self_assesment.scala.html
@@ -49,7 +49,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""
@@ -60,7 +60,7 @@
         case Some(PersonalRepresentative) => "personalRep."
         case Some(PersonalRepresentativeInPeriodOfAdmin) => "personalRepInPeriodOfAdmin."
         case Some(Capacitor) => "capacitor."
-        case None =>
+        case _ =>
             if (isAgent) "agent."
             else if (isATrust) "trust."
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/self_assessment_already_submitted.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/self_assessment_already_submitted.scala.html
@@ -43,7 +43,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/confirmation_of_submission.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/confirmation_of_submission.scala.html
@@ -79,7 +79,7 @@
     case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
     case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
     case Some(Capacitor) => ".capacitor"
-    case None =>
+    case _ =>
       if (isAgent) ".agent"
       else if (isATrust) ".trust"
       else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_fees.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_fees.scala.html
@@ -52,7 +52,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_price.scala.html
@@ -52,7 +52,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/how_much_did_you_own.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/how_much_did_you_own.scala.html
@@ -50,7 +50,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/summary_govuk.scala.html
@@ -45,7 +45,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/annual_exempt_amount.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/annual_exempt_amount.scala.html
@@ -63,7 +63,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/further_return_in_year_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/further_return_in_year_losses.scala.html
@@ -56,7 +56,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/further_return_previous_years_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/further_return_previous_years_losses.scala.html
@@ -62,7 +62,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/in_year_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/in_year_losses.scala.html
@@ -61,7 +61,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/previous_years_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/previous_years_losses.scala.html
@@ -61,7 +61,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/summary_govuk.scala.html
@@ -56,7 +56,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/gain_or_loss_after_reliefs.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/gain_or_loss_after_reliefs.scala.html
@@ -61,7 +61,7 @@
         case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent  => ".personalRepInPeriodOfAdmin.agent"
         case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/summary_govuk.scala.html
@@ -45,7 +45,7 @@ cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_ch
         case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent => ".personalRepInPeriodOfAdmin.agent"
         case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/initial_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/initial_gain_or_loss.scala.html
@@ -57,7 +57,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/summary_govuk.scala.html
@@ -38,7 +38,7 @@ cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_ch
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/partials/account_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/partials/account_name.scala.html
@@ -37,7 +37,7 @@
         s"${messages("account.personalRepInPeriodOfAdmin.prefix")} $accountName"
     case Some(Capacitor) =>
         s"${messages("account.personalRep.prefix")} ${crOrPRAccountName}"
-    case None =>
+    case _ =>
     if (isAnAgent)
         s"${messages("account.agent.prefix")} $accountName"
     else if (fillingOutReturn.subscribedDetails.isATrust)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/lettings_relief.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/lettings_relief.scala.html
@@ -56,7 +56,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/other_reliefs.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/other_reliefs.scala.html
@@ -56,7 +56,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) =>
         if(isAgent) ".personalRepInPeriodOfAdmin.agent" else ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
         if (isAgent) ".agent"
         else if (isATrust) ".trust"
         else ""
@@ -69,7 +69,7 @@
         case Some(PersonalRepresentativeInPeriodOfAdmin) =>
             if(isAgent) "personalRepInPeriodOfAdmin.agent." else "personalRepInPeriodOfAdmin."
         case Some(Capacitor) => "capacitor."
-        case None =>
+        case _ =>
             if (isAgent) "agent."
             else if (isATrust) "trust."
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/private_residents_relief.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/private_residents_relief.scala.html
@@ -57,7 +57,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) =>
           if(isAgent) ".personalRepInPeriodOfAdmin.agent" else ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/summary_govuk.scala.html
@@ -46,7 +46,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) =>
         if(isAgent) ".personalRepInPeriodOfAdmin.agent" else ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
         if (isAgent) ".agent"
         else if (isATrust) ".trust"
         else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/have_you_already_sent_self_assesment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/have_you_already_sent_self_assesment.scala.html
@@ -50,7 +50,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""
@@ -61,7 +61,7 @@
         case Some(PersonalRepresentative) => "personalRep."
         case Some(PersonalRepresentativeInPeriodOfAdmin) => "personalRepInPeriodOfAdmin."
         case Some(Capacitor) => "capacitor."
-        case None =>
+        case _ =>
             if (isAgent) "agent."
             else if (isATrust) "trust."
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/how_many_properties.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/how_many_properties.scala.html
@@ -54,7 +54,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/asset_type_for_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/asset_type_for_non_uk_residents.scala.html
@@ -57,7 +57,7 @@
     case Some(PersonalRepresentative) => ".personalRep"
     case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
     case Some(Capacitor) => ".capacitor"
-    case None =>
+    case _ =>
       if (isAgent) ".agent"
         else if (isATrust) ".trust"
         else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/country_of_residence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/country_of_residence.scala.html
@@ -55,7 +55,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/guidance.scala.html
@@ -47,7 +47,7 @@ govukButton: GovukButton
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/summary_govuk.scala.html
@@ -45,7 +45,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_you_a_uk_resident.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_you_a_uk_resident.scala.html
@@ -60,7 +60,7 @@
     case Some(PersonalRepresentative) => ".personalRep"
     case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
     case Some(Capacitor) => ".capacitor"
-    case None =>
+    case _ =>
       if (isAgent) ".agent"
       else if (isATrust) ".trust"
       else ""
@@ -72,7 +72,7 @@
     case Some(PersonalRepresentative) => "personalRep."
     case Some(PersonalRepresentativeInPeriodOfAdmin) => "personalRepInPeriodOfAdmin."
     case Some(Capacitor) => "capacitor."
-    case None =>
+    case _ =>
       if (isAgent) "agent."
       else if (isATrust) "trust."
       else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/self_assessment_already_submitted.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/self_assessment_already_submitted.scala.html
@@ -43,7 +43,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/asset_type_for_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/asset_type_for_non_uk_residents.scala.html
@@ -51,7 +51,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/completion_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/completion_date.scala.html
@@ -53,7 +53,7 @@
   case Some(PersonalRepresentative) => ".personalRep"
   case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
   case Some(Capacitor) => ".capacitor"
-  case None =>
+  case _ =>
    if (isAgent) ".agent"
    else if (isATrust) ".trust"
    else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/country_of_residence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/country_of_residence.scala.html
@@ -56,7 +56,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
@@ -52,7 +52,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""
@@ -64,7 +64,7 @@
         case Some(PersonalRepresentative) => "personalRep."
         case Some(PersonalRepresentativeInPeriodOfAdmin) => "personalRepInPeriodOfAdmin."
         case Some(Capacitor) => "capacitor."
-        case None =>
+        case _ =>
             if (isAgent) "agent."
             else if (isATrust) "trust."
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date.scala.html
@@ -54,7 +54,7 @@
   case Some(PersonalRepresentative) => ".personalRep"
   case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
   case Some(Capacitor) => ".capacitor"
-  case None =>
+  case _ =>
    if (isAgent) ".agent"
    else if (isATrust) ".trust"
    else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/have_you_already_sent_self_assesment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/have_you_already_sent_self_assesment.scala.html
@@ -50,7 +50,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""
@@ -61,7 +61,7 @@
         case Some(PersonalRepresentative) => "personalRep."
         case Some(PersonalRepresentativeInPeriodOfAdmin) => "personalRepInPeriodOfAdmin."
         case Some(Capacitor) => "capacitor."
-        case None =>
+        case _ =>
             if (isAgent) "agent."
             else if (isATrust) "trust."
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/how_did_you_dispose.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/how_did_you_dispose.scala.html
@@ -49,7 +49,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""
@@ -61,7 +61,7 @@
         case Some(PersonalRepresentative) => "personalRep."
         case Some(PersonalRepresentativeInPeriodOfAdmin) => "personalRep."
         case Some(Capacitor) => "capacitor."
-        case None =>
+        case _ =>
             if (isAgent) "agent."
             else if (isATrust) "trust."
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/summary_govuk.scala.html
@@ -44,7 +44,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/were_you_a_uk_resident.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/were_you_a_uk_resident.scala.html
@@ -53,7 +53,7 @@
         case Some(PersonalRepresentative) => ".personalRep."
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin."
         case Some(Capacitor) => ".capacitor."
-        case None =>
+        case _ =>
             if (isAgent) ".agent."
             else if (isATrust) ".trust."
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/uk_resident_can_only_dispose_residential.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/uk_resident_can_only_dispose_residential.scala.html
@@ -39,10 +39,10 @@ representativeType: Option[RepresentativeType])(implicit request: RequestWithSes
 @userKey = @{
     representativeType match {
         case Some(PersonalRepresentative) => ".personalRep"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent => ".personalRepInPeriodOfAdmin.agent"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if(isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_summary_govuk.scala.html
@@ -48,7 +48,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/estimated_income.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/estimated_income.scala.html
@@ -59,7 +59,7 @@
     case Some(PersonalRepresentative) => ".personalRep"
     case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
     case Some(Capacitor) => ".capacitor"
-    case None =>
+    case _ =>
       if (isAgent) ".agent"
       else ""
   }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_enter_tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_enter_tax_due.scala.html
@@ -52,7 +52,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
         if (isAgent) ".agent"
         else if (isATrust) ".trust"
         else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_taxable_gain_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_taxable_gain_guidance.scala.html
@@ -45,7 +45,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if(isAgent) ".agent"
             else if(isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_taxable_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_taxable_gain_or_loss.scala.html
@@ -61,10 +61,10 @@
 @userKey = @{
     representativeType match {
         case Some(PersonalRepresentative) => ".personalRep"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent) => ".personalRepInPeriodOfAdmin.agent"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent => ".personalRepInPeriodOfAdmin.agent"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if (isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_summary_govuk.scala.html
@@ -50,7 +50,7 @@
       case Some(PersonalRepresentative) => ".personalRep"
       case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/personal_allowance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/personal_allowance.scala.html
@@ -56,7 +56,7 @@
     case Some(PersonalRepresentative) => ".personalRep"
     case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRep"
     case Some(Capacitor) => ".capacitor"
-    case None =>
+    case _ =>
       if (isAgent) ".agent"
       else ""
   }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/repayment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/repayment.scala.html
@@ -57,7 +57,7 @@
     case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin."
     case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent  => ".personalRepInPeriodOfAdmin.agent."
     case Some(Capacitor) => ".capacitor."
-    case None =>
+    case _ =>
       if (isAgent) ".agent."
       else if (isATrust) ".trust."
       else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/taxable_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/taxable_gain_or_loss.scala.html
@@ -58,7 +58,7 @@
       case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
       case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent  => ".personalRepInPeriodOfAdmin.agent"
       case Some(Capacitor) => ".capacitor"
-      case None =>
+      case _ =>
           if (isAgent) ".agent"
           else if (isATrust) ".trust"
           else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/year_to_date_liability.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/year_to_date_liability.scala.html
@@ -54,10 +54,10 @@
 @userKey = @{
     representativeType match {
         case Some(PersonalRepresentative) => ".personalRep"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if(!isAgent) => ".personalRepInPeriodOfAdmin"
-        case Some(PersonalRepresentativeInPeriodOfAdmin) if(isAgent)  => ".personalRepInPeriodOfAdmin.agent"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if !isAgent => ".personalRepInPeriodOfAdmin"
+        case Some(PersonalRepresentativeInPeriodOfAdmin) if isAgent  => ".personalRepInPeriodOfAdmin.agent"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if (isAgent) ".agent"
             else if(isATrust) ".trust"
             else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/year_to_date_liability_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/year_to_date_liability_guidance.scala.html
@@ -45,7 +45,7 @@
         case Some(PersonalRepresentative) => ".personalRep"
         case Some(PersonalRepresentativeInPeriodOfAdmin) => ".personalRepInPeriodOfAdmin"
         case Some(Capacitor) => ".capacitor"
-        case None =>
+        case _ =>
             if(isAgent) ".agent"
             else if(isATrust) ".trust"
             else ""

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ lazy val microservice = Project(appName, file("."))
   .settings(scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s")
   .settings(
     scalacOptions ++= Seq(
-      "-Ymacro-annotations"
+      "-Ymacro-annotations",
+      "-Xlint:-byname-implicit"
     )
   )
   .settings(CodeCoverageSettings.settings *)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -20,18 +20,6 @@ play.http.router=prod.Routes
 # Content Security Policy
 play.filters.enabled += play.filters.csp.CSPFilter
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
-# An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
-
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform frontend microservice
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
-# play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters"
-
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/ControllerSpec.scala
@@ -183,11 +183,10 @@ trait ControllerSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll wi
     val bodyText = doc.select("body").text
     val regex    = """not_found_message\((.*?)\)""".r
 
-    val regexResult = regex.findAllMatchIn(bodyText).toList
-    if (regexResult.nonEmpty) fail(s"Missing message keys: ${regexResult.map(_.group(1)).mkString(", ")}")
-    else succeed
-
-    contentChecks(doc)
+    regex.findAllMatchIn(bodyText).toList match {
+      case Nil         => contentChecks(doc)
+      case regexResult => fail(s"Missing message keys: ${regexResult.map(_.group(1)).mkString(", ")}")
+    }
   }
 
   def urlEncode(s: String): String = URLEncoder.encode(s, "UTF-8")

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/EmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/EmailControllerSpec.scala
@@ -81,7 +81,7 @@ trait EmailControllerSpec[JourneyType <: EmailJourneyType] extends ControllerSpe
       .returning(EitherT.fromEither[Future](result))
 
   private def mockUuidGenerator(uuid: UUID): CallHandler0[UUID] =
-    (mockUuidGenerator.nextId: () => UUID).expects().returning(uuid)
+    (mockUuidGenerator.nextId _: () => UUID).expects().returning(uuid)
 
   private lazy val sessionDataWithValidJourneyStatus =
     SessionData.empty

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsControllerSpec.scala
@@ -1699,7 +1699,7 @@ class AcquisitionDetailsControllerSpec
         val price = 1.23d
 
         val answers = IncompleteAcquisitionDetailsAnswers.empty.copy(
-          acquisitionDate = Some(AcquisitionDate(ukResidents.minusDays(2))),
+          acquisitionDate = Some(AcquisitionDate(allResidents.minusDays(2))),
           acquisitionPrice = Some(sample[AmountInPence])
         )
 
@@ -2321,7 +2321,7 @@ class AcquisitionDetailsControllerSpec
                   sample[IncompleteAcquisitionDetailsAnswers].copy(
                     acquisitionDate = Some(
                       AcquisitionDate(
-                        RebasingCutoffDates.ukResidents.minusDays(2)
+                        RebasingCutoffDates.allResidents.minusDays(2)
                       )
                     ),
                     acquisitionMethod = None
@@ -2351,7 +2351,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[CompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = AcquisitionDate(ukResidents.plusDays(1))
+                      acquisitionDate = AcquisitionDate(allResidents.plusDays(1))
                     ),
                     AssetType.Residential,
                     wasUkResident = true,
@@ -2415,7 +2415,7 @@ class AcquisitionDetailsControllerSpec
                 sample[IncompleteAcquisitionDetailsAnswers].copy(
                   acquisitionDate = Some(
                     AcquisitionDate(
-                      RebasingCutoffDates.ukResidents.minusDays(1L)
+                      RebasingCutoffDates.allResidents.minusDays(1L)
                     )
                   ),
                   acquisitionPrice = Some(sample[AmountInPence]),
@@ -2434,7 +2434,7 @@ class AcquisitionDetailsControllerSpec
             performAction(),
             messageFromMessageKey(
               s"rebaseAcquisitionPrice${assetTypeMessageKey(assetType)}.title",
-              TimeUtils.govDisplayFormat(ukResidents)
+              TimeUtils.govDisplayFormat(allResidents)
             ),
             { doc =>
               doc
@@ -2562,7 +2562,7 @@ class AcquisitionDetailsControllerSpec
             performAction(),
             messageFromMessageKey(
               "rebaseAcquisitionPrice.title",
-              TimeUtils.govDisplayFormat(ukResidents)
+              TimeUtils.govDisplayFormat(allResidents)
             ),
             { doc =>
               doc
@@ -2617,7 +2617,7 @@ class AcquisitionDetailsControllerSpec
             performAction(),
             messageFromMessageKey(
               expectedTitleKey,
-              TimeUtils.govDisplayFormat(ukResidents)
+              TimeUtils.govDisplayFormat(allResidents)
             ),
             doc =>
               doc
@@ -2646,7 +2646,7 @@ class AcquisitionDetailsControllerSpec
           FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
         )
 
-      val acquisitionDate = AcquisitionDate(ukResidents.minusDays(1))
+      val acquisitionDate = AcquisitionDate(allResidents.minusDays(1))
 
       behave like redirectToStartBehaviour(() => performAction())
 
@@ -2716,7 +2716,7 @@ class AcquisitionDetailsControllerSpec
             )
           }
 
-          val formattedRebaseDate = TimeUtils.govDisplayFormat(ukResidents)
+          val formattedRebaseDate = TimeUtils.govDisplayFormat(allResidents)
           checkPageIsDisplayed(
             performAction(data: _*),
             messageFromMessageKey(
@@ -2756,7 +2756,7 @@ class AcquisitionDetailsControllerSpec
           individualUserType: IndividualUserType
         ): (SessionData, FillingOutReturn, DraftSingleDisposalReturn) = {
           val answers                         = IncompleteAcquisitionDetailsAnswers.empty.copy(
-            acquisitionDate = Some(AcquisitionDate(ukResidents.minusDays(2))),
+            acquisitionDate = Some(AcquisitionDate(allResidents.minusDays(2))),
             acquisitionPrice = Some(sample[AmountInPence])
           )
           val (session, journey, draftReturn) = sessionWithState(
@@ -2961,7 +2961,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[IncompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = Some(AcquisitionDate(ukResidents.plusDays(1L))),
+                      acquisitionDate = Some(AcquisitionDate(allResidents.plusDays(1L))),
                       acquisitionPrice = None
                     ),
                     AssetType.Residential,
@@ -2992,7 +2992,7 @@ class AcquisitionDetailsControllerSpec
                   sessionWithState(
                     sample[IncompleteAcquisitionDetailsAnswers].copy(
                       acquisitionMethod = Some(AcquisitionMethod.Bought),
-                      acquisitionDate = Some(AcquisitionDate(ukResidents.minusDays(1L))),
+                      acquisitionDate = Some(AcquisitionDate(allResidents.minusDays(1L))),
                       acquisitionPrice = Some(AmountInPence(100L)),
                       rebasedAcquisitionPrice = None
                     ),
@@ -3026,7 +3026,7 @@ class AcquisitionDetailsControllerSpec
             mockGetSession(
               sessionWithState(
                 sample[IncompleteAcquisitionDetailsAnswers].copy(
-                  acquisitionDate = Some(AcquisitionDate(ukResidents.minusDays(1L))),
+                  acquisitionDate = Some(AcquisitionDate(allResidents.minusDays(1L))),
                   rebasedAcquisitionPrice = Some(sample[AmountInPence])
                 ),
                 AssetType.Residential,
@@ -3074,7 +3074,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[IncompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = Some(AcquisitionDate(ukResidents.plusDays(1L))),
+                      acquisitionDate = Some(AcquisitionDate(allResidents.plusDays(1L))),
                       acquisitionPrice = Some(sample[AmountInPence]),
                       rebasedAcquisitionPrice = None
                     ),
@@ -3116,7 +3116,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[CompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = AcquisitionDate(ukResidents.minusDays(1L)),
+                      acquisitionDate = AcquisitionDate(allResidents.minusDays(1L)),
                       rebasedAcquisitionPrice = Some(sample[AmountInPence])
                     ),
                     AssetType.Residential,
@@ -3159,7 +3159,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[CompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = AcquisitionDate(ukResidents.plusDays(1L)),
+                      acquisitionDate = AcquisitionDate(allResidents.plusDays(1L)),
                       rebasedAcquisitionPrice = None
                     ),
                     AssetType.Residential,
@@ -3201,7 +3201,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[CompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = AcquisitionDate(ukResidents),
+                      acquisitionDate = AcquisitionDate(allResidents),
                       rebasedAcquisitionPrice = Some(sample[AmountInPence]),
                       improvementCosts = AmountInPence.zero
                     ),
@@ -3237,7 +3237,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[CompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = AcquisitionDate(ukResidents),
+                      acquisitionDate = AcquisitionDate(allResidents),
                       rebasedAcquisitionPrice = Some(sample[AmountInPence]),
                       improvementCosts = AmountInPence(2L)
                     ),
@@ -3307,7 +3307,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[IncompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = Some(AcquisitionDate(ukResidents.plusDays(1L))),
+                      acquisitionDate = Some(AcquisitionDate(allResidents.plusDays(1L))),
                       acquisitionPrice = None
                     ),
                     AssetType.Residential,
@@ -3337,7 +3337,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[IncompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = Some(AcquisitionDate(ukResidents.minusDays(1L))),
+                      acquisitionDate = Some(AcquisitionDate(allResidents.minusDays(1L))),
                       rebasedAcquisitionPrice = None
                     ),
                     AssetType.Residential,
@@ -3705,7 +3705,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[IncompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = Some(AcquisitionDate(ukResidents.minusDays(2L))),
+                      acquisitionDate = Some(AcquisitionDate(allResidents.minusDays(2L))),
                       shouldUseRebase = Some(true),
                       improvementCosts = Some(sample[AmountInPence])
                     ),
@@ -3794,7 +3794,7 @@ class AcquisitionDetailsControllerSpec
                 mockGetSession(
                   sessionWithState(
                     sample[CompleteAcquisitionDetailsAnswers].copy(
-                      acquisitionDate = AcquisitionDate(ukResidents.minusDays(1L)),
+                      acquisitionDate = AcquisitionDate(allResidents.minusDays(1L)),
                       shouldUseRebase = true
                     ),
                     AssetType.Residential,
@@ -4614,7 +4614,7 @@ class AcquisitionDetailsControllerSpec
                 testRedirectOnMissingData(
                   sessionWithState(
                     allQuestionsAnswered.copy(
-                      acquisitionDate = Some(AcquisitionDate(ukResidents.minusDays(1L))),
+                      acquisitionDate = Some(AcquisitionDate(allResidents.minusDays(1L))),
                       rebasedAcquisitionPrice = None
                     ),
                     AssetType.Residential,
@@ -4862,7 +4862,7 @@ class AcquisitionDetailsControllerSpec
             (userType: UserType, individualUserType: IndividualUserType) =>
               val nonUkRebasing = CompleteAcquisitionDetailsAnswers(
                 sample[AcquisitionMethod],
-                AcquisitionDate(ukResidents.minusDays(2)),
+                AcquisitionDate(allResidents.minusDays(2)),
                 sample[AmountInPence],
                 Some(sample[AmountInPence]),
                 sample[AmountInPence],
@@ -4909,7 +4909,7 @@ class AcquisitionDetailsControllerSpec
             (userType: UserType, individualUserType: IndividualUserType) =>
               val nonUkRebasing = CompleteAcquisitionDetailsAnswers(
                 sample[AcquisitionMethod],
-                AcquisitionDate(ukResidents.plusDays(1)),
+                AcquisitionDate(allResidents.plusDays(1)),
                 sample[AmountInPence],
                 Some(sample[AmountInPence]),
                 sample[AmountInPence],


### PR DESCRIPTION
Also addresses some of the compiler warnings
- Regarding `Xlint:-byname-implicit`, we are safe to do so considering the block it's applied to is a single expression
