### PR TITLE
DLS-9277 | Handle duplicate return submission

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/StartController.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.address.{
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.email.{routes => emailRoutes}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.{IvBehaviour, routes => onboardingRoutes}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.SubscriptionMissingData
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubmittingReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.RetrievedUserType.{Individual, NonGovernmentGatewayRetrievedUser, Trust}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
@@ -216,7 +217,8 @@ class StartController @Inject() (
       case _: AgentStatus.AgentSupplyingClientDetails =>
         Redirect(agentsRoutes.AgentAccessController.enterClientsCgtRef())
 
-      case _: StartingNewDraftReturn | _: FillingOutReturn | _: ViewingReturn | _: SubmitReturnFailed =>
+      case _: StartingNewDraftReturn | _: FillingOutReturn | _: ViewingReturn | _: SubmitReturnFailed |
+          _: SubmittingReturn =>
         Redirect(accounts.homepage.routes.HomePageController.homepage())
 
       case _: JustSubmittedReturn =>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageController.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.{ErrorHandler, ViewConfig
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.{AuthenticatedAction, RequestWithSessionData, SessionDataAction, WithAuthAndSessionDataAction}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{SessionUpdates, returns}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubmittingReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, JustSubmittedReturn, PreviousReturnData, StartingNewDraftReturn, SubmitReturnFailed, Subscribed, ViewingReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.CgtReference
@@ -321,6 +322,17 @@ class HomePageController @Inject() (
         }(f(s, _))
 
       case Some((s: SessionData, r: SubmitReturnFailed)) if withUplift =>
+        upliftToSubscribedAndThen(r, r.subscribedDetails.cgtReference) { case (r, draftReturns, sentReturns) =>
+          Subscribed(
+            r.subscribedDetails,
+            r.ggCredId,
+            r.agentReferenceNumber,
+            draftReturns,
+            sentReturns
+          )
+        }(f(s, _))
+
+      case Some((s: SessionData, r: SubmittingReturn)) if withUplift =>
         upliftToSubscribedAndThen(r, r.subscribedDetails.cgtReference) { case (r, draftReturns, sentReturns) =>
           Subscribed(
             r.subscribedDetails,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/CheckAllAnswersAndSubmitController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/CheckAllAnswersAndSubmitController.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.CheckAllAnsw
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.CheckAllAnswersAndSubmitController.SubmitReturnResult.{SubmitReturnError, SubmitReturnSuccess}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.acquisitiondetails.RebasingEligibilityUtil
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{SessionUpdates, routes => baseRoutes}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubmittingReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, JustSubmittedReturn, SubmitReturnFailed, Subscribed}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.{CompleteMultipleDisposalsReturn, CompleteMultipleIndirectDisposalReturn, CompleteSingleDisposalReturn, CompleteSingleIndirectDisposalReturn, CompleteSingleMixedUseDisposalReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.CompleteRepresenteeAnswers
@@ -133,6 +134,19 @@ class CheckAllAnswersAndSubmitController @Inject() (
 
             val result =
               for {
+                _               <- EitherT(
+                                     updateSession(sessionStore, request)(
+                                       _.copy(journeyStatus =
+                                         Some(
+                                           SubmittingReturn(
+                                             fillingOutReturn.subscribedDetails,
+                                             fillingOutReturn.ggCredId,
+                                             fillingOutReturn.agentReferenceNumber
+                                           )
+                                         )
+                                       )
+                                     )
+                                   )
                 response        <- EitherT.liftF(
                                      submitReturn(
                                        updatedCompleteReturn,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/JourneyStatus.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/JourneyStatus.scala
@@ -181,6 +181,13 @@ object JourneyStatus {
     agentReferenceNumber: Option[AgentReferenceNumber]
   ) extends JourneyStatus
 
+  //in progress submission
+  final case class SubmittingReturn(
+    subscribedDetails: SubscribedDetails,
+    ggCredId: GGCredId,
+    agentReferenceNumber: Option[AgentReferenceNumber]
+  ) extends SubscriptionStatus
+
   final case class ViewingReturn(
     subscribedDetails: SubscribedDetails,
     ggCredId: GGCredId,

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val microservice = Project("cgt-property-disposals-frontend", file("."))
   .settings(
     addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
     addCompilerPlugin(scalafixSemanticdb),
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.12",
     majorVersion := 2,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     onLoadMessage := "",
@@ -26,3 +26,5 @@ lazy val microservice = Project("cgt-property-disposals-frontend", file("."))
                       :: "-Ymacro-annotations" :: "-Xlint:-byname-implicit" :: Nil,
   )
   .settings(CodeCoverageSettings.settings *)
+
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,10 +4,12 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.14.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.2.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.15.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.4.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.19")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"          % "2.4.0")
-addSbtPlugin("org.scoverage"    %% "sbt-scoverage"         % "1.9.3")
+addSbtPlugin("org.scoverage"    %% "sbt-scoverage"         % "2.0.9")
 addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"          % "0.11.0")
 addSbtPlugin("org.scalastyle"   %% "scalastyle-sbt-plugin" % "1.0.0")
+
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.RedirectToStartBehaviour
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubmittingReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, JustSubmittedReturn, PreviousReturnData, StartingNewDraftReturn, SubmitReturnFailed, Subscribed, ViewingReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TimeUtils.govShortDisplayFormat
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
@@ -175,7 +176,7 @@ class HomePageControllerSpec
         () => performAction(),
         {
           case _: Subscribed | _: StartingNewDraftReturn | _: FillingOutReturn | _: JustSubmittedReturn |
-              _: ViewingReturn | _: SubmitReturnFailed =>
+              _: ViewingReturn | _: SubmitReturnFailed | _: SubmittingReturn =>
             true
           case _ => false
         }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RedirectToStartBehaviour.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RedirectToStartBehaviour.scala
@@ -48,7 +48,6 @@ trait RedirectToStartBehaviour {
           controllers.routes.StartController.start()
         )
       }
-
       "the journey status in session is not valid" taggedAs Retryable in {
         implicit val journeyStatusArb: Arbitrary[JourneyStatus] =
           arb(journeyStatusGen)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/StartControllerSpec.scala
@@ -37,7 +37,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.{routes =
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport, StartController, agents}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.{IndividualMissingEmail, RegistrationReady}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentStatus, AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, Subscribed, SubscriptionStatus, ViewingReturn}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentStatus, AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, SubmittingReturn, Subscribed, SubscriptionStatus, ViewingReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, AddressSource, Postcode}
@@ -3116,6 +3116,36 @@ class StartControllerSpec
               SessionData.empty.copy(
                 journeyStatus = Some(
                   sample[SubmitReturnFailed]
+                )
+              )
+            )
+
+            checkIsRedirect(
+              performAction(),
+              controllers.accounts.homepage.routes.HomePageController.homepage()
+            )
+          }
+
+        }
+      }
+
+      "the session data indicates that a submission is already in progress" must {
+
+        "redirect to the account homepage screen" in {
+          inSequence {
+            mockAuthWithAllRetrievals(
+              ConfidenceLevel.L200,
+              Some(AffinityGroup.Individual),
+              None,
+              None,
+              None,
+              Set(cgtEnrolment),
+              Some(retrievedGGCredId)
+            )
+            mockGetSession(
+              SessionData.empty.copy(
+                journeyStatus = Some(
+                  sample[SubmittingReturn]
                 )
               )
             )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/CheckAllAnswersAndSubmitControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/CheckAllAnswersAndSubmitControllerSpec.scala
@@ -43,6 +43,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.Multi
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.SingleDisposalsTriageControllerSpec.validateSingleDisposalTriageCheckYourAnswersPage
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.yeartodatelliability.YearToDateLiabilityControllerSpec.{validateCalculatedYearToDateLiabilityPage, validateNonCalculatedYearToDateLiabilityPage}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubmittingReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, JustSubmittedReturn, PreviousReturnData, SubmitReturnFailed, Subscribed}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Postcode
@@ -1340,6 +1341,11 @@ class CheckAllAnswersAndSubmitControllerSpec
         submitReturnResponse,
         completeFillingOutReturnNoRepresentee.amendReturnData
       )
+      val submittingReturn    = SubmittingReturn(
+        completeFillingOutReturnNoRepresentee.subscribedDetails,
+        completeFillingOutReturnNoRepresentee.ggCredId,
+        completeFillingOutReturnNoRepresentee.agentReferenceNumber
+      )
 
       lazy val submitReturnRequest = {
         val cyaPge                                                     = instanceOf[views.html.returns.check_all_answers]
@@ -1434,6 +1440,9 @@ class CheckAllAnswersAndSubmitControllerSpec
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(sessionWithJourney(completeFillingOutReturnNoRepresentee))
+            mockStoreSession(sessionWithJourney(submittingReturn))(
+              Right()
+            )
             mockSubmitReturn(submitReturnRequest, lang)(Right(submitReturnResponse))
             mockStoreSession(sessionWithJourney(justSubmittedReturn))(
               Left(Error(""))
@@ -1447,6 +1456,9 @@ class CheckAllAnswersAndSubmitControllerSpec
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(sessionWithJourney(completeFillingOutReturnNoRepresentee))
+            mockStoreSession(sessionWithJourney(submittingReturn))(
+              Right()
+            )
             mockSubmitReturn(submitReturnRequest, lang)(Left(Error("")))
             mockStoreSession(
               sessionWithJourney(
@@ -1470,6 +1482,9 @@ class CheckAllAnswersAndSubmitControllerSpec
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(sessionWithJourney(completeFillingOutReturnNoRepresentee))
+            mockStoreSession(sessionWithJourney(submittingReturn))(
+              Right()
+            )
             mockSubmitReturn(submitReturnRequest, lang)(Right(submitReturnResponse))
             mockStoreSession(sessionWithJourney(justSubmittedReturn))(Right(()))
           }
@@ -1496,6 +1511,9 @@ class CheckAllAnswersAndSubmitControllerSpec
             mockAuthWithNoRetrievals()
             mockGetSession(sessionWithJourney(completeFillingOutReturnWithRepresenteeWithNoReference))
             mockCgtRegistrationService(Right(mockRepresenteeCgtReference), representeeAnswersNoReferenceId, lang)
+            mockStoreSession(sessionWithJourney(submittingReturn))(
+              Right()
+            )
             mockSubmitReturn(
               submitReturnRequestForOverriddenReferenceId(mockRepresenteeCgtReference, hideEstimatesQuestion = false),
               lang
@@ -1537,6 +1555,9 @@ class CheckAllAnswersAndSubmitControllerSpec
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(sessionWithJourney(completeFillingOutReturnNoRepresentee))
+            mockStoreSession(sessionWithJourney(submittingReturn))(
+              Right()
+            )
             mockSubmitReturn(submitReturnRequest, lang)(Left(Error("")))
             mockStoreSession(
               sessionWithJourney(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
@@ -20,6 +20,7 @@ import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.{IndividualMissingEmail, IndividualSupplyingInformation, RegistrationReady}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.SubscriptionReady
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubmittingReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, JustSubmittedReturn, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, Subscribed, ViewingReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionResponse.SubscriptionSuccessful
 
@@ -67,6 +68,9 @@ trait JourneyStatusLowerPriorityGen { this: GenUtils =>
 
   implicit val submitReturnFailedGen: Gen[SubmitReturnFailed] =
     gen[SubmitReturnFailed]
+
+  implicit val submittingReturn: Gen[SubmittingReturn] =
+    gen[SubmittingReturn]
 
   implicit val startingToAmendReturnGen: Gen[StartingToAmendReturn] =
     gen[StartingToAmendReturn]


### PR DESCRIPTION
Introduce new journey status, `SubmittingReturn`,  to avoid duplicate returns.