### PR TITLE
DLS-11446 | Make 4 year tax window dynamic based on current tax year

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnController.scala
@@ -34,9 +34,9 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.acquisitiond
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.amend.AmendReturnController._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.UUIDGenerator
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AmendReturnData
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AmendReturnData, TaxYearExchanged}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.audit.CancelAmendReturn
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{BooleanFormatter, TaxYear}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.BooleanFormatter
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.AuditService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
@@ -127,7 +127,7 @@ class AmendReturnController @Inject() (
     authenticatedActionWithSessionData.async { implicit request =>
       withStartingToAmendReturn(request) { journey =>
         val originalTaxYear               = journey.originalReturn.summary.taxYear
-        val currentTaxYear                = TaxYear.thisTaxYearStartDate().getYear.toString
+        val currentTaxYear                = TaxYearExchanged.currentTaxYear.toString
         val futureDatesEnabled            = viewConfig.futureDatesEnabled
         val isSubmissionInPreviousTaxYear = originalTaxYear =!= currentTaxYear
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
@@ -408,10 +408,11 @@ class CommonTriageQuestionsController @Inject() (
         ) match {
           case None        => Redirect(redirectToCheckYourAnswers(state))
           case Some(wasUk) =>
+            val cutoffTaxYear = TaxYearExchanged.cutoffTaxYear
             if (wasUk) {
-              Ok(disposalDateTooEarlyUkResidents(backLink))
+              Ok(disposalDateTooEarlyUkResidents(backLink, cutoffTaxYear))
             } else {
-              Ok(disposalDateTooEarlyNonUkResidents(backLink))
+              Ok(disposalDateTooEarlyNonUkResidents(backLink, cutoffTaxYear))
             }
         }
       }
@@ -425,7 +426,7 @@ class CommonTriageQuestionsController @Inject() (
           _ => routes.MultipleDisposalsTriageController.disposalDateOfShares(),
           _ => routes.SingleDisposalsTriageController.disposalDateOfShares()
         )
-        Ok(disposalDateTooEarlyNonUkResidents(backLink))
+        Ok(disposalDateTooEarlyNonUkResidents(backLink, TaxYearExchanged.currentTaxYear))
       }
     }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageController.scala
@@ -562,7 +562,7 @@ class MultipleDisposalsTriageController @Inject() (
 
               val taxYearOfDateOfDeath = getDateOfDeath(state) match {
                 case Some(date) => TimeUtils.getTaxYearExchangedOfADate(date.value)
-                case _          => TaxYearExchanged.taxYearExchangedBefore2020
+                case _          => TaxYearExchanged.taxYearExchangedTooEarly
               }
 
               val representativeType: Option[RepresentativeType] =
@@ -606,7 +606,7 @@ class MultipleDisposalsTriageController @Inject() (
 
           val taxYearOfDateOfDeath = getDateOfDeath(state) match {
             case Some(date) => TimeUtils.getTaxYearExchangedOfADate(date.value)
-            case _          => TaxYearExchanged.taxYearExchangedBefore2020
+            case _          => TaxYearExchanged.taxYearExchangedTooEarly
           }
 
           val representativeType: Option[RepresentativeType] =
@@ -1540,7 +1540,7 @@ class MultipleDisposalsTriageController @Inject() (
     }
 
   private def isAValidCGTTaxTear(taxYearExchanged: TaxYearExchanged): Boolean =
-    !(taxYearExchanged === TaxYearExchanged.taxYearExchangedBefore2020 || taxYearExchanged === TaxYearExchanged.differentTaxYears)
+    !(taxYearExchanged === TaxYearExchanged.taxYearExchangedTooEarly || taxYearExchanged === TaxYearExchanged.differentTaxYears)
 
   private def isTaxYearWithinOriginalSubmissionTaxYear(
     taxYearExchanged: TaxYearExchanged,

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/TimeUtils.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/TimeUtils.scala
@@ -239,7 +239,7 @@ object TimeUtils {
   def getTaxYearExchangedOfADate(d: LocalDate): TaxYearExchanged = {
     val taxYearStartDate = taxYearStart(d)
     if (taxYearStartDate.getYear < 2020) {
-      TaxYearExchanged.taxYearExchangedBefore2020
+      TaxYearExchanged.taxYearExchangedTooEarly
     } else {
       TaxYearExchanged(taxYearStartDate.getYear)
     }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/TaxYearExchanged.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/TaxYearExchanged.scala
@@ -19,12 +19,16 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 import cats.Eq
 import julienrf.json.derived
 import play.api.libs.json.OFormat
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TaxYear
 
 final case class TaxYearExchanged(year: Int) extends Product with Serializable
 
 object TaxYearExchanged {
-  val cutoffYear: Int                              = 2020
-  val taxYearExchangedBefore2020: TaxYearExchanged = TaxYearExchanged(-2020)
+  val currentTaxYear: Int = TaxYear.thisTaxYearStartDate().getYear
+
+  // Cutoff tax year must be current tax year minus 4 years
+  val cutoffTaxYear: Int                         = currentTaxYear - 4
+  val taxYearExchangedTooEarly: TaxYearExchanged = TaxYearExchanged(-cutoffTaxYear)
 
   val differentTaxYears: TaxYearExchanged = TaxYearExchanged(-1)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsService.scala
@@ -560,14 +560,12 @@ class ReturnsServiceImpl @Inject() (
   def listReturns(cgtReference: CgtReference)(implicit
     hc: HeaderCarrier
   ): EitherT[Future, Error, List[ReturnSummary]] = {
-    val today          = LocalDate.now()
-    // fromDate must be current tax year minus 4 years
-    val currentTaxYear = TaxYear.thisTaxYearStartDate().getYear
-    val fromDate       = TimeUtils.getTaxYearStartDate(currentTaxYear - 4)
+    val today    = LocalDate.now()
+    val fromDate = TimeUtils.getTaxYearStartDate(TaxYearExchanged.cutoffTaxYear)
     // ETMP build queries from our date range in tax year batches, they have logic to reject an
     // end date that is before the end of the tax year that the toDate falls within, so we need to
     // satisfy this logic by using the end of the current tax year as our toDate
-    val toDate         = TimeUtils.getTaxYearEndDateInclusive(today)
+    val toDate   = TimeUtils.getTaxYearEndDateInclusive(today)
     connector.listReturns(cgtReference, fromDate, toDate).map(_.returns)
   }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/TestOnlyDraftReturnsConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/TestOnlyDraftReturnsConnector.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
-import uk.gov.hmrc.http.HttpReads.Implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_non_uk_residents.scala.html
@@ -24,7 +24,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call, cutoffTaxYear: Long)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"disposalDateTooEarly"}
 @title = @{messages(s"$key.non-uk.title")}
@@ -33,7 +33,7 @@
 
     <h1 class="govuk-heading-xl">@title</h1>
 
-    <p class="govuk-body">@messages(s"$key.non-uk.p1")</p>
+    <p class="govuk-body">@messages(s"$key.non-uk.p1", cutoffTaxYear.toString, (cutoffTaxYear + 1).toString)</p>
 
     <p class="govuk-body">@messages(s"$key.non-uk.p2")</p>
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_uk_residents.scala.html
@@ -24,7 +24,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call, cutoffTaxYear: Long)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"disposalDateTooEarly"}
 @title = @{messages(s"$key.uk.title")}
@@ -33,7 +33,7 @@
 
     <h1 class="govuk-heading-xl">@title</h1>
     <p class="govuk-body">
-      @messages(s"$key.uk.p1")
+      @messages(s"$key.uk.p1", cutoffTaxYear.toString, (cutoffTaxYear + 1).toString)
     </p>
     <p class="govuk-body">
       @Html(messages(s"$key.uk.p2", appConfig.cgtLegacyUrl))

--- a/conf/messages
+++ b/conf/messages
@@ -1092,14 +1092,14 @@ completionDate-day.error.dayAndMonthRequired=Completion date must include a day 
 completionDate.cyaChange=the completion date
 
 disposalDateTooEarly.non-uk.title=You cannot use this service
-disposalDateTooEarly.non-uk.p1=This is because when the property was sold or disposed of contracts were exchanged before 6 April 2020.
+disposalDateTooEarly.non-uk.p1=You can only use this service to report the disposal of UK property in the last 4 tax years. You cannot report disposals from the tax year {0} to {1} or before.
 disposalDateTooEarly.non-uk.p2=If an indirect disposal was made, it’s because the shares were sold before 6 April 2020.
 disposalDateTooEarly.non-uk.h2=What you’ll need to do next
 disposalDateTooEarly.non-uk.p3=You’ll need to complete a <a class="govuk-link" href="{0}">non-resident: report and pay Capital Gains Tax on UK property or land form</a>.
 
 disposalDateTooEarly.uk.title=You cannot use this service
-disposalDateTooEarly.uk.p1=This is because when the property was sold or disposed of contracts were exchanged before 6 April 2020.
-disposalDateTooEarly.uk.p2=Find out how to report and pay Capital Gains Tax on <a class="govuk-link" href="{0}">UK property sales or disposals before 6 April 2020</a>.
+disposalDateTooEarly.uk.p1=You can only use this service to report the disposal of UK property in the last 4 tax years. You cannot report disposals from the tax year {0} to {1} or before.
+disposalDateTooEarly.uk.p2=You’ll need to <a class="govuk-link" href="{0}">report your Capital Gains Tax on UK property by post</a>.
 
 triage.check-your-answers.title=Check your answers
 triage.cyaChange.countryOfResidence=your country of residence on the day you ‘exchanged’ contracts

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1092,14 +1092,14 @@ completionDate-day.error.dayAndMonthRequired=Mae’n rhaid i’r dyddiad cwblhau
 completionDate.cyaChange=y dyddiad cwblhau
 
 disposalDateTooEarly.non-uk.title=Ni allwch ddefnyddio’r gwasanaeth hwn
-disposalDateTooEarly.non-uk.p1=Mae hyn oherwydd pan gafodd yr eiddo ei werthu neu ei waredu, cyfnewidiwyd contractau cyn 6 Ebrill 2020.
+disposalDateTooEarly.non-uk.p1=Gallwch dim ond defnyddio’r gwasanaeth hwn i roi gwybod am warediad o eiddo yn y DU a wnaed yn ystod y 4 blwyddyn dreth ddiwethaf. Ni allwch roi gwybod am warediad o flwyddyn dreth {0} i {1} neu’n gynharach.
 disposalDateTooEarly.non-uk.p2=Os cafodd gwarediad anuniongyrchol ei wneud, mae hynny oherwydd bod y cyfranddaliadau wedi cael eu gwerthu cyn 6 Ebrill 2020.
 disposalDateTooEarly.non-uk.h2=Yr hyn y bydd angen i chi ei wneud nesaf
 disposalDateTooEarly.non-uk.p3=Bydd angen i chi lenwi <a class="govuk-link" href="{0}">dibreswyl: ffurflen rhoi gwybod am a thalu Treth Enillion Cyfalaf ar eiddo neu dir yn y DU</a>.
 
 disposalDateTooEarly.uk.title=Ni allwch ddefnyddio’r gwasanaeth hwn
-disposalDateTooEarly.uk.p1=Mae hyn oherwydd pan gafodd yr eiddo ei werthu neu ei waredu, cyfnewidiwyd contractau cyn 6 Ebrill 2020.
-disposalDateTooEarly.uk.p2=Dysgwch sut i roi gwybod am a thalu Treth Enillion Cyfalaf ar <a class="govuk-link" href="{0}">werthiannau neu warediadau eiddo yn y DU cyn 6 Ebrill 2020</a>.
+disposalDateTooEarly.uk.p1=Gallwch dim ond defnyddio’r gwasanaeth hwn i roi gwybod am warediad o eiddo yn y DU a wnaed yn ystod y 4 blwyddyn dreth ddiwethaf. Ni allwch roi gwybod am warediad o flwyddyn dreth {0} i {1} neu’n gynharach.
+disposalDateTooEarly.uk.p2=Bydd angen i chi <a class="govuk-link" href="{0}">roi gwybod am eich Treth Enillion Cyfalaf ar eiddo yn y DU drwy’r post</a>.
 
 triage.check-your-answers.title=Gwirio’ch atebion
 triage.cyaChange.countryOfResidence=eich gwlad breswyl ar y diwrnod y gwnaethoch ‘gyfnewid’ contractau

--- a/conf/triage.routes
+++ b/conf/triage.routes
@@ -34,7 +34,7 @@ POST        /before-start/did-sell-dispose-residential-property        uk.gov.hm
 GET         /before-start/date-exchanged-contracts                     uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.SingleDisposalsTriageController.whenWasDisposalDate()
 POST        /before-start/date-exchanged-contracts                     uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.SingleDisposalsTriageController.whenWasDisposalDateSubmit()
 
-GET         /exit/disposal-date-before-6-April-2020                    uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.CommonTriageQuestionsController.disposalDateTooEarly()
+GET         /exit/disposal-date-before-service-available               uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.CommonTriageQuestionsController.disposalDateTooEarly()
 GET         /exit/uk-resident-can-only-report-residential              uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.CommonTriageQuestionsController.ukResidentCanOnlyDisposeResidential()
 GET         /exit/share-date-too-early                                 uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.triage.CommonTriageQuestionsController.disposalsOfSharesTooEarly()
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ object AppDependencies {
   val mongoVersion     = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"                %% s"play-frontend-hmrc-$playVersion" % "8.3.0",
+    "uk.gov.hmrc"                %% s"play-frontend-hmrc-$playVersion" % "8.5.0",
     "uk.gov.hmrc"                %% s"bootstrap-frontend-$playVersion" % bootstrapVersion,
     "uk.gov.hmrc.mongo"          %% s"hmrc-mongo-$playVersion"         % mongoVersion,
     "uk.gov.hmrc"                %% s"domain-$playVersion"             % "10.0.0",

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnControllerSpec.scala
@@ -44,8 +44,8 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDeta
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.CompleteSingleDisposalReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.CompleteSingleDisposalTriageAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.audit.CancelAmendReturn
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AmendReturnData, IndividualUserType, ReturnSummary}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{CompleteReturnWithSummary, SessionData, TaxYear, UserType}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AmendReturnData, IndividualUserType, ReturnSummary, TaxYearExchanged}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{CompleteReturnWithSummary, SessionData, UserType}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -398,7 +398,7 @@ class AmendReturnControllerSpec
               individualUserType = Some(IndividualUserType.Self)
             )
           ),
-          summary = sample[ReturnSummary].copy(taxYear = TaxYear.thisTaxYearStartDate().getYear.toString)
+          summary = sample[ReturnSummary].copy(taxYear = TaxYearExchanged.currentTaxYear.toString)
         )
 
         "the user is not an agent" in {

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
@@ -1723,6 +1723,7 @@ class CommonTriageQuestionsControllerSpec
     }
 
     "handling requests to display the disposal date too early page" must {
+      val cutoffTaxYear = TaxYearExchanged.cutoffTaxYear
 
       def performAction(): Future[Result] =
         controller.disposalDateTooEarly()(FakeRequest())
@@ -1745,7 +1746,7 @@ class CommonTriageQuestionsControllerSpec
           countryOfResidence = None,
           assetTypes = Some(List(AssetType.Residential)),
           wereAllPropertiesResidential = Some(true),
-          taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedBefore2020)
+          taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedTooEarly)
         )
 
       behave like amendReturnToFillingOutReturnSpecBehaviour(
@@ -1819,7 +1820,9 @@ class CommonTriageQuestionsControllerSpec
                 doc
                   .select("#content > article > p:nth-child(3), #main-content p:nth-child(2)")
                   .text()                                          shouldBe messageFromMessageKey(
-                  "disposalDateTooEarly.uk.p1"
+                  "disposalDateTooEarly.uk.p1",
+                  cutoffTaxYear.toString,
+                  (cutoffTaxYear + 1).toString
                 )
                 doc
                   .select("#content > article > p:nth-child(4), #main-content p:nth-child(3)")
@@ -1848,7 +1851,7 @@ class CommonTriageQuestionsControllerSpec
             )
           }
 
-          "they are on a muliple disposals journey" in {
+          "they are on a multiple disposals journey" in {
 
             inSequence {
               mockAuthWithNoRetrievals()
@@ -1879,7 +1882,9 @@ class CommonTriageQuestionsControllerSpec
                 doc
                   .select("#content > article > p:nth-child(3), #main-content p:nth-child(2)")
                   .text()                                          shouldBe messageFromMessageKey(
-                  "disposalDateTooEarly.non-uk.p1"
+                  "disposalDateTooEarly.non-uk.p1",
+                  cutoffTaxYear.toString,
+                  (cutoffTaxYear + 1).toString
                 )
                 doc
                   .select("#content > article > p:nth-child(4), #main-content p:nth-child(3)")

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageControllerSpec.scala
@@ -269,8 +269,8 @@ class MultipleDisposalsTriageControllerSpec
       .returning(uuid)
 
   private def getTaxYearExchanged(taxYear: Option[TaxYear]): Option[TaxYearExchanged] = {
-    val currentTaxYear = TaxYear.thisTaxYearStartDate().getYear
-    val validYears     = TaxYearExchanged.cutoffYear to currentTaxYear
+    val currentTaxYear = TaxYearExchanged.currentTaxYear
+    val validYears     = TaxYearExchanged.cutoffTaxYear to currentTaxYear
     taxYear match {
       case Some(t) if validYears.contains(t.startDateInclusive.getYear) =>
         Some(TaxYearExchanged(t.startDateInclusive.getYear))
@@ -1924,7 +1924,7 @@ class MultipleDisposalsTriageControllerSpec
               mockAuthWithNoRetrievals()
               mockGetSession(session)
               mockAvailableTaxYears()(Right(List()))
-              mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedBefore2020.year))(
+              mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedTooEarly.year))(
                 Right(None)
               )
               mockStoreSession(
@@ -1933,7 +1933,7 @@ class MultipleDisposalsTriageControllerSpec
                     journey.copy(
                       newReturnTriageAnswers = Left(
                         answers.copy(
-                          taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedBefore2020),
+                          taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedTooEarly),
                           taxYear = None
                         )
                       )
@@ -1971,7 +1971,7 @@ class MultipleDisposalsTriageControllerSpec
               mockAuthWithNoRetrievals()
               mockGetSession(session)
               mockAvailableTaxYears()(Right(List()))
-              mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedBefore2020.year))(
+              mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedTooEarly.year))(
                 Right(None)
               )
               mockStoreSession(
@@ -1980,7 +1980,7 @@ class MultipleDisposalsTriageControllerSpec
                     journey.copy(
                       newReturnTriageAnswers = Left(
                         answers.copy(
-                          taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedBefore2020),
+                          taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedTooEarly),
                           taxYear = None,
                           completionDate = None,
                           alreadySentSelfAssessment = None
@@ -2211,7 +2211,7 @@ class MultipleDisposalsTriageControllerSpec
           .copy(
             taxYear = None,
             completionDate = None,
-            taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedBefore2020),
+            taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedTooEarly),
             alreadySentSelfAssessment = None
           )
         val updatedDraftReturn = draftReturn.copy(
@@ -2227,7 +2227,7 @@ class MultipleDisposalsTriageControllerSpec
             mockAuthWithNoRetrievals()
             mockGetSession(session)
             mockAvailableTaxYears()(Right(List()))
-            mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedBefore2020.year))(
+            mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedTooEarly.year))(
               Right(None)
             )
             mockStoreDraftReturn(updatedJourney)(
@@ -2243,7 +2243,7 @@ class MultipleDisposalsTriageControllerSpec
             mockAuthWithNoRetrievals()
             mockGetSession(session)
             mockAvailableTaxYears()(Right(List()))
-            mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedBefore2020.year))(
+            mockGetTaxYear(TimeUtils.getTaxYearStartDate(TaxYearExchanged.taxYearExchangedTooEarly.year))(
               Right(None)
             )
             mockStoreDraftReturn(updatedJourney)(
@@ -4414,7 +4414,7 @@ class MultipleDisposalsTriageControllerSpec
       "redirect to the tax year too early page" when {
         "the user indicated that the tax year was before 6th April 2020" in {
           testRedirectWhenIncomplete(
-            allQuestionsAnsweredUk.copy(taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedBefore2020)),
+            allQuestionsAnsweredUk.copy(taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedTooEarly)),
             routes.CommonTriageQuestionsController.disposalDateTooEarly()
           )
         }
@@ -4424,7 +4424,7 @@ class MultipleDisposalsTriageControllerSpec
             allQuestionsAnsweredUk
               .copy(
                 assetTypes = Some(List(IndirectDisposal)),
-                taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedBefore2020)
+                taxYearExchanged = Some(TaxYearExchanged.taxYearExchangedTooEarly)
               ),
             routes.CommonTriageQuestionsController.disposalsOfSharesTooEarly()
           )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsServiceImplSpec.scala
@@ -1633,8 +1633,7 @@ class ReturnsServiceImplSpec extends AnyWordSpec with Matchers with MockFactory 
 
       val cgtReference     = sample[CgtReference]
       val today: LocalDate = LocalDate.now()
-      val currentTaxYear   = TaxYear.thisTaxYearStartDate().getYear
-      val fromDate         = TimeUtils.getTaxYearStartDate(currentTaxYear - 4)
+      val fromDate         = TimeUtils.getTaxYearStartDate(TaxYearExchanged.cutoffTaxYear)
       val toDate           = TimeUtils.getTaxYearEndDateInclusive(today)
 
       "return an error " when {


### PR DESCRIPTION
- Content changes to make the earlier tax period configurable, based on current tax yaer
- Remove any usage/mention of year 2020 from codebase and align with the "early years" change.