### PR TITLE
DLS-9370 | Handle acquisition method according to representative user journey

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
@@ -92,7 +92,7 @@
       (messages("acquisitionPrice.2.title", TimeUtils.govDisplayFormat(acquisitionDate.value)), Html(messages("acquisitionPrice.2.helpText")))
     case (true, Bought, Some(Capacitor | PersonalRepresentative)) =>
       (messages("acquisitionPrice.4.title"), Html(messages("acquisitionPrice.4.helpText")))
-    case (true, Gifted, Some(Capacitor | PersonalRepresentative)) =>
+    case (true, _, Some(Capacitor | PersonalRepresentative)) =>
       (messages("acquisitionPrice.5.title"), Html(messages("acquisitionPrice.5.helpText")))
     case (true, _, Some(PersonalRepresentativeInPeriodOfAdmin)) =>
       (messages("acquisitionPrice.6.title"), Html(messages("acquisitionPrice.6.helpText")))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
@@ -1988,6 +1988,7 @@ class HomePageControllerSpec
           case _: JustSubmittedReturn    => true
           case _: ViewingReturn          => true
           case _: FillingOutReturn       => true
+          case _: SubmittingReturn       => true
           case _                         => false
         }
       )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RedirectToStartBehaviour.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RedirectToStartBehaviour.scala
@@ -52,7 +52,7 @@ trait RedirectToStartBehaviour {
           controllers.routes.StartController.start()
         )
       }
-      "the journey status in session is not valid" taggedAs Retryable in {
+      "the journey status in session is not valid" in {
         implicit val journeyStatusArb: Arbitrary[JourneyStatus] =
           arb(journeyStatusGen)
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsControllerSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.acquisition
 
 import org.jsoup.nodes.Document
 import org.scalacheck.Gen
-import org.scalatest.{Outcome, Retries}
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.http.Status.BAD_REQUEST
@@ -41,6 +40,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.MoneyUtils.formatAmountOfMoneyWithPoundSign
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.{AmountInPence, MoneyUtils}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.completeDisposalDetailsAnswersGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
@@ -58,6 +58,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, Tru
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.{CompleteAcquisitionDetailsAnswers, IncompleteAcquisitionDetailsAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AssetType.{IndirectDisposal, NonResidential, Residential}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalDetailsAnswers.CompleteDisposalDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{Capacitor, PersonalRepresentative, PersonalRepresentativeInPeriodOfAdmin, Self}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.{CompleteRepresenteeAnswers, IncompleteRepresenteeAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.IncompleteSingleDisposalTriageAnswers
@@ -76,17 +77,7 @@ class AcquisitionDetailsControllerSpec
     with ReturnsServiceSupport
     with ScalaCheckDrivenPropertyChecks
     with RedirectToStartBehaviour
-    with StartingToAmendToFillingOutReturnSpecBehaviour
-    with Retries {
-
-  override def withFixture(test: NoArgTest): Outcome =
-    if (isRetryable(test)) {
-      this.withRetry {
-        super.withFixture(test)
-      }
-    } else {
-      super.withFixture(test)
-    }
+    with StartingToAmendToFillingOutReturnSpecBehaviour {
 
   private lazy val controller = instanceOf[AcquisitionDetailsController]
 
@@ -322,6 +313,7 @@ class AcquisitionDetailsControllerSpec
         disposalDate = disposalDate,
         individualUserType = Some(individualUserType)
       ),
+      disposalDetailsAnswers = Some(sample[CompleteDisposalDetailsAnswers]),
       acquisitionDetailsAnswers = answers,
       representeeAnswers = representeeAnswers
     )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/disposaldetails/DisposalDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/disposaldetails/DisposalDetailsControllerSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.disposaldet
 
 import org.jsoup.nodes.Document
 import org.scalacheck.Gen
-import org.scalatest.{Outcome, Retries}
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.i18n.MessagesApi
@@ -73,19 +72,9 @@ class DisposalDetailsControllerSpec
     with ReturnsServiceSupport
     with ScalaCheckDrivenPropertyChecks
     with RedirectToStartBehaviour
-    with StartingToAmendToFillingOutReturnSpecBehaviour
-    with Retries {
+    with StartingToAmendToFillingOutReturnSpecBehaviour {
 
   import DisposalDetailsControllerSpec._
-
-  override def withFixture(test: NoArgTest): Outcome =
-    if (isRetryable(test)) {
-      this.withRetry {
-        super.withFixture(test)
-      }
-    } else {
-      super.withFixture(test)
-    }
 
   val mockUUIDGenerator: UUIDGenerator = mock[UUIDGenerator]
 


### PR DESCRIPTION
For the journeys mentioned in https://docs.google.com/spreadsheets/d/15BS3r3ceZrhe0CYUi1tNJls8S3G8OWciuh3S64fl6EA/edit?pli=1#gid=1748147366, representative (capacitor/personalrepresentative) journey should bucket acquisition methods that isn't a `Bought`. 

Verified manually by running the journey. It's a risk to just cater for `Inherited` as highlighted in the ticket. Because, by choosing `Other` also fails. This change caters for both, and is inline with how we handle these acquisition methods in other parts of the same journey.

_Also includes changes for intermittent test failures. Involves fix to the test fixtures for some testsuites to factor in valid/invalid scenarios when generators are in play. Might not the be end of it all, but gets us a start and hopefully fix anything that comes along with next PRs._ 