### PR TITLE
DLS-10554 Even less shapeless and more sharing

### DIFF
--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/Common.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/Common.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.CompleteAcquisitionDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalDetailsAnswers.CompleteDisposalDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLossesAnswers.CompleteExemptionAndLossesAnswers
@@ -26,10 +25,14 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SupportingEvidenc
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.CompleteNonCalculatedYTDAnswers
 
 trait Common extends GenUtils {
-  val exemptionAndLossesAnswers: Gen[CompleteExemptionAndLossesAnswers] = gen[CompleteExemptionAndLossesAnswers]
-  val yearToDateLiabilityAnswers: Gen[CompleteNonCalculatedYTDAnswers]  = gen[CompleteNonCalculatedYTDAnswers]
-  val supportingDocumentAnswers: Gen[CompleteSupportingEvidenceAnswers] = gen[CompleteSupportingEvidenceAnswers]
-  val representeeAnswers: Gen[CompleteRepresenteeAnswers]               = gen[CompleteRepresenteeAnswers]
-  val disposalDetails: Gen[CompleteDisposalDetailsAnswers]              = gen[CompleteDisposalDetailsAnswers]
-  val acquisitionDetails: Gen[CompleteAcquisitionDetailsAnswers]        = gen[CompleteAcquisitionDetailsAnswers]
+  val exemptionAndLossesAnswers: Gen[CompleteExemptionAndLossesAnswers] =
+    ExemptionsAndLossesAnswersGen.completeExemptionAndLossesAnswersGen
+  val yearToDateLiabilityAnswers: Gen[CompleteNonCalculatedYTDAnswers]  =
+    YearToDateLiabilityAnswersGen.completeNonCalculatedYTDLiabilityAnswersGen
+  val supportingDocumentAnswers: Gen[CompleteSupportingEvidenceAnswers] =
+    FileUploadGen.completeUploadSupportingEvidenceAnswersGen
+  val representeeAnswers: Gen[CompleteRepresenteeAnswers]               = RepresenteeAnswersGen.completeRepresenteeAnswersGen
+  val disposalDetails: Gen[CompleteDisposalDetailsAnswers]              = DisposalDetailsGen.completeDisposalDetailsAnswersGen
+  val acquisitionDetails: Gen[CompleteAcquisitionDetailsAnswers]        =
+    AcquisitionDetailsGen.completeAcquisitionDetailsAnswersGen
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/Common.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/Common.scala
@@ -20,25 +20,16 @@ import org.scalacheck.Gen
 import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.CompleteAcquisitionDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalDetailsAnswers.CompleteDisposalDetailsAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExamplePropertyDetailsAnswers.CompleteExamplePropertyDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLossesAnswers.CompleteExemptionAndLossesAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MultipleDisposalsTriageAnswers.CompleteMultipleDisposalsTriageAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.CompleteRepresenteeAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.CompleteSingleDisposalTriageAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SupportingEvidenceAnswers.CompleteSupportingEvidenceAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.CompleteNonCalculatedYTDAnswers
 
 trait Common extends GenUtils {
-  val completeMultipleDisposalsTriageAnswers: Gen[CompleteMultipleDisposalsTriageAnswers] =
-    gen[CompleteMultipleDisposalsTriageAnswers]
-  val completeSingleDisposalTriageAnswers: Gen[CompleteSingleDisposalTriageAnswers]       =
-    gen[CompleteSingleDisposalTriageAnswers]
-  val examplePropertyDetailsAnswers: Gen[CompleteExamplePropertyDetailsAnswers]           =
-    gen[CompleteExamplePropertyDetailsAnswers]
-  val exemptionAndLossesAnswers: Gen[CompleteExemptionAndLossesAnswers]                   = gen[CompleteExemptionAndLossesAnswers]
-  val yearToDateLiabilityAnswers: Gen[CompleteNonCalculatedYTDAnswers]                    = gen[CompleteNonCalculatedYTDAnswers]
-  val supportingDocumentAnswers: Gen[CompleteSupportingEvidenceAnswers]                   = gen[CompleteSupportingEvidenceAnswers]
-  val representeeAnswers: Gen[CompleteRepresenteeAnswers]                                 = gen[CompleteRepresenteeAnswers]
-  val disposalDetails: Gen[CompleteDisposalDetailsAnswers]                                = gen[CompleteDisposalDetailsAnswers]
-  val acquisitionDetails: Gen[CompleteAcquisitionDetailsAnswers]                          = gen[CompleteAcquisitionDetailsAnswers]
+  val exemptionAndLossesAnswers: Gen[CompleteExemptionAndLossesAnswers] = gen[CompleteExemptionAndLossesAnswers]
+  val yearToDateLiabilityAnswers: Gen[CompleteNonCalculatedYTDAnswers]  = gen[CompleteNonCalculatedYTDAnswers]
+  val supportingDocumentAnswers: Gen[CompleteSupportingEvidenceAnswers] = gen[CompleteSupportingEvidenceAnswers]
+  val representeeAnswers: Gen[CompleteRepresenteeAnswers]               = gen[CompleteRepresenteeAnswers]
+  val disposalDetails: Gen[CompleteDisposalDetailsAnswers]              = gen[CompleteDisposalDetailsAnswers]
+  val acquisitionDetails: Gen[CompleteAcquisitionDetailsAnswers]        = gen[CompleteAcquisitionDetailsAnswers]
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
@@ -17,12 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.{CompleteMultipleDisposalsReturn, CompleteMultipleIndirectDisposalReturn, CompleteSingleDisposalReturn, CompleteSingleIndirectDisposalReturn, CompleteSingleMixedUseDisposalReturn}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExampleCompanyDetailsAnswers.CompleteExampleCompanyDetailsAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MixedUsePropertyDetailsAnswers.CompleteMixedUsePropertyDetailsAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.CalculatedYTDAnswers.CompleteCalculatedYTDAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.CompleteNonCalculatedYTDAnswers
 
 object CompleteReturnGen extends LowerPriorityCompleteReturnGen {
 
@@ -34,7 +29,8 @@ object CompleteReturnGen extends LowerPriorityCompleteReturnGen {
       acquisitionDetails         <- acquisitionDetails
       reliefDetails              <- ReliefDetailsGen.completeReliefDetailsAnswersGen
       exemptionsAndLossesDetails <- ExemptionsAndLossesAnswersGen.completeExemptionAndLossesAnswersGen
-      yearToDateLiabilityAnswers <- gen[Either[CompleteNonCalculatedYTDAnswers, CompleteCalculatedYTDAnswers]]
+      yearToDateLiabilityAnswers <-
+        Gen.either(yearToDateLiabilityAnswers, YearToDateLiabilityAnswersGen.completeCalculatedYTDLiabilityAnswersGen)
       supportingDocumentAnswers  <- supportingDocumentAnswers
       initialGainOrLoss          <- Gen.option(MoneyGen.amountInPenceGen)
       representeeAnswers         <- Gen.option(RepresenteeAnswersGen.completeRepresenteeAnswersGen)
@@ -107,7 +103,7 @@ trait LowerPriorityCompleteReturnGen extends Common {
 
   implicit val completeMultipleIndirectDisposalReturnGen: Gen[CompleteMultipleIndirectDisposalReturn] = for {
     triageAnswers                <- completeMultipleDisposalsTriageAnswers
-    exampleCompanyDetailsAnswers <- gen[CompleteExampleCompanyDetailsAnswers]
+    exampleCompanyDetailsAnswers <- ExampleCompanyDetailsAnswersGen.completeExampleCompanyDetailsAnswersGen
     exemptionsAndLossesDetails   <- exemptionAndLossesAnswers
     yearToDateLiabilityAnswers   <- yearToDateLiabilityAnswers
     supportingDocumentAnswers    <- supportingDocumentAnswers
@@ -128,7 +124,7 @@ trait LowerPriorityCompleteReturnGen extends Common {
   implicit val completeSingleMixedUseDisposalReturnGen: Gen[CompleteSingleMixedUseDisposalReturn] = {
     for {
       triageAnswers              <- completeSingleDisposalTriageAnswers
-      propertyDetailsAnswers     <- gen[CompleteMixedUsePropertyDetailsAnswers]
+      propertyDetailsAnswers     <- SingleMixedUseDetailsAnswersGen.completeMixedUsePropertyDetailsAnswers
       exemptionsAndLossesDetails <- exemptionAndLossesAnswers
       yearToDateLiabilityAnswers <- yearToDateLiabilityAnswers
       supportingDocumentAnswers  <- supportingDocumentAnswers

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
@@ -23,7 +23,7 @@ object CompleteReturnGen extends LowerPriorityCompleteReturnGen {
 
   implicit val completeSingleDisposalReturnGen: Gen[CompleteSingleDisposalReturn] =
     for {
-      triageAnswers              <- completeSingleDisposalTriageAnswers
+      triageAnswers              <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
       propertyAddress            <- AddressGen.ukAddressGen
       disposalDetails            <- disposalDetails
       acquisitionDetails         <- acquisitionDetails
@@ -56,8 +56,8 @@ object CompleteReturnGen extends LowerPriorityCompleteReturnGen {
 trait LowerPriorityCompleteReturnGen extends Common {
 
   implicit val completeMultipleDisposalsReturnGen: Gen[CompleteMultipleDisposalsReturn] = for {
-    triageAnswers                 <- completeMultipleDisposalsTriageAnswers
-    examplePropertyDetailsAnswers <- examplePropertyDetailsAnswers
+    triageAnswers                 <- TriageQuestionsGen.completeMultipleDisposalsTriageAnswersGen
+    examplePropertyDetailsAnswers <- ExamplePropertyDetailsAnswersGen.completeExamplePropertyDetailsAnswersGen
     exemptionAndLossesAnswers     <- exemptionAndLossesAnswers
     yearToDateLiabilityAnswers    <- yearToDateLiabilityAnswers
     supportingDocumentAnswers     <- supportingDocumentAnswers
@@ -77,7 +77,7 @@ trait LowerPriorityCompleteReturnGen extends Common {
 
   implicit val completeSingleIndirectDisposalReturnGen: Gen[CompleteSingleIndirectDisposalReturn] = {
     for {
-      triageAnswers              <- completeSingleDisposalTriageAnswers
+      triageAnswers              <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
       companyAddress             <- AddressGen.addressGen
       disposalDetails            <- disposalDetails
       acquisitionDetails         <- acquisitionDetails
@@ -102,7 +102,7 @@ trait LowerPriorityCompleteReturnGen extends Common {
   }
 
   implicit val completeMultipleIndirectDisposalReturnGen: Gen[CompleteMultipleIndirectDisposalReturn] = for {
-    triageAnswers                <- completeMultipleDisposalsTriageAnswers
+    triageAnswers                <- TriageQuestionsGen.completeMultipleDisposalsTriageAnswersGen
     exampleCompanyDetailsAnswers <- ExampleCompanyDetailsAnswersGen.completeExampleCompanyDetailsAnswersGen
     exemptionsAndLossesDetails   <- exemptionAndLossesAnswers
     yearToDateLiabilityAnswers   <- yearToDateLiabilityAnswers
@@ -123,7 +123,7 @@ trait LowerPriorityCompleteReturnGen extends Common {
 
   implicit val completeSingleMixedUseDisposalReturnGen: Gen[CompleteSingleMixedUseDisposalReturn] = {
     for {
-      triageAnswers              <- completeSingleDisposalTriageAnswers
+      triageAnswers              <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
       propertyDetailsAnswers     <- SingleMixedUseDetailsAnswersGen.completeMixedUsePropertyDetailsAnswers
       exemptionsAndLossesDetails <- exemptionAndLossesAnswers
       yearToDateLiabilityAnswers <- yearToDateLiabilityAnswers

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DisposalMethodGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DisposalMethodGen.scala
@@ -17,12 +17,9 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalMethod
 
-object DisposalMethodGen extends GenUtils {
-
+object DisposalMethodGen {
   implicit val disposalMethodGen: Gen[DisposalMethod] =
-    gen[DisposalMethod]
-
+    Gen.oneOf(DisposalMethod.Sold, DisposalMethod.Gifted, DisposalMethod.Other)
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DraftReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DraftReturnGen.scala
@@ -37,7 +37,6 @@ trait HigherPriorityDraftReturnGen extends LowerPriorityDraftReturnGen {
 
 trait LowerPriorityDraftReturnGen extends GenUtils {
 
-  val triageAnswersGen: Gen[SingleDisposalTriageAnswers]             = gen[SingleDisposalTriageAnswers]
   private val supportingEvidenceGen: Gen[SupportingEvidenceAnswers]  = gen[SupportingEvidenceAnswers]
   private val exemptionsAndLossesAnswersGen                          = Gen.oneOf(
     ExemptionsAndLossesAnswersGen.completeExemptionAndLossesAnswersGen,
@@ -53,7 +52,7 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
   val singleDisposalDraftReturnGen2: Gen[DraftSingleDisposalReturn] =
     for {
       id                         <- Gen.uuid
-      triageAnswers              <- triageAnswersGen
+      triageAnswers              <- TriageQuestionsGen.singleDisposalTraiageAnswersGen
       propertyAddress            <- Gen.option(AddressGen.ukAddressGen)
       disposalDetailsAnswers     <- Gen.option(disposalDetailsAnswersGen)
       acquisitionDetailsAnswers  <- Gen.option(acquisitionDetailsAnswersGen)
@@ -81,12 +80,10 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
       lastUpdatedDate
     )
 
-  val multipleTriageGen = gen[MultipleDisposalsTriageAnswers]
-
   implicit val multipleDisposalDraftReturnGen: Gen[DraftMultipleDisposalsReturn] = {
     for {
       id                            <- Gen.uuid
-      triageAnswers                 <- multipleTriageGen
+      triageAnswers                 <- TriageQuestionsGen.multipleDisposalsTriageAnswersGen
       examplePropertyDetailsAnswers <- Gen.option(gen[ExamplePropertyDetailsAnswers])
       exemptionAndLossesAnswers     <- Gen.option(exemptionsAndLossesAnswersGen)
       yearToDateLiabilityAnswers    <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
@@ -110,7 +107,7 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
   implicit val multipleIndirectDisposalDraftReturnGen: Gen[DraftMultipleIndirectDisposalsReturn] = {
     for {
       id                           <- Gen.uuid
-      triageAnswers                <- multipleTriageGen
+      triageAnswers                <- TriageQuestionsGen.multipleDisposalsTriageAnswersGen
       exampleCompanyDetailsAnswers <- Gen.option(gen[ExampleCompanyDetailsAnswers])
       exemptionAndLossesAnswers    <- Gen.option(exemptionsAndLossesAnswersGen)
       yearToDateLiabilityAnswers   <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
@@ -134,7 +131,7 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
   implicit val singleIndirectDisposalDraftReturnGen: Gen[DraftSingleIndirectDisposalReturn] =
     for {
       id                         <- Gen.uuid
-      triageAnswers              <- triageAnswersGen
+      triageAnswers              <- TriageQuestionsGen.singleDisposalTraiageAnswersGen
       companyAddress             <- Gen.option(AddressGen.addressGen)
       disposalDetailsAnswers     <- Gen.option(disposalDetailsAnswersGen)
       acquisitionDetailsAnswers  <- Gen.option(acquisitionDetailsAnswersGen)
@@ -161,7 +158,7 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
   implicit val singleMixedUseDraftReturnGen: Gen[DraftSingleMixedUseDisposalReturn] =
     for {
       id                             <- Gen.uuid
-      triageAnswers                  <- triageAnswersGen
+      triageAnswers                  <- TriageQuestionsGen.singleDisposalTraiageAnswersGen
       mixedUsePropertyDetailsAnswers <- Gen.option(gen[MixedUsePropertyDetailsAnswers])
       exemptionAndLossesAnswers      <- Gen.option(exemptionsAndLossesAnswersGen)
       yearToDateLiabilityAnswers     <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/EmailGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/EmailGen.scala
@@ -17,11 +17,10 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.{Email, EmailSource}
 
 object EmailGen extends GenUtils {
-  implicit val emailGen: Gen[Email] = gen[Email]
-
-  implicit val emailSourceGen: Gen[EmailSource] = gen[EmailSource]
+  implicit val emailGen: Gen[Email]             = Generators.stringGen.map(Email(_))
+  implicit val emailSourceGen: Gen[EmailSource] =
+    Gen.oneOf(EmailSource.GovernmentGateway, EmailSource.BusinessPartnerRecord, EmailSource.ManuallyEntered)
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ExemptionsAndLossesAnswersGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ExemptionsAndLossesAnswersGen.scala
@@ -17,15 +17,23 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLossesAnswers.{CompleteExemptionAndLossesAnswers, IncompleteExemptionAndLossesAnswers}
 
 object ExemptionsAndLossesAnswersGen extends GenUtils {
 
-  implicit val completeExemptionAndLossesAnswersGen: Gen[CompleteExemptionAndLossesAnswers] =
-    gen[CompleteExemptionAndLossesAnswers]
+  implicit val completeExemptionAndLossesAnswersGen: Gen[CompleteExemptionAndLossesAnswers] = {
+    for {
+      inYearLosses        <- MoneyGen.amountInPenceGen
+      previousYearsLosses <- MoneyGen.amountInPenceGen
+      annualExemptAmount  <- MoneyGen.amountInPenceGen
+    } yield CompleteExemptionAndLossesAnswers(inYearLosses, previousYearsLosses, annualExemptAmount)
+  }
 
   implicit val incompleteExemptionAndLossesAnswersGen: Gen[IncompleteExemptionAndLossesAnswers] =
-    gen[IncompleteExemptionAndLossesAnswers]
+    for {
+      inYearLosses        <- Gen.option(MoneyGen.amountInPenceGen)
+      previousYearsLosses <- Gen.option(MoneyGen.amountInPenceGen)
+      annualExemptAmount  <- Gen.option(MoneyGen.amountInPenceGen)
+    } yield IncompleteExemptionAndLossesAnswers(inYearLosses, previousYearsLosses, annualExemptAmount)
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/Generators.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/Generators.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.{Arbitrary, Gen}
 
+import java.time.LocalDate
 import scala.language.implicitConversions
 
 object Generators {
@@ -35,5 +36,7 @@ object Generators {
     gen.sample.getOrElse(sys.error(s"Could not generate instance with $gen"))
 
   implicit def arb[A](implicit g: Gen[A]): Arbitrary[A] = Arbitrary(g)
+
+  val dateGen: Gen[LocalDate] = Arbitrary.arbitrary[LocalDate]
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
@@ -20,9 +20,8 @@ import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.{IndividualMissingEmail, IndividualSupplyingInformation, IndividualWantsToRegisterTrust, RegistrationReady}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.SubscriptionReady
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, PreviousReturnData, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, SubmittingReturn, Subscribed, ViewingReturn}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, SubmittingReturn, Subscribed, ViewingReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionResponse.SubscriptionSuccessful
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 
 object JourneyStatusGen extends JourneyStatusLowerPriorityGen with GenUtils {
   implicit val subscriptionReadyGen: Gen[SubscriptionReady] = for {
@@ -98,7 +97,10 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
       subscribedDetails      <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId               <- IdGen.ggCredIdGen
       agentReferenceNumber   <- Gen.option(IdGen.arnGen)
-      newReturnTriageAnswers <- Gen.either(gen[MultipleDisposalsTriageAnswers], gen[SingleDisposalTriageAnswers])
+      newReturnTriageAnswers <- Gen.either(
+                                  TriageQuestionsGen.multipleDisposalsTriageAnswersGen,
+                                  TriageQuestionsGen.singleDisposalTraiageAnswersGen
+                                )
       representeeAnswers     <- Gen.option(RepresenteeAnswersGen.representeeAnswersGen)
       previousSentReturns    <- Gen.option(ReturnGen.previousReturnDataGen)
     } yield StartingNewDraftReturn(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/JourneyStatusGen.scala
@@ -21,7 +21,6 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.{IndividualMissingEmail, IndividualSupplyingInformation, IndividualWantsToRegisterTrust, RegistrationReady}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.SubscriptionReady
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, PreviousReturnData, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, SubmittingReturn, Subscribed, ViewingReturn}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.AgentReferenceNumber
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionResponse.SubscriptionSuccessful
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 
@@ -35,7 +34,7 @@ object JourneyStatusGen extends JourneyStatusLowerPriorityGen with GenUtils {
     gen[IndividualWantsToRegisterTrust],
     gen[IndividualSupplyingInformation],
     gen[IndividualMissingEmail],
-    gen[RegistrationReady]
+    registrationReadyGen
   )
 
   implicit val journeyStatusGen: Gen[JourneyStatus] = Gen.oneOf(
@@ -63,8 +62,6 @@ object JourneyStatusGen extends JourneyStatusLowerPriorityGen with GenUtils {
 
 trait JourneyStatusLowerPriorityGen extends GenUtils {
 
-  private val agentReferenceNumberGen = gen[AgentReferenceNumber]
-
   implicit val subscriptionSuccessfulGen: Gen[SubscriptionSuccessful] =
     gen[SubscriptionSuccessful]
 
@@ -81,7 +78,7 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
     for {
       subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId             <- IdGen.ggCredIdGen
-      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      agentReferenceNumber <- Gen.option(IdGen.arnGen)
       draftReturns         <- Gen.listOf(DraftReturnGen.draftReturnGen)
       sentReturns          <- Gen.listOf(ReturnGen.returnSummaryGen)
     } yield Subscribed(subscribedDetails, ggCredId, agentReferenceNumber, draftReturns, sentReturns)
@@ -100,7 +97,7 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
     for {
       subscribedDetails      <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId               <- IdGen.ggCredIdGen
-      agentReferenceNumber   <- Gen.option(agentReferenceNumberGen)
+      agentReferenceNumber   <- Gen.option(IdGen.arnGen)
       newReturnTriageAnswers <- Gen.either(gen[MultipleDisposalsTriageAnswers], gen[SingleDisposalTriageAnswers])
       representeeAnswers     <- Gen.option(RepresenteeAnswersGen.representeeAnswersGen)
       previousSentReturns    <- Gen.option(ReturnGen.previousReturnDataGen)
@@ -117,7 +114,7 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
     for {
       subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId             <- IdGen.ggCredIdGen
-      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      agentReferenceNumber <- Gen.option(IdGen.arnGen)
       draftReturn          <- DraftReturnGen.draftReturnGen
       previousSentReturns  <- Gen.option(ReturnGen.previousReturnDataGen)
       amendReturnData      <- Gen.option(ReturnGen.amendReturnDataGen)
@@ -134,9 +131,9 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
     for {
       subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId             <- IdGen.ggCredIdGen
-      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      agentReferenceNumber <- Gen.option(IdGen.arnGen)
       completeReturn       <- ReturnGen.completeReturnGen
-      submissionResponse   <- gen[SubmitReturnResponse]
+      submissionResponse   <- ReturnAPIGen.submitReturnResponseGen
       amendReturnData      <- Gen.option(ReturnGen.amendReturnDataGen)
     } yield JustSubmittedReturn(
       subscribedDetails,
@@ -147,17 +144,15 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
       amendReturnData
     )
 
-  private val previousReturnDataGen = gen[PreviousReturnData]
-
   implicit val viewingReturnGen: Gen[ViewingReturn] =
     for {
       subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId             <- IdGen.ggCredIdGen
-      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      agentReferenceNumber <- Gen.option(IdGen.arnGen)
       completeReturn       <- ReturnGen.completeReturnGen
       returnType           <- ReturnGen.returnTypeGen
       returnSummary        <- ReturnGen.returnSummaryGen
-      previousSentReturns  <- Gen.option(previousReturnDataGen)
+      previousSentReturns  <- Gen.option(ReturnGen.previousReturnDataGen)
     } yield ViewingReturn(
       subscribedDetails,
       ggCredId,
@@ -172,23 +167,23 @@ trait JourneyStatusLowerPriorityGen extends GenUtils {
     for {
       subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId             <- IdGen.ggCredIdGen
-      agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+      agentReferenceNumber <- Gen.option(IdGen.arnGen)
     } yield SubmitReturnFailed(subscribedDetails, ggCredId, agentReferenceNumber)
 
   implicit val submittingReturn: Gen[SubmittingReturn] = for {
     subscribedDetails    <- SubscribedDetailsGen.subscribedDetailsGen
     ggCredId             <- IdGen.ggCredIdGen
-    agentReferenceNumber <- Gen.option(agentReferenceNumberGen)
+    agentReferenceNumber <- Gen.option(IdGen.arnGen)
   } yield SubmittingReturn(subscribedDetails, ggCredId, agentReferenceNumber)
 
   implicit val startingToAmendReturnGen: Gen[StartingToAmendReturn] = {
     for {
       subscribedDetails       <- SubscribedDetailsGen.subscribedDetailsGen
       ggCredId                <- IdGen.ggCredIdGen
-      agentReferenceNumber    <- Gen.option(agentReferenceNumberGen)
+      agentReferenceNumber    <- Gen.option(IdGen.arnGen)
       originalReturn          <- ReturnGen.completeReturnWithSummaryGen
       isFirstReturn           <- Generators.booleanGen
-      previousSentReturns     <- Gen.option(previousReturnDataGen)
+      previousSentReturns     <- Gen.option(ReturnGen.previousReturnDataGen)
       unmetDependencyFieldUrl <- Gen.option(Generators.stringGen)
     } yield StartingToAmendReturn(
       subscribedDetails,

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/NameGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/NameGen.scala
@@ -17,15 +17,18 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{ContactName, IndividualName, TrustName}
 
 object NameGen extends GenUtils {
 
-  implicit val contactNameGen: Gen[ContactName] = gen[ContactName]
+  implicit val contactNameGen: Gen[ContactName] = Generators.stringGen.map(ContactName(_))
 
-  implicit val individualNameGen: Gen[IndividualName] = gen[IndividualName]
+  implicit val individualNameGen: Gen[IndividualName] =
+    for {
+      firstName <- Generators.stringGen
+      lastName  <- Generators.stringGen
+    } yield IndividualName(firstName, lastName)
 
-  implicit val trustNameGen: Gen[TrustName] = gen[TrustName]
+  implicit val trustNameGen: Gen[TrustName] = Generators.stringGen.map(TrustName(_))
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnAPIGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnAPIGen.scala
@@ -51,7 +51,7 @@ object ReturnAPIGen extends Common {
 
   implicit val calculateCgtTaxDueRequestGen: Gen[CalculateCgtTaxDueRequest] =
     for {
-      triageAnswers      <- completeSingleDisposalTriageAnswers
+      triageAnswers      <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
       address            <- AddressGen.ukAddressGen
       disposalDetails    <- disposalDetails
       acquisitionDetails <- acquisitionDetails

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SubscribedDetailsGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SubscribedDetailsGen.scala
@@ -17,12 +17,21 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TelephoneNumber
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 
 object SubscribedDetailsGen extends GenUtils {
 
-  implicit val subscribedDetailsGen: Gen[SubscribedDetails] =
-    gen[SubscribedDetails]
+  implicit val subscribedDetailsGen: Gen[SubscribedDetails] = for {
+    name: Either[TrustName, IndividualName] <-
+      Gen.oneOf(NameGen.trustNameGen.map(Left(_)), NameGen.individualNameGen.map(Right(_)))
+    emailAddress                            <- EmailGen.emailGen
+    address                                 <- AddressGen.addressGen
+    contactName                             <- NameGen.contactNameGen
+    cgtReference                            <- IdGen.cgtReferenceArb
+    telephoneNumber                         <- Gen.option(Generators.stringGen.map(TelephoneNumber(_)))
+    registeredWithId                        <- Generators.booleanGen
+  } yield SubscribedDetails(name, emailAddress, address, contactName, cgtReference, telephoneNumber, registeredWithId)
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/TriageQuestionsGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/TriageQuestionsGen.scala
@@ -25,17 +25,26 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 object TriageQuestionsGen extends HigherPriorityTriageQuestionsGen with GenUtils
 
 trait HigherPriorityTriageQuestionsGen extends LowerPriorityTriageQuestionsGen { this: GenUtils =>
-  implicit val individualTriageAnswersGen: Gen[SingleDisposalTriageAnswers] =
-    gen[SingleDisposalTriageAnswers]
 
   implicit val completeSingleDisposalTriageAnswersGen: Gen[CompleteSingleDisposalTriageAnswers] =
     gen[CompleteSingleDisposalTriageAnswers]
+
+  implicit val individualTriageAnswersGen: Gen[SingleDisposalTriageAnswers] = Gen.oneOf(
+    completeSingleDisposalTriageAnswersGen,
+    incompleteSingleDisposalTriageAnswersGen
+  )
+
+  val singleDisposalTraiageAnswersGen: Gen[SingleDisposalTriageAnswers] =
+    Gen.oneOf(completeSingleDisposalTriageAnswersGen, incompleteSingleDisposalTriageAnswersGen)
 
   implicit val completeMultipleDisposalsTriageAnswersGen: Gen[CompleteMultipleDisposalsTriageAnswers] =
     gen[CompleteMultipleDisposalsTriageAnswers]
 
   implicit val incompleteMultipleDisposalsTriageAnswersGen: Gen[IncompleteMultipleDisposalsTriageAnswers] =
     gen[IncompleteMultipleDisposalsTriageAnswers]
+
+  val multipleDisposalsTriageAnswersGen: Gen[MultipleDisposalsTriageAnswers] =
+    Gen.oneOf(completeMultipleDisposalsTriageAnswersGen, incompleteMultipleDisposalsTriageAnswersGen)
 
   implicit val individualUserTypeGen: Gen[IndividualUserType] =
     gen[IndividualUserType]
@@ -48,7 +57,6 @@ trait HigherPriorityTriageQuestionsGen extends LowerPriorityTriageQuestionsGen {
   implicit val completionDateGen: Gen[CompletionDate] = gen[CompletionDate]
 
   implicit val assetTypeGen: Gen[AssetType] = gen[AssetType]
-
 }
 
 trait LowerPriorityTriageQuestionsGen { this: GenUtils =>

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/UserTypeGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/UserTypeGen.scala
@@ -17,11 +17,10 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import org.scalacheck.ScalacheckShapeless._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType
 
 object UserTypeGen extends GenUtils {
 
-  implicit val userTypeGen: Gen[UserType] = gen[UserType]
-
+  implicit val userTypeGen: Gen[UserType] =
+    Gen.oneOf(UserType.Individual, UserType.Organisation, UserType.NonGovernmentGatewayUser, UserType.Agent)
 }


### PR DESCRIPTION
Each *Gen file compiles now in under 1 second. In total they take 15s (the rest of the compilation 45+). While it would be nice to make the build even faster, I think at this point, we should only go with removing shapeless completely if Platform dropped its support - the remaining classes are pretty massive, rewriting takes a while, you'd be gaining a second an hour.