### PR TITLE
DLS-10554 Partial removal of shapeless and saving shapeless results to speed up compilation

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsService.scala
@@ -621,14 +621,14 @@ class ReturnsServiceImpl @Inject() (
   def listReturns(cgtReference: CgtReference)(implicit
     hc: HeaderCarrier
   ): EitherT[Future, Error, List[ReturnSummary]] = {
-    val today    = LocalDate.now()
+    val today          = LocalDate.now()
     // fromDate must be current tax year minus 4 years
     val currentTaxYear = TaxYear.thisTaxYearStartDate().getYear
-    val fromDate = TimeUtils.getTaxYearStartDate(currentTaxYear - 4)
+    val fromDate       = TimeUtils.getTaxYearStartDate(currentTaxYear - 4)
     // ETMP build queries from our date range in tax year batches, they have logic to reject an
     // end date that is before the end of the tax year that the toDate falls within, so we need to
     // satisfy this logic by using the end of the current tax year as our toDate
-    val toDate   = TimeUtils.getTaxYearEndDateInclusive(today)
+    val toDate         = TimeUtils.getTaxYearEndDateInclusive(today)
     connector.listReturns(cgtReference, fromDate, toDate).subflatMap { response =>
       if (response.status === OK) {
         response

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       %% "sbt-auto-build"        % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"       %% "sbt-auto-build"        % "3.22.0")
 addSbtPlugin("uk.gov.hmrc"       %% "sbt-distributables"    % "2.5.0")
 addSbtPlugin("org.playframework" %% "sbt-plugin"            % "3.0.2")
 addSbtPlugin("org.scalameta"     %% "sbt-scalafmt"          % "2.4.0")

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/Common.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/Common.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
+
+import org.scalacheck.Gen
+import org.scalacheck.ScalacheckShapeless._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.CompleteAcquisitionDetailsAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalDetailsAnswers.CompleteDisposalDetailsAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExamplePropertyDetailsAnswers.CompleteExamplePropertyDetailsAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLossesAnswers.CompleteExemptionAndLossesAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MultipleDisposalsTriageAnswers.CompleteMultipleDisposalsTriageAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.CompleteRepresenteeAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.CompleteSingleDisposalTriageAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SupportingEvidenceAnswers.CompleteSupportingEvidenceAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.CompleteNonCalculatedYTDAnswers
+
+trait Common extends GenUtils {
+  val completeMultipleDisposalsTriageAnswers: Gen[CompleteMultipleDisposalsTriageAnswers] =
+    gen[CompleteMultipleDisposalsTriageAnswers]
+  val completeSingleDisposalTriageAnswers: Gen[CompleteSingleDisposalTriageAnswers]       =
+    gen[CompleteSingleDisposalTriageAnswers]
+  val examplePropertyDetailsAnswers: Gen[CompleteExamplePropertyDetailsAnswers]           =
+    gen[CompleteExamplePropertyDetailsAnswers]
+  val exemptionAndLossesAnswers: Gen[CompleteExemptionAndLossesAnswers]                   = gen[CompleteExemptionAndLossesAnswers]
+  val yearToDateLiabilityAnswers: Gen[CompleteNonCalculatedYTDAnswers]                    = gen[CompleteNonCalculatedYTDAnswers]
+  val supportingDocumentAnswers: Gen[CompleteSupportingEvidenceAnswers]                   = gen[CompleteSupportingEvidenceAnswers]
+  val representeeAnswers: Gen[CompleteRepresenteeAnswers]                                 = gen[CompleteRepresenteeAnswers]
+  val disposalDetails: Gen[CompleteDisposalDetailsAnswers]                                = gen[CompleteDisposalDetailsAnswers]
+  val acquisitionDetails: Gen[CompleteAcquisitionDetailsAnswers]                          = gen[CompleteAcquisitionDetailsAnswers]
+}

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
@@ -18,22 +18,42 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
 import org.scalacheck.ScalacheckShapeless._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.CompleteAcquisitionDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.{CompleteMultipleDisposalsReturn, CompleteMultipleIndirectDisposalReturn, CompleteSingleDisposalReturn, CompleteSingleIndirectDisposalReturn, CompleteSingleMixedUseDisposalReturn}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalDetailsAnswers.CompleteDisposalDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExampleCompanyDetailsAnswers.CompleteExampleCompanyDetailsAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExamplePropertyDetailsAnswers.CompleteExamplePropertyDetailsAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLossesAnswers.CompleteExemptionAndLossesAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MixedUsePropertyDetailsAnswers.CompleteMixedUsePropertyDetailsAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MultipleDisposalsTriageAnswers.CompleteMultipleDisposalsTriageAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.CompleteRepresenteeAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.CompleteSingleDisposalTriageAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SupportingEvidenceAnswers.CompleteSupportingEvidenceAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.CalculatedYTDAnswers.CompleteCalculatedYTDAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.CompleteNonCalculatedYTDAnswers
 
-object CompleteReturnGen extends LowerPriorityCompleteReturnGen with GenUtils {
+object CompleteReturnGen extends LowerPriorityCompleteReturnGen {
 
-  implicit val completeSingleDisposalReturnGen: Gen[CompleteSingleDisposalReturn] = gen[CompleteSingleDisposalReturn]
+  implicit val completeSingleDisposalReturnGen: Gen[CompleteSingleDisposalReturn] =
+    for {
+      triageAnswers              <- completeSingleDisposalTriageAnswers
+      propertyAddress            <- AddressGen.ukAddressGen
+      disposalDetails            <- disposalDetails
+      acquisitionDetails         <- acquisitionDetails
+      reliefDetails              <- ReliefDetailsGen.completeReliefDetailsAnswersGen
+      exemptionsAndLossesDetails <- ExemptionsAndLossesAnswersGen.completeExemptionAndLossesAnswersGen
+      yearToDateLiabilityAnswers <- gen[Either[CompleteNonCalculatedYTDAnswers, CompleteCalculatedYTDAnswers]]
+      supportingDocumentAnswers  <- supportingDocumentAnswers
+      initialGainOrLoss          <- Gen.option(MoneyGen.amountInPenceGen)
+      representeeAnswers         <- Gen.option(RepresenteeAnswersGen.completeRepresenteeAnswersGen)
+      gainOrLossAfterReliefs     <- Gen.option(MoneyGen.amountInPenceGen)
+      hasAttachments             <- Generators.booleanGen
+    } yield CompleteSingleDisposalReturn(
+      triageAnswers,
+      propertyAddress,
+      disposalDetails,
+      acquisitionDetails,
+      reliefDetails,
+      exemptionsAndLossesDetails,
+      yearToDateLiabilityAnswers,
+      supportingDocumentAnswers,
+      initialGainOrLoss,
+      representeeAnswers,
+      gainOrLossAfterReliefs,
+      hasAttachments
+    )
 
 }
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
@@ -37,17 +37,7 @@ object CompleteReturnGen extends LowerPriorityCompleteReturnGen with GenUtils {
 
 }
 
-trait LowerPriorityCompleteReturnGen { this: GenUtils =>
-
-  private val completeMultipleDisposalsTriageAnswers = gen[CompleteMultipleDisposalsTriageAnswers]
-  private val completeSingleDisposalTriageAnswers    = gen[CompleteSingleDisposalTriageAnswers]
-  private val examplePropertyDetailsAnswers          = gen[CompleteExamplePropertyDetailsAnswers]
-  private val exemptionAndLossesAnswers              = gen[CompleteExemptionAndLossesAnswers]
-  private val yearToDateLiabilityAnswers             = gen[CompleteNonCalculatedYTDAnswers]
-  private val supportingDocumentAnswers              = gen[CompleteSupportingEvidenceAnswers]
-  private val representeeAnswers                     = gen[CompleteRepresenteeAnswers]
-  private val disposalDetails                        = gen[CompleteDisposalDetailsAnswers]
-  private val acquisitionDetails                     = gen[CompleteAcquisitionDetailsAnswers]
+trait LowerPriorityCompleteReturnGen extends Common {
 
   implicit val completeMultipleDisposalsReturnGen: Gen[CompleteMultipleDisposalsReturn] = for {
     triageAnswers                 <- completeMultipleDisposalsTriageAnswers

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
@@ -18,7 +18,18 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
 import org.scalacheck.ScalacheckShapeless._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.CompleteAcquisitionDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.{CompleteMultipleDisposalsReturn, CompleteMultipleIndirectDisposalReturn, CompleteSingleDisposalReturn, CompleteSingleIndirectDisposalReturn, CompleteSingleMixedUseDisposalReturn}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalDetailsAnswers.CompleteDisposalDetailsAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExampleCompanyDetailsAnswers.CompleteExampleCompanyDetailsAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExamplePropertyDetailsAnswers.CompleteExamplePropertyDetailsAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLossesAnswers.CompleteExemptionAndLossesAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MixedUsePropertyDetailsAnswers.CompleteMixedUsePropertyDetailsAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MultipleDisposalsTriageAnswers.CompleteMultipleDisposalsTriageAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.CompleteRepresenteeAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.CompleteSingleDisposalTriageAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SupportingEvidenceAnswers.CompleteSupportingEvidenceAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.CompleteNonCalculatedYTDAnswers
 
 object CompleteReturnGen extends LowerPriorityCompleteReturnGen with GenUtils {
 
@@ -28,16 +39,102 @@ object CompleteReturnGen extends LowerPriorityCompleteReturnGen with GenUtils {
 
 trait LowerPriorityCompleteReturnGen { this: GenUtils =>
 
-  implicit val completeMultipleDisposalsReturnGen: Gen[CompleteMultipleDisposalsReturn] =
-    gen[CompleteMultipleDisposalsReturn]
+  private val completeMultipleDisposalsTriageAnswers = gen[CompleteMultipleDisposalsTriageAnswers]
+  private val completeSingleDisposalTriageAnswers    = gen[CompleteSingleDisposalTriageAnswers]
+  private val examplePropertyDetailsAnswers          = gen[CompleteExamplePropertyDetailsAnswers]
+  private val exemptionAndLossesAnswers              = gen[CompleteExemptionAndLossesAnswers]
+  private val yearToDateLiabilityAnswers             = gen[CompleteNonCalculatedYTDAnswers]
+  private val supportingDocumentAnswers              = gen[CompleteSupportingEvidenceAnswers]
+  private val representeeAnswers                     = gen[CompleteRepresenteeAnswers]
+  private val disposalDetails                        = gen[CompleteDisposalDetailsAnswers]
+  private val acquisitionDetails                     = gen[CompleteAcquisitionDetailsAnswers]
 
-  implicit val completeSingleIndirectDisposalReturnGen: Gen[CompleteSingleIndirectDisposalReturn] =
-    gen[CompleteSingleIndirectDisposalReturn]
+  implicit val completeMultipleDisposalsReturnGen: Gen[CompleteMultipleDisposalsReturn] = for {
+    triageAnswers                 <- completeMultipleDisposalsTriageAnswers
+    examplePropertyDetailsAnswers <- examplePropertyDetailsAnswers
+    exemptionAndLossesAnswers     <- exemptionAndLossesAnswers
+    yearToDateLiabilityAnswers    <- yearToDateLiabilityAnswers
+    supportingDocumentAnswers     <- supportingDocumentAnswers
+    representeeAnswers            <- Gen.option(representeeAnswers)
+    gainOrLossAfterReliefs        <- Gen.option(MoneyGen.amountInPenceGen)
+    hasAttachments                <- Generators.booleanGen
+  } yield CompleteMultipleDisposalsReturn(
+    triageAnswers,
+    examplePropertyDetailsAnswers,
+    exemptionAndLossesAnswers,
+    yearToDateLiabilityAnswers,
+    supportingDocumentAnswers,
+    representeeAnswers,
+    gainOrLossAfterReliefs,
+    hasAttachments
+  )
 
-  implicit val completeMultipleIndirectDisposalReturnGen: Gen[CompleteMultipleIndirectDisposalReturn] =
-    gen[CompleteMultipleIndirectDisposalReturn]
+  implicit val completeSingleIndirectDisposalReturnGen: Gen[CompleteSingleIndirectDisposalReturn] = {
+    for {
+      triageAnswers              <- completeSingleDisposalTriageAnswers
+      companyAddress             <- AddressGen.addressGen
+      disposalDetails            <- disposalDetails
+      acquisitionDetails         <- acquisitionDetails
+      exemptionsAndLossesDetails <- exemptionAndLossesAnswers
+      yearToDateLiabilityAnswers <- yearToDateLiabilityAnswers
+      supportingDocumentAnswers  <- supportingDocumentAnswers
+      representeeAnswers         <- Gen.option(representeeAnswers)
+      gainOrLossAfterReliefs     <- Gen.option(MoneyGen.amountInPenceGen)
+      hasAttachments             <- Generators.booleanGen
+    } yield CompleteSingleIndirectDisposalReturn(
+      triageAnswers,
+      companyAddress,
+      disposalDetails,
+      acquisitionDetails,
+      exemptionsAndLossesDetails,
+      yearToDateLiabilityAnswers,
+      supportingDocumentAnswers,
+      representeeAnswers,
+      gainOrLossAfterReliefs,
+      hasAttachments
+    )
+  }
 
-  implicit val completeSingleMixedUseDisposalReturnGen: Gen[CompleteSingleMixedUseDisposalReturn] =
-    gen[CompleteSingleMixedUseDisposalReturn]
+  implicit val completeMultipleIndirectDisposalReturnGen: Gen[CompleteMultipleIndirectDisposalReturn] = for {
+    triageAnswers                <- completeMultipleDisposalsTriageAnswers
+    exampleCompanyDetailsAnswers <- gen[CompleteExampleCompanyDetailsAnswers]
+    exemptionsAndLossesDetails   <- exemptionAndLossesAnswers
+    yearToDateLiabilityAnswers   <- yearToDateLiabilityAnswers
+    supportingDocumentAnswers    <- supportingDocumentAnswers
+    representeeAnswers           <- Gen.option(representeeAnswers)
+    gainOrLossAfterReliefs       <- Gen.option(MoneyGen.amountInPenceGen)
+    hasAttachments               <- Generators.booleanGen
+  } yield CompleteMultipleIndirectDisposalReturn(
+    triageAnswers,
+    exampleCompanyDetailsAnswers,
+    exemptionsAndLossesDetails,
+    yearToDateLiabilityAnswers,
+    supportingDocumentAnswers,
+    representeeAnswers,
+    gainOrLossAfterReliefs,
+    hasAttachments
+  )
+
+  implicit val completeSingleMixedUseDisposalReturnGen: Gen[CompleteSingleMixedUseDisposalReturn] = {
+    for {
+      triageAnswers              <- completeSingleDisposalTriageAnswers
+      propertyDetailsAnswers     <- gen[CompleteMixedUsePropertyDetailsAnswers]
+      exemptionsAndLossesDetails <- exemptionAndLossesAnswers
+      yearToDateLiabilityAnswers <- yearToDateLiabilityAnswers
+      supportingDocumentAnswers  <- supportingDocumentAnswers
+      representeeAnswers         <- Gen.option(representeeAnswers)
+      gainOrLossAfterReliefs     <- Gen.option(MoneyGen.amountInPenceGen)
+      hasAttachments             <- Generators.booleanGen
+    } yield CompleteSingleMixedUseDisposalReturn(
+      triageAnswers,
+      propertyDetailsAnswers,
+      exemptionsAndLossesDetails,
+      yearToDateLiabilityAnswers,
+      supportingDocumentAnswers,
+      representeeAnswers,
+      gainOrLossAfterReliefs,
+      hasAttachments
+    )
+  }
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DraftReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DraftReturnGen.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
+import java.time.LocalDate
 
 object DraftReturnGen extends HigherPriorityDraftReturnGen with GenUtils
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DraftReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DraftReturnGen.scala
@@ -16,31 +16,168 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import org.scalacheck.Gen
 import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 
 object DraftReturnGen extends HigherPriorityDraftReturnGen with GenUtils
 
-trait HigherPriorityDraftReturnGen extends LowerPriorityDraftReturnGen { this: GenUtils =>
-  implicit val draftReturnGen: Gen[DraftReturn] = gen[DraftReturn]
+trait HigherPriorityDraftReturnGen extends LowerPriorityDraftReturnGen {
+  implicit val singleDisposalDraftReturnGen: Gen[DraftSingleDisposalReturn] = singleDisposalDraftReturnGen2
 
-  implicit val singleDisposalDraftReturnGen: Gen[DraftSingleDisposalReturn] =
-    gen[DraftSingleDisposalReturn]
-
+  implicit val draftReturnGen: Gen[DraftReturn] = Gen.oneOf(
+    singleDisposalDraftReturnGen,
+    singleIndirectDisposalDraftReturnGen,
+    singleMixedUseDraftReturnGen,
+    multipleDisposalDraftReturnGen,
+    multipleIndirectDisposalDraftReturnGen
+  )
 }
 
-trait LowerPriorityDraftReturnGen { this: GenUtils =>
+trait LowerPriorityDraftReturnGen extends GenUtils {
 
-  implicit val multipleDisposalDraftReturnGen: Gen[DraftMultipleDisposalsReturn] = gen[DraftMultipleDisposalsReturn]
+  val triageAnswersGen: Gen[SingleDisposalTriageAnswers]             = gen[SingleDisposalTriageAnswers]
+  private val supportingEvidenceGen: Gen[SupportingEvidenceAnswers]  = gen[SupportingEvidenceAnswers]
+  private val exemptionsAndLossesAnswersGen                          = Gen.oneOf(
+    ExemptionsAndLossesAnswersGen.completeExemptionAndLossesAnswersGen,
+    ExemptionsAndLossesAnswersGen.incompleteExemptionAndLossesAnswersGen
+  )
+  private val disposalDetailsAnswersGen: Gen[DisposalDetailsAnswers] =
+    Gen.oneOf(
+      DisposalDetailsGen.completeDisposalDetailsAnswersGen,
+      DisposalDetailsGen.incompleteDisposalDetailsAnswersGen
+    )
+  private val acquisitionDetailsAnswersGen                           = gen[AcquisitionDetailsAnswers]
 
-  implicit val multipleIndirectDisposalDraftReturnGen: Gen[DraftMultipleIndirectDisposalsReturn] =
-    gen[DraftMultipleIndirectDisposalsReturn]
+  val singleDisposalDraftReturnGen2: Gen[DraftSingleDisposalReturn] =
+    for {
+      id                         <- Gen.uuid
+      triageAnswers              <- triageAnswersGen
+      propertyAddress            <- Gen.option(AddressGen.ukAddressGen)
+      disposalDetailsAnswers     <- Gen.option(disposalDetailsAnswersGen)
+      acquisitionDetailsAnswers  <- Gen.option(acquisitionDetailsAnswersGen)
+      reliefDetailsAnswers       <- Gen.option(gen[ReliefDetailsAnswers])
+      exemptionAndLossesAnswers  <- Gen.option(exemptionsAndLossesAnswersGen)
+      yearToDateLiabilityAnswers <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
+      initialGainOrLoss          <- Gen.option(MoneyGen.amountInPenceGen)
+      supportingEvidenceAnswers  <- Gen.option(supportingEvidenceGen)
+      representeeAnswers         <- Gen.option(RepresenteeAnswersGen.representeeAnswersGen)
+      gainOrLossAfterReliefs     <- Gen.option(MoneyGen.amountInPenceGen)
+      lastUpdatedDate            <- Arbitrary.arbitrary[LocalDate]
+    } yield DraftSingleDisposalReturn(
+      id,
+      triageAnswers,
+      propertyAddress,
+      disposalDetailsAnswers,
+      acquisitionDetailsAnswers,
+      reliefDetailsAnswers,
+      exemptionAndLossesAnswers,
+      yearToDateLiabilityAnswers,
+      initialGainOrLoss,
+      supportingEvidenceAnswers,
+      representeeAnswers,
+      gainOrLossAfterReliefs,
+      lastUpdatedDate
+    )
+
+  val multipleTriageGen = gen[MultipleDisposalsTriageAnswers]
+
+  implicit val multipleDisposalDraftReturnGen: Gen[DraftMultipleDisposalsReturn] = {
+    for {
+      id                            <- Gen.uuid
+      triageAnswers                 <- multipleTriageGen
+      examplePropertyDetailsAnswers <- Gen.option(gen[ExamplePropertyDetailsAnswers])
+      exemptionAndLossesAnswers     <- Gen.option(exemptionsAndLossesAnswersGen)
+      yearToDateLiabilityAnswers    <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
+      supportingEvidenceAnswers     <- Gen.option(supportingEvidenceGen)
+      representeeAnswers            <- Gen.option(RepresenteeAnswersGen.representeeAnswersGen)
+      gainOrLossAfterReliefs        <- Gen.option(MoneyGen.amountInPenceGen)
+      lastUpdatedDate               <- Arbitrary.arbitrary[LocalDate]
+    } yield DraftMultipleDisposalsReturn(
+      id,
+      triageAnswers,
+      examplePropertyDetailsAnswers,
+      exemptionAndLossesAnswers,
+      yearToDateLiabilityAnswers,
+      supportingEvidenceAnswers,
+      representeeAnswers,
+      gainOrLossAfterReliefs,
+      lastUpdatedDate
+    )
+  }
+
+  implicit val multipleIndirectDisposalDraftReturnGen: Gen[DraftMultipleIndirectDisposalsReturn] = {
+    for {
+      id                           <- Gen.uuid
+      triageAnswers                <- multipleTriageGen
+      exampleCompanyDetailsAnswers <- Gen.option(gen[ExampleCompanyDetailsAnswers])
+      exemptionAndLossesAnswers    <- Gen.option(exemptionsAndLossesAnswersGen)
+      yearToDateLiabilityAnswers   <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
+      supportingEvidenceAnswers    <- Gen.option(supportingEvidenceGen)
+      representeeAnswers           <- Gen.option(RepresenteeAnswersGen.representeeAnswersGen)
+      gainOrLossAfterReliefs       <- Gen.option(MoneyGen.amountInPenceGen)
+      lastUpdatedDate              <- Arbitrary.arbitrary[LocalDate]
+    } yield DraftMultipleIndirectDisposalsReturn(
+      id,
+      triageAnswers,
+      exampleCompanyDetailsAnswers,
+      exemptionAndLossesAnswers,
+      yearToDateLiabilityAnswers,
+      supportingEvidenceAnswers,
+      representeeAnswers,
+      gainOrLossAfterReliefs,
+      lastUpdatedDate
+    )
+  }
 
   implicit val singleIndirectDisposalDraftReturnGen: Gen[DraftSingleIndirectDisposalReturn] =
-    gen[DraftSingleIndirectDisposalReturn]
+    for {
+      id                         <- Gen.uuid
+      triageAnswers              <- triageAnswersGen
+      companyAddress             <- Gen.option(AddressGen.addressGen)
+      disposalDetailsAnswers     <- Gen.option(disposalDetailsAnswersGen)
+      acquisitionDetailsAnswers  <- Gen.option(acquisitionDetailsAnswersGen)
+      exemptionAndLossesAnswers  <- Gen.option(exemptionsAndLossesAnswersGen)
+      yearToDateLiabilityAnswers <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
+      supportingEvidenceAnswers  <- Gen.option(supportingEvidenceGen)
+      representeeAnswers         <- Gen.option(RepresenteeAnswersGen.representeeAnswersGen)
+      gainOrLossAfterReliefs     <- Gen.option(MoneyGen.amountInPenceGen)
+      lastUpdatedDate            <- Arbitrary.arbitrary[LocalDate]
+    } yield DraftSingleIndirectDisposalReturn(
+      id,
+      triageAnswers,
+      companyAddress,
+      disposalDetailsAnswers,
+      acquisitionDetailsAnswers,
+      exemptionAndLossesAnswers,
+      yearToDateLiabilityAnswers,
+      supportingEvidenceAnswers,
+      representeeAnswers,
+      gainOrLossAfterReliefs,
+      lastUpdatedDate
+    )
 
   implicit val singleMixedUseDraftReturnGen: Gen[DraftSingleMixedUseDisposalReturn] =
-    gen[DraftSingleMixedUseDisposalReturn]
+    for {
+      id                             <- Gen.uuid
+      triageAnswers                  <- triageAnswersGen
+      mixedUsePropertyDetailsAnswers <- Gen.option(gen[MixedUsePropertyDetailsAnswers])
+      exemptionAndLossesAnswers      <- Gen.option(exemptionsAndLossesAnswersGen)
+      yearToDateLiabilityAnswers     <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
+      supportingEvidenceAnswers      <- Gen.option(supportingEvidenceGen)
+      representeeAnswers             <- Gen.option(RepresenteeAnswersGen.representeeAnswersGen)
+      gainOrLossAfterReliefs         <- Gen.option(MoneyGen.amountInPenceGen)
+      lastUpdatedDate                <- Arbitrary.arbitrary[LocalDate]
+    } yield DraftSingleMixedUseDisposalReturn(
+      id,
+      triageAnswers,
+      mixedUsePropertyDetailsAnswers,
+      exemptionAndLossesAnswers,
+      yearToDateLiabilityAnswers,
+      supportingEvidenceAnswers,
+      representeeAnswers,
+      gainOrLossAfterReliefs,
+      lastUpdatedDate
+    )
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/IdGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/IdGen.scala
@@ -17,26 +17,25 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.UploadReference
 
 object IdGen extends GenUtils {
 
-  implicit val cgtReferenceArb: Gen[CgtReference] = gen[CgtReference]
+  implicit val cgtReferenceArb: Gen[CgtReference] = Generators.stringGen.map(CgtReference(_))
 
-  implicit val ggCredIdGen: Gen[GGCredId] = gen[GGCredId]
+  implicit val ggCredIdGen: Gen[GGCredId] = Generators.stringGen.map(GGCredId(_))
 
-  implicit val ninoGen: Gen[NINO] = gen[NINO]
+  implicit val ninoGen: Gen[NINO] = Generators.stringGen.map(NINO(_))
 
-  implicit val sautrGen: Gen[SAUTR] = gen[SAUTR]
+  implicit val sautrGen: Gen[SAUTR] = Generators.stringGen.map(SAUTR(_))
 
-  implicit val sapNumberGen: Gen[SapNumber] = gen[SapNumber]
+  implicit val sapNumberGen: Gen[SapNumber] = Generators.stringGen.map(SapNumber(_))
 
-  implicit val arnGen: Gen[AgentReferenceNumber] = gen[AgentReferenceNumber]
+  implicit val arnGen: Gen[AgentReferenceNumber] = Generators.stringGen.map(AgentReferenceNumber(_))
 
-  implicit val draftReturnIdGen: Gen[DraftReturnId] = gen[DraftReturnId]
+  implicit val draftReturnIdGen: Gen[DraftReturnId] = Generators.stringGen.map(DraftReturnId(_))
 
-  implicit val uploadReferenceGen: Gen[UploadReference] = gen[UploadReference]
+  implicit val uploadReferenceGen: Gen[UploadReference] = Generators.stringGen.map(UploadReference(_))
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
@@ -18,17 +18,46 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 import org.scalacheck.Gen
 import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.{IndividualMissingEmail, IndividualSupplyingInformation, RegistrationReady}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.{IndividualMissingEmail, IndividualSupplyingInformation, IndividualWantsToRegisterTrust, RegistrationReady}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.SubscriptionReady
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubmittingReturn
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, JustSubmittedReturn, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, Subscribed, ViewingReturn}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, SubmittingReturn, Subscribed, ViewingReturn}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionResponse.SubscriptionSuccessful
 
 object JourneyStatusGen extends JourneyStatusLowerPriorityGen with GenUtils {
-  implicit val subscriptionReadyGen: Gen[SubscriptionReady] =
-    gen[SubscriptionReady]
+  implicit val subscriptionReadyGen: Gen[SubscriptionReady] = for {
+    subscriptionDetails <- OnboardingDetailsGen.subscriptionDetailsArb
+    ggCredId            <- IdGen.ggCredIdGen
+  } yield SubscriptionReady(subscriptionDetails, ggCredId)
 
-  implicit val journeyStatusGen: Gen[JourneyStatus] = gen[JourneyStatus]
+  private val registrationStatusGen = Gen.oneOf(
+    gen[IndividualWantsToRegisterTrust],
+    gen[IndividualSupplyingInformation],
+    gen[IndividualMissingEmail],
+    gen[RegistrationReady]
+  )
+
+  implicit val journeyStatusGen: Gen[JourneyStatus] = Gen.oneOf(
+    subscriptionReadyGen,
+    individualSupplyingInformationGen,
+    subscribedGen,
+    individualMissingEmailGen,
+    registrationReadyGen,
+    startingNewDraftReturnGen,
+    fillingOutReturnGen,
+    justSubmittedReturnGen,
+    viewingReturnGen,
+    submitReturnFailedGen,
+    submittingReturn,
+    startingToAmendReturnGen,
+    gen[NewEnrolmentCreatedForMissingEnrolment],
+    gen[AlreadySubscribedWithDifferentGGAccount],
+    gen[RegistrationStatus],
+    Gen.const(NonGovernmentGatewayJourney),
+    Gen.const(AgentWithoutAgentEnrolment),
+    registrationStatusGen
+  )
 
 }
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
@@ -32,13 +32,6 @@ object JourneyStatusGen extends JourneyStatusLowerPriorityGen with GenUtils {
 
 }
 
-trait JourneyStatusHigherPriorityGen extends JourneyStatusLowerPriorityGen { this: GenUtils =>
-  implicit val journeyStatusGen: Gen[JourneyStatus] = gen[JourneyStatus]
-
-  implicit val subscriptionReadyGen: Gen[SubscriptionReady] =
-    gen[SubscriptionReady]
-}
-
 trait JourneyStatusLowerPriorityGen { this: GenUtils =>
 
   implicit val subscriptionSuccessfulGen: Gen[SubscriptionSuccessful] =

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
@@ -64,8 +64,6 @@ object JourneyStatusGen extends JourneyStatusLowerPriorityGen with GenUtils {
 trait JourneyStatusLowerPriorityGen extends GenUtils {
 
   private val agentReferenceNumberGen = gen[AgentReferenceNumber]
-  private val returnSummaryGen        = gen[ReturnSummary]
-  private val completeReturnGen       = gen[CompleteReturn]
 
   implicit val subscriptionSuccessfulGen: Gen[SubscriptionSuccessful] =
     gen[SubscriptionSuccessful]
@@ -85,7 +83,7 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
       ggCredId             <- IdGen.ggCredIdGen
       agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
       draftReturns         <- Gen.listOf(DraftReturnGen.draftReturnGen)
-      sentReturns          <- Gen.listOf(returnSummaryGen)
+      sentReturns          <- Gen.listOf(ReturnGen.returnSummaryGen)
     } yield Subscribed(subscribedDetails, ggCredId, agentReferenceNumber, draftReturns, sentReturns)
   }
 
@@ -137,7 +135,7 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
       subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId             <- IdGen.ggCredIdGen
       agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
-      completeReturn       <- completeReturnGen
+      completeReturn       <- ReturnGen.completeReturnGen
       submissionResponse   <- gen[SubmitReturnResponse]
       amendReturnData      <- Gen.option(ReturnGen.amendReturnDataGen)
     } yield JustSubmittedReturn(
@@ -156,9 +154,9 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
       subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId             <- IdGen.ggCredIdGen
       agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
-      completeReturn       <- completeReturnGen
+      completeReturn       <- ReturnGen.completeReturnGen
       returnType           <- ReturnGen.returnTypeGen
-      returnSummary        <- returnSummaryGen
+      returnSummary        <- ReturnGen.returnSummaryGen
       previousSentReturns  <- Gen.option(previousReturnDataGen)
     } yield ViewingReturn(
       subscribedDetails,

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
@@ -20,10 +20,10 @@ import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.{IndividualMissingEmail, IndividualSupplyingInformation, IndividualWantsToRegisterTrust, RegistrationReady}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.SubscriptionReady
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, SubmittingReturn, Subscribed, ViewingReturn}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionDetails
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, PreviousReturnData, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, SubmittingReturn, Subscribed, ViewingReturn}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.AgentReferenceNumber
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionResponse.SubscriptionSuccessful
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 
 object JourneyStatusGen extends JourneyStatusLowerPriorityGen with GenUtils {
   implicit val subscriptionReadyGen: Gen[SubscriptionReady] = for {
@@ -61,40 +61,146 @@ object JourneyStatusGen extends JourneyStatusLowerPriorityGen with GenUtils {
 
 }
 
-trait JourneyStatusLowerPriorityGen { this: GenUtils =>
+trait JourneyStatusLowerPriorityGen extends GenUtils {
+
+  private val agentReferenceNumberGen = gen[AgentReferenceNumber]
+  private val returnSummaryGen        = gen[ReturnSummary]
+  private val completeReturnGen       = gen[CompleteReturn]
 
   implicit val subscriptionSuccessfulGen: Gen[SubscriptionSuccessful] =
     gen[SubscriptionSuccessful]
 
   implicit val individualSupplyingInformationGen: Gen[IndividualSupplyingInformation] =
-    gen[IndividualSupplyingInformation]
+    for {
+      name        <- Gen.option(NameGen.individualNameGen)
+      address     <- Gen.option(AddressGen.addressGen)
+      email       <- Gen.option(EmailGen.emailGen)
+      emailSource <- Gen.option(EmailGen.emailSourceGen)
+      ggCredId    <- IdGen.ggCredIdGen
+    } yield IndividualSupplyingInformation(name, address, email, emailSource, ggCredId)
 
-  implicit val subscribedGen: Gen[Subscribed] = gen[Subscribed]
+  implicit val subscribedGen: Gen[Subscribed] = {
+    for {
+      subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
+      ggCredId             <- IdGen.ggCredIdGen
+      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      draftReturns         <- Gen.listOf(DraftReturnGen.draftReturnGen)
+      sentReturns          <- Gen.listOf(returnSummaryGen)
+    } yield Subscribed(subscribedDetails, ggCredId, agentReferenceNumber, draftReturns, sentReturns)
+  }
 
-  implicit val individualMissingEmailGen: Gen[IndividualMissingEmail] =
-    gen[IndividualMissingEmail]
+  implicit val individualMissingEmailGen: Gen[IndividualMissingEmail] = for {
+    name     <- NameGen.individualNameGen
+    address  <- AddressGen.addressGen
+    ggCredId <- IdGen.ggCredIdGen
+  } yield IndividualMissingEmail(name, address, ggCredId)
 
   implicit val registrationReadyGen: Gen[RegistrationReady] =
     gen[RegistrationReady]
 
   implicit val startingNewDraftReturnGen: Gen[StartingNewDraftReturn] =
-    gen[StartingNewDraftReturn]
+    for {
+      subscribedDetails      <- SubscribedDetailsGen.subscribedDetailsGen
+      ggCredId               <- IdGen.ggCredIdGen
+      agentReferenceNumber   <- Gen.option(agentReferenceNumberGen)
+      newReturnTriageAnswers <- Gen.either(gen[MultipleDisposalsTriageAnswers], gen[SingleDisposalTriageAnswers])
+      representeeAnswers     <- Gen.option(RepresenteeAnswersGen.representeeAnswersGen)
+      previousSentReturns    <- Gen.option(ReturnGen.previousReturnDataGen)
+    } yield StartingNewDraftReturn(
+      subscribedDetails,
+      ggCredId,
+      agentReferenceNumber,
+      newReturnTriageAnswers,
+      representeeAnswers,
+      previousSentReturns
+    )
 
   implicit val fillingOutReturnGen: Gen[FillingOutReturn] =
-    gen[FillingOutReturn]
+    for {
+      subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
+      ggCredId             <- IdGen.ggCredIdGen
+      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      draftReturn          <- DraftReturnGen.draftReturnGen
+      previousSentReturns  <- Gen.option(ReturnGen.previousReturnDataGen)
+      amendReturnData      <- Gen.option(ReturnGen.amendReturnDataGen)
+    } yield FillingOutReturn(
+      subscribedDetails,
+      ggCredId,
+      agentReferenceNumber,
+      draftReturn,
+      previousSentReturns,
+      amendReturnData
+    )
 
   implicit val justSubmittedReturnGen: Gen[JustSubmittedReturn] =
-    gen[JustSubmittedReturn]
+    for {
+      subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
+      ggCredId             <- IdGen.ggCredIdGen
+      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      completeReturn       <- completeReturnGen
+      submissionResponse   <- gen[SubmitReturnResponse]
+      amendReturnData      <- Gen.option(ReturnGen.amendReturnDataGen)
+    } yield JustSubmittedReturn(
+      subscribedDetails,
+      ggCredId,
+      agentReferenceNumber,
+      completeReturn,
+      submissionResponse,
+      amendReturnData
+    )
 
-  implicit val viewingReturnGen: Gen[ViewingReturn] = gen[ViewingReturn]
+  private val previousReturnDataGen = gen[PreviousReturnData]
+
+  implicit val viewingReturnGen: Gen[ViewingReturn] =
+    for {
+      subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
+      ggCredId             <- IdGen.ggCredIdGen
+      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      completeReturn       <- completeReturnGen
+      returnType           <- ReturnGen.returnTypeGen
+      returnSummary        <- returnSummaryGen
+      previousSentReturns  <- Gen.option(previousReturnDataGen)
+    } yield ViewingReturn(
+      subscribedDetails,
+      ggCredId,
+      agentReferenceNumber,
+      completeReturn,
+      returnType,
+      returnSummary,
+      previousSentReturns
+    )
 
   implicit val submitReturnFailedGen: Gen[SubmitReturnFailed] =
-    gen[SubmitReturnFailed]
+    for {
+      subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
+      ggCredId             <- IdGen.ggCredIdGen
+      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+    } yield SubmitReturnFailed(subscribedDetails, ggCredId, agentReferenceNumber)
 
-  implicit val submittingReturn: Gen[SubmittingReturn] =
-    gen[SubmittingReturn]
+  implicit val submittingReturn: Gen[SubmittingReturn] = for {
+    subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
+    ggCredId             <- IdGen.ggCredIdGen
+    agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+  } yield SubmittingReturn(subscribedDetails, ggCredId, agentReferenceNumber)
 
-  implicit val startingToAmendReturnGen: Gen[StartingToAmendReturn] =
-    gen[StartingToAmendReturn]
+  implicit val startingToAmendReturnGen: Gen[StartingToAmendReturn] = {
+    for {
+      subscribedDetails       <- SubscribedDetailsGen.subscribedDetailsGen
+      ggCredId                <- IdGen.ggCredIdGen
+      agentReferenceNumber    <- Gen.option(agentReferenceNumberGen)
+      originalReturn          <- ReturnGen.completeReturnWithSummaryGen
+      isFirstReturn           <- Generators.booleanGen
+      previousSentReturns     <- Gen.option(previousReturnDataGen)
+      unmetDependencyFieldUrl <- Gen.option(Generators.stringGen)
+    } yield StartingToAmendReturn(
+      subscribedDetails,
+      ggCredId,
+      agentReferenceNumber,
+      originalReturn,
+      isFirstReturn,
+      previousSentReturns,
+      unmetDependencyFieldUrl
+    )
+  }
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnGen.scala
@@ -20,7 +20,8 @@ import org.scalacheck.Gen
 import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.CompleteReturnWithSummary
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.PreviousReturnData
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AmendReturnData, ReturnSummary, ReturnType}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AmendReturnData, CompleteReturn, ReturnSummary, ReturnType}
+
 
 object ReturnGen extends GenUtils {
 
@@ -34,4 +35,5 @@ object ReturnGen extends GenUtils {
 
   implicit val returnTypeGen: Gen[ReturnType] = gen[ReturnType]
 
+  implicit val completeReturnGen: Gen[CompleteReturn] = gen[CompleteReturn]
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnGen.scala
@@ -25,15 +25,29 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AmendReturnData,
 
 object ReturnGen extends GenUtils {
 
+  implicit val completeReturnGen: Gen[CompleteReturn] =
+    Gen.oneOf(
+      CompleteReturnGen.completeSingleDisposalReturnGen,
+      CompleteReturnGen.completeSingleIndirectDisposalReturnGen,
+      CompleteReturnGen.completeSingleMixedUseDisposalReturnGen,
+      CompleteReturnGen.completeMultipleDisposalsReturnGen,
+      CompleteReturnGen.completeMultipleIndirectDisposalReturnGen
+    )
+
   implicit val returnSummaryGen: Gen[ReturnSummary] = gen[ReturnSummary]
 
   implicit val previousReturnDataGen: Gen[PreviousReturnData] = gen[PreviousReturnData]
 
-  implicit val completeReturnWithSummaryGen: Gen[CompleteReturnWithSummary] = gen[CompleteReturnWithSummary]
-
-  implicit val amendReturnDataGen: Gen[AmendReturnData] = gen[AmendReturnData]
-
   implicit val returnTypeGen: Gen[ReturnType] = gen[ReturnType]
 
-  implicit val completeReturnGen: Gen[CompleteReturn] = gen[CompleteReturn]
+  implicit val completeReturnWithSummaryGen: Gen[CompleteReturnWithSummary] = for {
+    completeReturn <- completeReturnGen
+    summary        <- returnSummaryGen
+    returnType     <- returnTypeGen
+  } yield CompleteReturnWithSummary(completeReturn, summary, returnType)
+
+  implicit val amendReturnDataGen: Gen[AmendReturnData] = for {
+    originalReturn                      <- completeReturnWithSummaryGen
+    shouldDisplayGainOrLossAfterReliefs <- Generators.booleanGen
+  } yield AmendReturnData(originalReturn, shouldDisplayGainOrLossAfterReliefs)
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnGen.scala
@@ -22,7 +22,6 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.CompleteReturnWithSummary
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.PreviousReturnData
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AmendReturnData, CompleteReturn, ReturnSummary, ReturnType}
 
-
 object ReturnGen extends GenUtils {
 
   implicit val completeReturnGen: Gen[CompleteReturn] =

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SessionDataGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SessionDataGen.scala
@@ -27,7 +27,7 @@ object SessionDataGen extends GenUtils {
 
   private val emailToBeVerifiedGen: Gen[EmailToBeVerified] = for {
     email                      <- EmailGen.emailGen
-    id                          = UUID.randomUUID()
+    id                         <- Gen.uuid
     verified                   <- Generators.booleanGen
     hasResentVerificationEmail <- Generators.booleanGen
   } yield EmailToBeVerified(email, id, verified, hasResentVerificationEmail)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SessionDataGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SessionDataGen.scala
@@ -17,11 +17,58 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.SessionData
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.AddressLookupResult
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailToBeVerified
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.NeedMoreDetailsDetails
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.NeedMoreDetailsDetails.AffinityGroup
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
 
 object SessionDataGen extends GenUtils {
 
-  implicit val sessionDataGen: Gen[SessionData] = gen[SessionData]
+  private val emailToBeVerifiedGen: Gen[EmailToBeVerified] = for {
+    email                      <- EmailGen.emailGen
+    id                          = UUID.randomUUID()
+    verified                   <- Generators.booleanGen
+    hasResentVerificationEmail <- Generators.booleanGen
+  } yield EmailToBeVerified(email, id, verified, hasResentVerificationEmail)
+
+  private val addressLookupResultGen: Gen[AddressLookupResult] = for {
+    postcode  <- AddressGen.postcodeGen
+    filter    <- Gen.option(Generators.stringGen)
+    addresses <- Gen.listOf(AddressGen.addressGen)
+  } yield AddressLookupResult(postcode, filter, addresses)
+
+  private val needMoreDetailsDetailsGen: Gen[NeedMoreDetailsDetails] = for {
+    continueUrl   <- Generators.stringGen
+    affinityGroup <- Gen.oneOf(AffinityGroup.Individual, AffinityGroup.Organisation)
+  } yield NeedMoreDetailsDetails(continueUrl, affinityGroup)
+
+  private val userTypeGen: Gen[UserType] =
+    Gen.oneOf(
+      UserType.Individual,
+      UserType.Organisation,
+      UserType.NonGovernmentGatewayUser,
+      UserType.Agent
+    )
+
+  private val journeyTypeGen: Gen[JourneyType] =
+    Gen.oneOf(OnBoarding, Returns, Amend)
+
+  implicit val sessionDataGen: Gen[SessionData] =
+    for {
+      journeyStatus          <- Gen.option(JourneyStatusGen.journeyStatusGen)
+      emailToBeVerified      <- Gen.option(emailToBeVerifiedGen)
+      addressLookupResult    <- Gen.option(addressLookupResultGen)
+      needMoreDetailsDetails <- Gen.option(needMoreDetailsDetailsGen)
+      userType               <- Gen.option(userTypeGen)
+      journeyType            <- Gen.option(journeyTypeGen)
+    } yield SessionData(
+      journeyStatus,
+      emailToBeVerified,
+      addressLookupResult,
+      needMoreDetailsDetails,
+      userType,
+      journeyType
+    )
 
 }


### PR DESCRIPTION
Focusing on the following step: "Test / clean" "Test / compile"

Before: 290-300s
After: 85s

Memory consumption stays under 700mb.

We can go further, but that's a start.