### PR TITLE
DLS-9571 | Re-enable disabled tests inline with the updated workflow

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/PropertyDetailsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/PropertyDetailsController.scala
@@ -874,7 +874,7 @@ class PropertyDetailsController @Inject() (
                     },
                     _ =>
                       m.triageAnswers.fold(_.numberOfProperties, x => Some(x.numberOfProperties)) match {
-                        case None =>
+                        case None                =>
                           Redirect(returnsRoutes.TaskListController.taskList())
                         case Some(propertyCount) =>
                           Ok(
@@ -886,7 +886,7 @@ class PropertyDetailsController @Inject() (
                               extractDateOfDeath(r),
                               firstTimeVisiting = true,
                               addressLine1,
-                              propertyCount,
+                              propertyCount
                             )
                           )
                       }
@@ -894,7 +894,7 @@ class PropertyDetailsController @Inject() (
 
                 case c: CompleteExamplePropertyDetailsAnswers =>
                   m.triageAnswers.fold(_.numberOfProperties, x => Some(x.numberOfProperties)) match {
-                    case None =>
+                    case None                =>
                       Redirect(returnsRoutes.TaskListController.taskList())
                     case Some(propertyCount) =>
                       Ok(
@@ -906,7 +906,7 @@ class PropertyDetailsController @Inject() (
                           extractDateOfDeath(r),
                           firstTimeVisiting = false,
                           c.address.line1,
-                          propertyCount,
+                          propertyCount
                         )
                       )
                   }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageController.scala
@@ -1484,7 +1484,7 @@ class MultipleDisposalsTriageController @Inject() (
                     _._1.subscribedDetails.isATrust
                   ),
                   representeeAnswers,
-                  firstTimeVisiting = state.isLeft,
+                  firstTimeVisiting = state.isLeft
                 )
               )
             )
@@ -1514,7 +1514,7 @@ class MultipleDisposalsTriageController @Inject() (
                     _._1.subscribedDetails.isATrust
                   ),
                   representeeAnswers,
-                  firstTimeVisiting = state.isLeft,
+                  firstTimeVisiting = state.isLeft
                 )
               )
             )
@@ -1529,7 +1529,7 @@ class MultipleDisposalsTriageController @Inject() (
                   _._1.subscribedDetails.isATrust
                 ),
                 representeeAnswers,
-                firstTimeVisiting = state.isLeft,
+                firstTimeVisiting = state.isLeft
               )
             )
           case _                                         =>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2023 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import play.api.data.Form
 @import play.api.i18n.Messages
 @import play.api.mvc.Call

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       %% "sbt-auto-build"        % "3.15.0")
+addSbtPlugin("uk.gov.hmrc"       %% "sbt-auto-build"        % "3.18.0")
 addSbtPlugin("uk.gov.hmrc"       %% "sbt-distributables"    % "2.4.0")
 addSbtPlugin("com.typesafe.play" %% "sbt-plugin"            % "2.8.20")
 addSbtPlugin("org.scalameta"     %% "sbt-scalafmt"          % "2.4.0")

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/ControllerSpec.scala
@@ -172,7 +172,8 @@ trait ControllerSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll wi
     result: Future[Result],
     expectedTitle: String,
     contentChecks: Document => Unit = _ => (),
-    expectedStatus: Int = OK
+    expectedStatus: Int = OK,
+    messageRegexPrefix: String = "not_found_message"
   ): Unit = {
     (status(result), redirectLocation(result)) shouldBe (expectedStatus -> None)
     status(result)                             shouldBe expectedStatus
@@ -181,7 +182,7 @@ trait ControllerSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll wi
     doc.select("h1").text should include(expectedTitle)
 
     val bodyText = doc.select("body").text
-    val regex    = """not_found_message\((.*?)\)""".r
+    val regex    = raw"""$messageRegexPrefix\((.*?)\)""".r
 
     regex.findAllMatchIn(bodyText).toList match {
       case Nil         => contentChecks(doc)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MultipleDisposalsPropertyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MultipleDisposalsPropertyDetailsControllerSpec.scala
@@ -1565,7 +1565,11 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           representeeAnswers: Option[RepresenteeAnswers] = None
         )(
           formData: List[(String, String)]
-        )(expectedErrorMessageKey: String, args: Seq[String] = Seq()): Unit = {
+        )(
+          expectedErrorMessageKey: String,
+          args: Seq[String] = Seq(),
+          messageRegexPrefix: String = "not_found_message"
+        ): Unit = {
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(
@@ -1604,7 +1608,8 @@ class MultipleDisposalsPropertyDetailsControllerSpec
                 expectedErrorMessageKey,
                 args: _*
               ),
-            BAD_REQUEST
+            BAD_REQUEST,
+            messageRegexPrefix
           )
         }
 
@@ -1634,12 +1639,13 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           )
         }
 
-        "the date entered is too far in past" ignore {
+        "the date entered is too far in past" in {
           val param1 = taxYear.startDateInclusive.getYear.toString
           val param2 = taxYear.endDateExclusive.getYear.toString
           testFormError()(formData(taxYear.startDateInclusive.minusYears(2L)))(
             s"$key.error.tooFarInPast",
-            Seq(param1, param2)
+            Seq(param1, param2),
+            "ignore_not_found_message"
           )
         }
 
@@ -3108,7 +3114,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           result: Future[Result],
           answers: CompleteExamplePropertyDetailsAnswers,
           expectedTitleKey: String,
-          hasGuidanceLink: Boolean,
+          hasGuidanceLink: Boolean
         ): Unit =
           checkPageIsDisplayed(
             result,
@@ -3119,7 +3125,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
               if (hasGuidanceLink) {
                 guidanceLink.attr(
                   "href"
-                ) shouldBe routes.PropertyDetailsController
+                )                   shouldBe routes.PropertyDetailsController
                   .multipleDisposalsGuidance()
                   .url
                 guidanceLink.text() shouldBe messageFromMessageKey(
@@ -3152,7 +3158,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             performAction(),
             completeAnswers,
             "returns.property-address.cya.title",
-            hasGuidanceLink = false,
+            hasGuidanceLink = false
           )
         }
 
@@ -3168,7 +3174,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             performAction(),
             completeAnswers,
             "returns.property-address.cya.title",
-            hasGuidanceLink = true,
+            hasGuidanceLink = true
           )
         }
       }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnControllerSpec.scala
@@ -45,7 +45,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.Co
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.CompleteSingleDisposalTriageAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.audit.CancelAmendReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AmendReturnData, IndividualUserType, ReturnSummary}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{CompleteReturnWithSummary, SessionData, UserType}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{CompleteReturnWithSummary, SessionData, TaxYear, UserType}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -397,10 +397,11 @@ class AmendReturnControllerSpec
             triageAnswers = sample[CompleteSingleDisposalTriageAnswers].copy(
               individualUserType = Some(IndividualUserType.Self)
             )
-          )
+          ),
+          summary = sample[ReturnSummary].copy(taxYear = TaxYear.thisTaxYearStartDate().getYear.toString)
         )
 
-        "the user is not an agent" ignore {
+        "the user is not an agent" in {
           test(
             SessionData.empty.copy(
               journeyStatus = Some(
@@ -414,7 +415,7 @@ class AmendReturnControllerSpec
           )
         }
 
-        "the user is an agent" ignore {
+        "the user is an agent" in {
           test(
             SessionData.empty.copy(
               journeyStatus = Some(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/RepresenteeControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/RepresenteeControllerSpec.scala
@@ -1480,12 +1480,12 @@ class RepresenteeControllerSpec
           doc => {
             doc.select("#back, .govuk-back-link").attr("href") shouldBe expectedBackLink.url
             doc
-              .select("#name-question")
+              .select("#main-content .govuk-summary-list__key")
               .text                                            shouldBe messageFromMessageKey(
               "representeeConfirmPerson.summaryLine1"
             )
             doc
-              .select("#name-answer")
+              .select("#main-content .govuk-summary-list__value")
               .text                                            shouldBe s"${expectedName.firstName} ${expectedName.lastName}"
             if (isCgtRow) {
               doc
@@ -1502,7 +1502,7 @@ class RepresenteeControllerSpec
               .confirmPersonSubmit()
               .url
             doc
-              .select("#confirmed > legend > h2")
+              .select("#main-content form legend")
               .text()                                          shouldBe messageFromMessageKey(
               "representeeConfirmPerson.formTitle"
             )
@@ -1524,7 +1524,7 @@ class RepresenteeControllerSpec
               hasConfirmedContactDetails = false,
               None
             )
-          "show the summary" ignore {
+          "show the summary" in {
             test(
               sessionWithStartingNewDraftReturn(
                 requiredPreviousAnswers,
@@ -1623,7 +1623,7 @@ class RepresenteeControllerSpec
           Capacitor
         )._1
 
-        "nothing is selected" ignore {
+        "nothing is selected" in {
 
           testFormError(performAction, "representeeConfirmPerson.title", session)(
             List.empty,

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageControllerSpec.scala
@@ -1913,11 +1913,14 @@ class MultipleDisposalsTriageControllerSpec
             )
           }
 
-          "user has not answered the tax year exchanged section and selects before April 06th, 2020" ignore {
+          "user has not answered the tax year exchanged section and selects before April 06th, 2020" in {
             inSequence {
               mockAuthWithNoRetrievals()
               mockGetSession(session)
               mockAvailableTaxYears()(Right(List()))
+              mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedBefore2020.year))(
+                Right(None)
+              )
               mockStoreSession(
                 session.copy(journeyStatus =
                   Some(
@@ -1940,7 +1943,7 @@ class MultipleDisposalsTriageControllerSpec
             )
           }
 
-          "user has already answered were all properties residential section and re-selected different option" ignore {
+          "user has already answered were all properties residential section and re-selected different option" in {
             val answers = sample[IncompleteMultipleDisposalsTriageAnswers]
               .copy(
                 individualUserType = Some(Self),
@@ -1962,6 +1965,9 @@ class MultipleDisposalsTriageControllerSpec
               mockAuthWithNoRetrievals()
               mockGetSession(session)
               mockAvailableTaxYears()(Right(List()))
+              mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedBefore2020.year))(
+                Right(None)
+              )
               mockStoreSession(
                 session.copy(journeyStatus =
                   Some(
@@ -2220,11 +2226,14 @@ class MultipleDisposalsTriageControllerSpec
         )
         val updatedJourney     = journey.copy(draftReturn = updatedDraftReturn)
 
-        "there is an error updating the draft return" ignore {
+        "there is an error updating the draft return" in {
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(session)
             mockAvailableTaxYears()(Right(List()))
+            mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedBefore2020.year))(
+              Right(None)
+            )
             mockStoreDraftReturn(updatedJourney)(
               Left(Error(""))
             )
@@ -2233,11 +2242,14 @@ class MultipleDisposalsTriageControllerSpec
           checkIsTechnicalErrorPage(performAction(key -> "-2020"))
         }
 
-        "there is an error updating the session data" ignore {
+        "there is an error updating the session data" in {
           inSequence {
             mockAuthWithNoRetrievals()
             mockGetSession(session)
             mockAvailableTaxYears()(Right(List()))
+            mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedBefore2020.year))(
+              Right(None)
+            )
             mockStoreDraftReturn(updatedJourney)(
               Right(())
             )
@@ -3508,7 +3520,7 @@ class MultipleDisposalsTriageControllerSpec
           )
         }
 
-        "the date entered is invalid" ignore {
+        "the date entered is invalid" in {
           DateErrorScenarios
             .dateErrorScenarios(
               "multipleDisposalsCompletionDate",
@@ -3527,17 +3539,15 @@ class MultipleDisposalsTriageControllerSpec
             }
         }
 
-        "the date entered is later than today" ignore {
+        "the date entered is later than today" in {
           testFormError(formData(today.plusYears(2L).plusDays(1L)))(
             "multipleDisposalsCompletionDate.error.tooFarInFuture"
           )
         }
 
-        "the date entered is before 06-04-2020" ignore {
-          val date = LocalDate.of(2020, 1, 5)
-
-          testFormError(formData(date))(
-            "multipleDisposalsCompletionDate.error.dateOfDeathBeforeTaxYear"
+        "the date entered is before 06-04-2020" in {
+          testFormError(formData(LocalDate.of(2020, 1, 5)))(
+            "multipleDisposalsCompletionDate.error.tooFarInPast"
           )
         }
 
@@ -4432,7 +4442,7 @@ class MultipleDisposalsTriageControllerSpec
 
       "not redirect to the asset types not implemented page" when {
 
-        "the user selects a valid combination of asset types" ignore {
+        "the user selects a valid combination of asset types" in {
           val invalidAssetTypes = List(
             List(AssetType.IndirectDisposal, AssetType.MixedUse),
             List(AssetType.MixedUse, AssetType.IndirectDisposal)


### PR DESCRIPTION
This PR is to update test fixtures to match the workflow changes that were introduced. Off the 28, only one test was no longer relevant as it was covered by another updated test fixture. 

Tests being ignored fell into following cases and fixtures updated accordingly to re-enable them

- **ControllerSpec**: 
Following commit introduced a change to capture missing messages as part of tests. However, it hasn't catered for cases with parameterised messages and how the page rendering (rendered html) will report missing message for the actual message (than the key). Rather than handling those cases, tests were ignored
 `modivilioglu* 22/05/2020, 10:56 [CPDP-1631] - Add tests to discover missing messages (#549)`
Fix is so that we cater for those cases and ignore looking for `not_found_message` key. Ideal way would be to let the individual test cases to pass in a different key to verify the change.

- **FurtherReturnCalculationEligibilityUtilSpec**: 
As part of the change in below commit, there was a change to workflow to filter previous tax years. 
`DCWL-107: Fix for YTD liability calculation LIVE issue (#1023) rambabu-posa* 28/04/2021, 12:03`
Rather than updating the test fixtures to setup the returns accordingly, they were ignored. Changes to tests have been to not filter all returns so that the workflows can be tested accordingly

- **HomePageControllerSpec**: 
As part of change in below commit, there was a change to update return status.
`DLS-4223: SA Question BackwardCompatibility for Amends journey (#1030) rambabu-posa* 12/05/2021, 09:54`
Tests haven't been updated to reflect that and were instead ignored. This has now been fixed with relevant mocks setup

- **MultipleDisposalsTriageControllerSpec**
As part of the change in below commit, some of the tests were ignored rather than updating the test fixtures with relevant mocks for tax year. They have been updated accordingly.
`rambabu-posa* 06/06/2022, 13:00 DLS-5172: Frontend work to make functionality operate for a sequence of tax year.`

- **RepresenteeControllerSpec**
Change to `confirm_person` page over the period on back of a commented test case (line 1626 of above spec) meant the css selections for doc verification were out of date. These have been updated accordingly

