### PR TITLE
DLS-9273: Changed positioning of manual address entry link

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/select_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/select_address.scala.html
@@ -92,9 +92,6 @@
  }
  <span class="govuk-caption-xl">@messages(addressJourneyType.captionMessageKey())</span>
 
-    <p class="govuk-body">
-        <a class="govuk-link" href="@{enterUkAddress.url}">@messages("address.manual.linkText")</a>
-    </p>
  @formWrapper(submit) {
    @govukRadios(Radios(
      fieldset = Some(Fieldset(
@@ -104,20 +101,27 @@
          isPageHeading = true
        ))
      )),
-     name = key,
-     items = addresses.zipWithIndex.map { case (option, index) =>
-       RadioItem(
-         content = HtmlContent(addressDisplay(option, Line)),
-         value = Some(index.toString),
-         checked = form.value.map(addresses.indexOf(_)).contains(index)
-       )
-     },
-     errorMessage = form.error(key).map(e =>
-       ErrorMessage(
-         content = Text(messages(s"$key${journeyErrorKey.stripSuffix(".")}${userKey.stripSuffix(".")}.${e.message}"))
-       )
-     )
    ))
+
+     <p class="govuk-body">
+         <a class="govuk-link" href="@{enterUkAddress.url}">@messages("address.manual.linkText")</a>
+     </p>
+
+     @govukRadios(Radios(
+         name = key,
+         items = addresses.zipWithIndex.map { case (option, index) =>
+             RadioItem(
+                 content = HtmlContent(addressDisplay(option, Line)),
+                 value = Some(index.toString),
+                 checked = form.value.map(addresses.indexOf(_)).contains(index)
+             )
+         },
+         errorMessage = form.error(key).map(e =>
+             ErrorMessage(
+                 content = Text(messages(s"$key${journeyErrorKey.stripSuffix(".")}${userKey.stripSuffix(".")}.${e.message}"))
+             )
+         )
+     ))
 
 
    @govukButton(Button(


### PR DESCRIPTION
According to a guide, the manual address entry link should be between the first input field and H1. Previously it was just under the caption before H1

![image](https://github.com/hmrc/cgt-property-disposals-frontend/assets/112881943/87dcc7d1-85a8-41b1-96ae-ed33937610c1)


![image](https://github.com/hmrc/cgt-property-disposals-frontend/assets/112881943/c6190d8e-adb6-48da-aa5a-295d1e28b395)
