### PR TITLE
Mmudi/dls 11613 scala3 upgrade

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
-version=2.7.1
+runner.dialect = scala3
+version = 3.7.13
 maxColumn = 120
 lineEndings = unix
 importSelectors = singleLine

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/config/ErrorHandler.scala
@@ -45,7 +45,7 @@ class ErrorHandler @Inject() (
   ): Future[Html] =
     Future.successful(error_template(None, pageTitle, heading, message))
 
-  def errorResult[R <: Request[_]](
+  def errorResult[R <: Request[?]](
     userType: Option[UserType]
   )(implicit request: R): Result =
     InternalServerError(
@@ -57,6 +57,6 @@ class ErrorHandler @Inject() (
       )
     )
 
-  def errorResult()(implicit request: RequestWithSessionData[_]): Result =
+  def errorResult()(implicit request: RequestWithSessionData[?]): Result =
     errorResult(request.userType)
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/AddressLookupConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/AddressLookupConnector.scala
@@ -34,6 +34,8 @@ import java.util.Locale
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.chaining.scalaUtilChainingOps
 
+import play.api.libs.ws.writeableOf_JsValue
+
 @ImplementedBy(classOf[AddressLookupConnectorImpl])
 trait AddressLookupConnector {
   def lookupAddress(postcode: Postcode, filter: Option[String])(implicit
@@ -66,7 +68,7 @@ class AddressLookupConnectorImpl @Inject() (
     http
       .post(url"$url")
       .withBody(Json.toJson(body))
-      .setHeader(headers: _*)
+      .setHeader(headers*)
       .execute[Either[UpstreamErrorResponse, AddressLookupResponse]]
       .map(_.left.map { error =>
         logger.error(s"POST to $url failed", error)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/CGTPropertyDisposalsConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/CGTPropertyDisposalsConnector.scala
@@ -31,6 +31,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.writeableOf_JsValue
 
 @ImplementedBy(classOf[CGTPropertyDisposalsConnectorImpl])
 trait CGTPropertyDisposalsConnector {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/EmailVerificationConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/EmailVerificationConnector.scala
@@ -34,6 +34,8 @@ import java.util.Locale
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
+import play.api.libs.ws.writeableOf_JsValue
+
 @ImplementedBy(classOf[EmailVerificationConnectorImpl])
 trait EmailVerificationConnector {
   def verifyEmail(email: Email, name: ContactName, continueCall: Call, language: AcceptLanguage)(implicit

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/returns/PaymentsConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/returns/PaymentsConnector.scala
@@ -33,6 +33,8 @@ import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
+import play.api.libs.ws.writeableOf_JsValue
+
 @ImplementedBy(classOf[PaymentsConnectorImpl])
 trait PaymentsConnector {
   def startPaymentJourney(
@@ -75,10 +77,11 @@ class PaymentsConnectorImpl @Inject() (
       s"$selfBaseUrl${backUrl.url}"
     )
 
+    val value = Json.toJson(body)
     EitherT(
       http
         .post(url"$startPaymentJourneyUrl")
-        .withBody(Json.toJson(body))
+        .withBody(value)
         .execute[HttpResponse]
         .map(
           Right(_)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/returns/ReturnsConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/returns/ReturnsConnector.scala
@@ -40,6 +40,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.chaining.scalaUtilChainingOps
 import scala.util.control.NonFatal
 
+import play.api.libs.ws.writeableOf_JsValue
+
 @ImplementedBy(classOf[ReturnsConnectorImpl])
 trait ReturnsConnector {
   def storeDraftReturn(draftReturn: DraftReturn, cgtReference: CgtReference)(implicit

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/upscan/UpscanConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/upscan/UpscanConnector.scala
@@ -32,6 +32,8 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import play.api.libs.ws.writeableOf_JsValue
+
 @ImplementedBy(classOf[UpscanConnectorImpl])
 trait UpscanConnector {
   def getUpscanUpload(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/SessionUpdates.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/SessionUpdates.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 
 import cats.syntax.eq._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.SessionUpdates.SessionProvider
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.{RequestWithSessionData, RequestWithSessionDataAndRetrievedData, RequestWithSubscriptionReady}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, SessionData}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
@@ -27,20 +26,16 @@ import scala.concurrent.Future
 
 trait SessionUpdates {
 
-  def updateSession[R](sessionStore: SessionStore, request: R)(
+  def updateSession[R](sessionStore: SessionStore, session: SessionData)(
     update: SessionData => SessionData
-  )(implicit
-    sessionProvider: SessionProvider[R],
-    hc: HeaderCarrier
-  ): Future[Either[Error, Unit]] = {
-    val session        = sessionProvider.toSession(request)
+  )(implicit hc: HeaderCarrier): Future[Either[Error, Unit]] = {
     val updatedSession = update(session)
 
     if (session === updatedSession) {
       // don't bother updating the session if it's the same
       Future.successful(Right(()))
     } else {
-      sessionStore.store(update(sessionProvider.toSession(request)))
+      sessionStore.store(update(session))
     }
   }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/AccountController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/AccountController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.{Authenticat
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.SessionData
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionDetail
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -73,7 +73,7 @@ class AccountController @Inject() (
       }
     }
 
-  private def withSubscribedUser(request: RequestWithSessionData[_])(
+  private def withSubscribedUser(request: RequestWithSessionData[?])(
     f: (SessionData, Subscribed) => Future[Result]
   ): Future[Result] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeAddressController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeAddressController.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus, Se
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.onboarding.SubscriptionService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.{AuditService, UKAddressLookupService}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.address.AddressJourneyType.ManagingSubscription.SubscribedAddressJourney
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, views}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -69,7 +69,7 @@ class SubscribedChangeAddressController @Inject() (
     journey.journey.subscribedDetails.isATrust
 
   def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Future[Result], (SessionData, SubscribedAddressJourney)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, s: Subscribed)) =>
@@ -83,7 +83,7 @@ class SubscribedChangeAddressController @Inject() (
     isManuallyEnteredAddress: Boolean
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] = {
     val updatedSubscribedDetails =
       journey.journey.subscribedDetails.copy(address = address)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeContactNameController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeContactNameController.scala
@@ -58,7 +58,7 @@ class SubscribedChangeContactNameController @Inject() (
   override val isSubscribedJourney: Boolean = true
 
   override def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, Subscribed)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, s: Subscribed)) => Right(sessionData -> s)
@@ -67,7 +67,7 @@ class SubscribedChangeContactNameController @Inject() (
 
   override def updateContactName(journey: Subscribed, contactName: ContactName)(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, Subscribed] = {
     val journeyWithUpdatedContactName =
       journey.subscribedDetails.copy(contactName = contactName)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeEmailController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeEmailController.scala
@@ -65,7 +65,7 @@ class SubscribedChangeEmailController @Inject() (
     with EmailController[ChangingAccountEmail] {
 
   override def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, ChangingAccountEmail)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, s: Subscribed)) =>
@@ -74,7 +74,7 @@ class SubscribedChangeEmailController @Inject() (
     }
 
   override def validVerificationCompleteJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, ChangingAccountEmail)] =
     validJourney(request)
 
@@ -83,7 +83,7 @@ class SubscribedChangeEmailController @Inject() (
     email: Email
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] = {
     val journey                 = changingAccountEmail.journey
     val journeyWithUpdatedEmail =
@@ -105,7 +105,7 @@ class SubscribedChangeEmailController @Inject() (
   override def auditEmailVerifiedEvent(
     changingAccountEmail: ChangingAccountEmail,
     email: Email
-  )(implicit hc: HeaderCarrier, request: Request[_]): Unit = {
+  )(implicit hc: HeaderCarrier, request: Request[?]): Unit = {
     val journey = changingAccountEmail.journey
     auditService.sendEvent(
       "changeEmailAddressVerified",
@@ -123,7 +123,7 @@ class SubscribedChangeEmailController @Inject() (
   override def auditEmailChangeAttempt(
     changingAccountEmail: ChangingAccountEmail,
     email: Email
-  )(implicit hc: HeaderCarrier, request: Request[_]): Unit = {
+  )(implicit hc: HeaderCarrier, request: Request[?]): Unit = {
     val journey = changingAccountEmail.journey
     auditService.sendEvent(
       "changeEmailAddressAttempted",
@@ -141,20 +141,20 @@ class SubscribedChangeEmailController @Inject() (
   override def name(changingAccountEmail: ChangingAccountEmail): ContactName =
     changingAccountEmail.journey.subscribedDetails.contactName
 
-  override lazy protected val backLinkCall: Option[Call]      = Some(
+  override protected lazy val backLinkCall: Option[Call]      = Some(
     controllers.accounts.routes.AccountController.manageYourDetails()
   )
-  override lazy protected val enterEmailCall: Call            =
+  override protected lazy val enterEmailCall: Call            =
     routes.SubscribedChangeEmailController.enterEmail()
-  override lazy protected val enterEmailSubmitCall: Call      =
+  override protected lazy val enterEmailSubmitCall: Call      =
     routes.SubscribedChangeEmailController.enterEmailSubmit()
-  override lazy protected val checkYourInboxCall: Call        =
+  override protected lazy val checkYourInboxCall: Call        =
     routes.SubscribedChangeEmailController.checkYourInbox()
-  override lazy protected val verifyEmailCall: UUID => Call   =
+  override protected lazy val verifyEmailCall: UUID => Call   =
     routes.SubscribedChangeEmailController.verifyEmail
-  override lazy protected val emailVerifiedCall: Call         =
+  override protected lazy val emailVerifiedCall: Call         =
     routes.SubscribedChangeEmailController.emailVerified()
-  override lazy protected val emailVerifiedContinueCall: Call =
+  override protected lazy val emailVerifiedContinueCall: Call =
     controllers.accounts.routes.AccountController.contactEmailUpdated()
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedWithoutIdChangeContactNameController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedWithoutIdChangeContactNameController.scala
@@ -60,7 +60,7 @@ class SubscribedWithoutIdChangeContactNameController @Inject() (
   override val isSubscribedJourney: Boolean = true
 
   override def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, Subscribed)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, r: Subscribed)) => Right(sessionData -> r)
@@ -69,7 +69,7 @@ class SubscribedWithoutIdChangeContactNameController @Inject() (
 
   override def updateName(journey: Subscribed, name: IndividualName)(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, Subscribed] = {
     val contactName            = s"${name.firstName} ${name.lastName}"
     val journeyWithUpdatedName =

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SessionDataAction.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SessionDataAction.scala
@@ -33,6 +33,8 @@ final case class RequestWithSessionData[A](
   override def messagesApi: MessagesApi =
     authenticatedRequest.request.messagesApi
   val userType: Option[UserType]        = sessionData.flatMap(_.userType)
+
+  def toSession: SessionData = sessionData.getOrElse(SessionData.empty)
 }
 
 @Singleton

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SessionDataActionBase.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SessionDataActionBase.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait SessionDataActionBase[R[_] <: Request[_], P[_] <: Request[_]] extends ActionRefiner[R, P] with Logging {
+trait SessionDataActionBase[R[_] <: Request[?], P[_] <: Request[?]] extends ActionRefiner[R, P] with Logging {
 
   val sessionStore: SessionStore
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/agents/AgentAccessController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/agents/AgentAccessController.scala
@@ -48,7 +48,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.AuditService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.onboarding.SubscriptionService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging.LoggerOps
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, views}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -241,7 +241,7 @@ class AgentAccessController @Inject() (
                                   }
 
             _ <- EitherT(
-                   updateSession(sessionStore, request)(
+                   updateSession(sessionStore, request.toSession)(
                      _.copy(
                        journeyStatus = Some(
                          Subscribed(
@@ -291,7 +291,7 @@ class AgentAccessController @Inject() (
     ggCredId: GGCredId
   )(implicit
     hc: HeaderCarrier,
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Future[Result] =
     authorisedFunctions
       .authorised(
@@ -325,7 +325,7 @@ class AgentAccessController @Inject() (
                        )
 
           _ <- EitherT(
-                 updateSession(sessionStore, request)(
+                 updateSession(sessionStore, request.toSession)(
                    _.copy(
                      journeyStatus = Some(
                        AgentSupplyingClientDetails(
@@ -384,11 +384,11 @@ class AgentAccessController @Inject() (
       UnsuccessfulVerifierAttempts
     ]
   )(implicit
-    request: RequestWithSessionData[_],
+    request: RequestWithSessionData[?],
     toEither: V => Either[Country, Postcode]
   ): Future[Result] = {
     lazy val handleMatchedVerifier: Future[Result] =
-      updateSession(sessionStore, request)(
+      updateSession(sessionStore, request.toSession)(
         _.copy(
           journeyStatus = Some(
             currentAgentSupplyingClientDetails.copy(
@@ -509,7 +509,7 @@ class AgentAccessController @Inject() (
 
   private def withAgentSupplyingClientDetails(
     f: AgentSupplyingClientDetails => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     request.sessionData.flatMap(_.journeyStatus) match {
       case Some(a: AgentStatus.AgentSupplyingClientDetails) => f(a)
       case _                                                => Redirect(controllers.routes.StartController.start())
@@ -521,7 +521,7 @@ class AgentAccessController @Inject() (
       VerifierMatchingDetails,
       Option[UnsuccessfulVerifierAttempts]
     ) => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     request.sessionData.flatMap(_.journeyStatus) match {
       case Some(a @ AgentStatus.AgentSupplyingClientDetails(_, _, Some(v))) =>
         agentVerifierMatchRetryStore

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/SubscriptionController.scala
@@ -23,7 +23,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.{ErrorHandler, ViewConfig}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.routes
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.{routes => onboardingRoutes}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AlreadySubscribedWithDifferentGGAccount, Subscribed}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.CgtReference
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
@@ -75,7 +75,7 @@ class SubscriptionController @Inject() (
         _                    <- EitherT(
                                   subscriptionResponse match {
                                     case SubscriptionSuccessful(cgtReferenceNumber) =>
-                                      updateSession(sessionStore, request)(
+                                      updateSession(sessionStore, request.sessionData)(
                                         _.copy(
                                           journeyStatus = Some(
                                             Subscribed(
@@ -97,7 +97,7 @@ class SubscriptionController @Inject() (
                                         )
                                       )
                                     case AlreadySubscribed                          =>
-                                      updateSession(sessionStore, request)(
+                                      updateSession(sessionStore, request.sessionData)(
                                         _.copy(
                                           journeyStatus = Some(
                                             AlreadySubscribedWithDifferentGGAccount(
@@ -130,7 +130,7 @@ class SubscriptionController @Inject() (
               case Left(e)  => logger.warn(s"Failed to clear name mismatch session cache for $ggCredId", e)
               case Right(_) => logger.info(s"Cleared name mismatch session cache for $ggCredId")
             }
-            Redirect(routes.SubscriptionController.subscribed())
+            Redirect(onboardingRoutes.SubscriptionController.subscribed())
           case AlreadySubscribed                          =>
             logger.info("Response to subscription request indicated that the user has already subscribed to cgt")
             auditService.sendEvent(
@@ -142,7 +142,7 @@ class SubscriptionController @Inject() (
               "access-with-wrong-gg-account"
             )
             Redirect(
-              routes.SubscriptionController
+              onboardingRoutes.SubscriptionController
                 .alreadySubscribedWithDifferentGGAccount()
             )
         }
@@ -169,7 +169,7 @@ class SubscriptionController @Inject() (
 
   def changeGGAccountForSubscription(): Action[AnyContent] =
     authenticatedActionWithSubscriptionReady { implicit request =>
-      Ok(changeGGAccountPage(routes.SubscriptionController.checkYourDetails()))
+      Ok(changeGGAccountPage(onboardingRoutes.SubscriptionController.checkYourDetails()))
     }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/RegistrationChangeAddressController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/RegistrationChangeAddressController.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.audit.{AuditAd
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus, SessionData}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.{AuditService, UKAddressLookupService}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.address.AddressJourneyType.Onboarding.RegistrationReadyAddressJourney
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, views}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -65,7 +65,7 @@ class RegistrationChangeAddressController @Inject() (
   def isATrust(journey: RegistrationReadyAddressJourney): Boolean = false
 
   def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Future[Result], (SessionData, RegistrationReadyAddressJourney)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, r: RegistrationReady)) =>
@@ -79,7 +79,7 @@ class RegistrationChangeAddressController @Inject() (
     isManuallyEnteredAddress: Boolean
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] = {
     auditService.sendEvent(
       "registrationContactAddressChanged",

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/RegistrationEnterAddressController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/RegistrationEnterAddressController.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus, SessionData}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.{AuditService, UKAddressLookupService}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.address.AddressJourneyType.Onboarding.IndividualSupplyingInformationAddressJourney
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, views}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -65,7 +65,7 @@ class RegistrationEnterAddressController @Inject() (
     false
 
   def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Future[Result], (SessionData, IndividualSupplyingInformationAddressJourney)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some(
@@ -85,7 +85,7 @@ class RegistrationEnterAddressController @Inject() (
     isManuallyEnteredAddress: Boolean
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] =
     EitherT.pure[Future, Error](journey.journey.copy(address = Some(address)))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/SubscriptionEnterAddressController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/SubscriptionEnterAddressController.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.audit.{AuditAd
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus, SessionData}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.{AuditService, UKAddressLookupService}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.address.AddressJourneyType.Onboarding.SubscriptionEnterAddressJourney
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, views}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -64,7 +64,7 @@ class SubscriptionEnterAddressController @Inject() (
     journey.journey.businessPartnerRecord.name.isLeft
 
   def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Future[Result], (SessionData, SubscriptionEnterAddressJourney)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, s: SubscriptionMissingData)) => Right(sessionData -> SubscriptionEnterAddressJourney(s))
@@ -77,7 +77,7 @@ class SubscriptionEnterAddressController @Inject() (
     isManuallyEnteredAddress: Boolean
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] = {
     auditService.sendEvent(
       "subscriptionSetupContactAddress",

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/RegistrationChangeEmailController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/RegistrationChangeEmailController.scala
@@ -61,7 +61,7 @@ class RegistrationChangeEmailController @Inject() (
     with EmailController[ChangingRegistrationEmail] {
 
   override def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, ChangingRegistrationEmail)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, r: RegistrationReady)) =>
@@ -70,7 +70,7 @@ class RegistrationChangeEmailController @Inject() (
     }
 
   override def validVerificationCompleteJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, ChangingRegistrationEmail)] =
     validJourney(request)
 
@@ -79,7 +79,7 @@ class RegistrationChangeEmailController @Inject() (
     email: Email
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] =
     EitherT.rightT[Future, Error](
       changingRegistrationEmail.journey.copy(
@@ -93,7 +93,7 @@ class RegistrationChangeEmailController @Inject() (
   override def auditEmailVerifiedEvent(
     changingRegistrationEmail: ChangingRegistrationEmail,
     email: Email
-  )(implicit hc: HeaderCarrier, request: Request[_]): Unit =
+  )(implicit hc: HeaderCarrier, request: Request[?]): Unit =
     auditService.sendEvent(
       "registrationChangeEmailAddressVerified",
       RegistrationChangeEmailAddressVerifiedEvent(
@@ -106,7 +106,7 @@ class RegistrationChangeEmailController @Inject() (
   override def auditEmailChangeAttempt(
     changingRegistrationEmail: ChangingRegistrationEmail,
     email: Email
-  )(implicit hc: HeaderCarrier, request: Request[_]): Unit =
+  )(implicit hc: HeaderCarrier, request: Request[?]): Unit =
     auditService.sendEvent(
       "registrationChangeEmailAddressAttempted",
       RegistrationChangeEmailAttemptedEvent(
@@ -123,21 +123,21 @@ class RegistrationChangeEmailController @Inject() (
       changingRegistrationEmail.journey.registrationDetails.name.makeSingleName
     )
 
-  override lazy protected val backLinkCall: Option[Call] = Some(
+  override protected lazy val backLinkCall: Option[Call] = Some(
     controllers.onboarding.routes.RegistrationController.checkYourAnswers()
   )
 
-  override lazy protected val enterEmailCall: Call          =
+  override protected lazy val enterEmailCall: Call          =
     routes.RegistrationChangeEmailController.enterEmail()
-  override lazy protected val enterEmailSubmitCall: Call    =
+  override protected lazy val enterEmailSubmitCall: Call    =
     routes.RegistrationChangeEmailController.enterEmailSubmit()
-  override lazy protected val checkYourInboxCall: Call      =
+  override protected lazy val checkYourInboxCall: Call      =
     routes.RegistrationChangeEmailController.checkYourInbox()
-  override lazy protected val verifyEmailCall: UUID => Call =
+  override protected lazy val verifyEmailCall: UUID => Call =
     routes.RegistrationChangeEmailController.verifyEmail
-  override lazy protected val emailVerifiedCall: Call       =
+  override protected lazy val emailVerifiedCall: Call       =
     routes.RegistrationChangeEmailController.emailVerified()
 
-  override lazy protected val emailVerifiedContinueCall: Call =
+  override protected lazy val emailVerifiedContinueCall: Call =
     controllers.onboarding.routes.RegistrationController.checkYourAnswers()
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/RegistrationEnterEmailController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/RegistrationEnterEmailController.scala
@@ -62,7 +62,7 @@ class RegistrationEnterEmailController @Inject() (
     with EmailController[EnteringRegistrationEmail] {
 
   override def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, EnteringRegistrationEmail)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, i: IndividualMissingEmail)) =>
@@ -71,7 +71,7 @@ class RegistrationEnterEmailController @Inject() (
     }
 
   override def validVerificationCompleteJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, EnteringRegistrationEmail)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, r: RegistrationReady)) =>
@@ -84,7 +84,7 @@ class RegistrationEnterEmailController @Inject() (
     email: Email
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] =
     EitherT.rightT[Future, Error](
       RegistrationReady(
@@ -103,7 +103,7 @@ class RegistrationEnterEmailController @Inject() (
   override def auditEmailVerifiedEvent(
     enteringRegistrationEmail: EnteringRegistrationEmail,
     email: Email
-  )(implicit hc: HeaderCarrier, request: Request[_]): Unit =
+  )(implicit hc: HeaderCarrier, request: Request[?]): Unit =
     auditService.sendEvent(
       "registrationSetupEmailAddressVerified",
       RegistrationSetupEmailVerifiedEvent(
@@ -115,7 +115,7 @@ class RegistrationEnterEmailController @Inject() (
   override def auditEmailChangeAttempt(
     enteringRegistrationEmail: EnteringRegistrationEmail,
     email: Email
-  )(implicit hc: HeaderCarrier, request: Request[_]): Unit =
+  )(implicit hc: HeaderCarrier, request: Request[?]): Unit =
     auditService.sendEvent(
       "registrationSetupEmailAddressAttempted",
       RegistrationSetupEmailAttemptedEvent(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/RegistrationChangeIndividualNameController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/RegistrationChangeIndividualNameController.scala
@@ -55,7 +55,7 @@ class RegistrationChangeIndividualNameController @Inject() (
   override val isSubscribedJourney: Boolean = false
 
   override def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, RegistrationReady)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, r: RegistrationReady)) => Right(sessionData -> r)
@@ -64,7 +64,7 @@ class RegistrationChangeIndividualNameController @Inject() (
 
   override def updateName(journey: RegistrationReady, name: IndividualName)(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, RegistrationReady] = {
     auditService.sendEvent(
       "registrationContactNameChanged",

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/RegistrationEnterIndividualNameController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/RegistrationEnterIndividualNameController.scala
@@ -52,7 +52,7 @@ class RegistrationEnterIndividualNameController @Inject() (
   override val isSubscribedJourney: Boolean = false
 
   override def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, IndividualSupplyingInformation)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, i: IndividualSupplyingInformation)) =>
@@ -65,7 +65,7 @@ class RegistrationEnterIndividualNameController @Inject() (
     name: IndividualName
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, IndividualSupplyingInformation] =
     EitherT.rightT[Future, Error](journey.copy(name = Some(name)))
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/SubscriptionChangeContactNameController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/SubscriptionChangeContactNameController.scala
@@ -56,7 +56,7 @@ class SubscriptionChangeContactNameController @Inject() (
   override val isSubscribedJourney: Boolean = false
 
   override def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, SubscriptionReady)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, s: SubscriptionReady)) => Right(sessionData -> s)
@@ -68,7 +68,7 @@ class SubscriptionChangeContactNameController @Inject() (
     contactName: ContactName
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, SubscriptionReady] = {
     auditService.sendEvent(
       "subscriptionContactNameChanged",

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/DraftReturnSavedController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/DraftReturnSavedController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.FillingOutR
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TimeUtils
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsService
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/StartingToAmendToFillingOutReturnBehaviour.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/StartingToAmendToFillingOutReturnBehaviour.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait StartingToAmendToFillingOutReturnBehaviour { this: FrontendController with SessionUpdates with Logging =>
+trait StartingToAmendToFillingOutReturnBehaviour { this: FrontendController & SessionUpdates & Logging =>
 
   def convertFromStartingAmendToFillingOutReturn(
     startingToAmendReturn: StartingToAmendReturn,
@@ -41,10 +41,10 @@ trait StartingToAmendToFillingOutReturnBehaviour { this: FrontendController with
     errorHandler: ErrorHandler,
     uuidGenerator: UUIDGenerator,
     redirectUrlOverride: Option[String] = None
-  )(implicit request: RequestWithSessionData[_], hc: HeaderCarrier, ec: ExecutionContext): Future[Result] = {
+  )(implicit request: RequestWithSessionData[?], hc: HeaderCarrier, ec: ExecutionContext): Future[Result] = {
     val fillingOutReturn = toFillingOutReturn(startingToAmendReturn, uuidGenerator)
 
-    updateSession(sessionStore, request)(
+    updateSession(sessionStore, request.toSession)(
       _.copy(
         journeyStatus = Some(fillingOutReturn)
       )
@@ -65,11 +65,11 @@ trait StartingToAmendToFillingOutReturnBehaviour { this: FrontendController with
     sessionStore: SessionStore,
     errorHandler: ErrorHandler
   )(implicit
-    request: RequestWithSessionData[_],
+    request: RequestWithSessionData[?],
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[Result] =
-    updateSession(sessionStore, request)(
+    updateSession(sessionStore, request.toSession)(
       _.copy(journeyStatus = Some(startingToAmendReturn.copy(unmetDependencyFieldUrl = Some(request.uri))))
     ).map {
       case Left(e) =>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/TaskListController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/TaskListController.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, TimeUtils}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.{tasklist => taskListPages}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -89,7 +89,7 @@ class TaskListController @Inject() (
     draftReturn: DraftReturn,
     journey: FillingOutReturn
   )(implicit
-    request: RequestWithSessionData[_],
+    request: RequestWithSessionData[?],
     hc: HeaderCarrier
   ) = {
     val updatedUploadSupportingEvidenceAnswers =
@@ -175,7 +175,7 @@ class TaskListController @Inject() (
       for {
         _ <- returnsService.storeDraftReturn(journey)
         _ <- EitherT(
-               updateSession(sessionStore, request)(
+               updateSession(sessionStore, request.toSession)(
                  _.copy(journeyStatus = Some(journey.copy(draftReturn = updatedDraftReturn)))
                )
              )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnController.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Amend, CompleteReturnWit
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.PaymentsService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -100,7 +100,7 @@ class ViewReturnController @Inject() (
             None
           )
 
-          updateSession(sessionStore, request)(
+          updateSession(sessionStore, request.toSession)(
             _.copy(journeyStatus = Some(newJourneyStatus), journeyType = Some(Amend))
           )
             .map {
@@ -151,7 +151,7 @@ class ViewReturnController @Inject() (
 
   private def withViewingReturn()(
     f: ViewingReturn => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     request.sessionData.flatMap(_.journeyStatus) match {
       case Some(v: ViewingReturn) => f(v)
 
@@ -166,7 +166,7 @@ class ViewReturnController @Inject() (
           s.previousSentReturns
         )
 
-        updateSession(sessionStore, request)(_.copy(journeyStatus = Some(journeyStatus))).flatMap {
+        updateSession(sessionStore, request.toSession)(_.copy(journeyStatus = Some(journeyStatus))).flatMap {
           case Left(e) =>
             logger.warn("Could not update session", e)
             errorHandler.errorResult()

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsController.scala
@@ -46,7 +46,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging.LoggerOps
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.{acquisitiondetails => pages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -93,7 +93,7 @@ class AcquisitionDetailsController @Inject() (
       JourneyState,
       AcquisitionDetailsAnswers
     ) => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] = {
+  )(implicit request: RequestWithSessionData[?]): Future[Result] = {
     def defaultAnswers(
       triageAnswers: SingleDisposalTriageAnswers,
       representeeAnswers: Option[RepresenteeAnswers],
@@ -261,7 +261,7 @@ class AcquisitionDetailsController @Inject() (
   )(
     updateState: (A, AcquisitionDetailsAnswers, JourneyState) => JourneyState
   )(implicit
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Future[Result] =
     if (requiredPreviousAnswer(currentAnswers)) {
       lazy val backLink = currentAnswers.fold(
@@ -285,7 +285,7 @@ class AcquisitionDetailsController @Inject() (
                      returnsService.storeDraftReturn(newJourney)
                    }
               _ <- EitherT(
-                     updateSession(sessionStore, request)(
+                     updateSession(sessionStore, request.toSession)(
                        _.copy(journeyStatus = Some(newJourney))
                      )
                    )
@@ -757,7 +757,7 @@ class AcquisitionDetailsController @Inject() (
                     )
                   }
                 )(
-                  requiredPreviousAnswer = answers => {
+                  requiredPreviousAnswer = answers =>
                     if (wasUkResident) {
                       noAnswersRequired
                     } else {
@@ -767,8 +767,7 @@ class AcquisitionDetailsController @Inject() (
                           c => Some(c.acquisitionPrice)
                         )
                         .isDefined
-                    }
-                  },
+                    },
                   redirectToIfNoRequiredPreviousAnswer = routes.AcquisitionDetailsController.acquisitionPrice()
                 )(
                   updateState = { (p, answers, draftReturn) =>
@@ -1355,7 +1354,7 @@ class AcquisitionDetailsController @Inject() (
     fillingOutReturn: FillingOutReturn,
     assetType: AssetType,
     wasAUkResident: Boolean
-  )(implicit request: RequestWithSessionData[_]): Future[Result] = {
+  )(implicit request: RequestWithSessionData[?]): Future[Result] = {
     val newDraftReturn =
       state.fold(
         _.copy(acquisitionDetailsAnswers = Some(completeAnswers)),
@@ -1367,7 +1366,7 @@ class AcquisitionDetailsController @Inject() (
     val result = for {
       _ <- returnsService.storeDraftReturn(newJourney)
       _ <- EitherT(
-             updateSession(sessionStore, request)(
+             updateSession(sessionStore, request.toSession)(
                _.copy(journeyStatus = Some(newJourney))
              )
            )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnController.scala
@@ -39,7 +39,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.audit.CancelAmend
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.BooleanFormatter
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.AuditService
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.{amend => pages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -216,7 +216,7 @@ class AmendReturnController @Inject() (
   }
 
   private def withStartingToAmendReturn(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   )(f: StartingToAmendReturn => Future[Result]): Future[Result] =
     request.sessionData.flatMap(_.journeyStatus) match {
       case Some(s: StartingToAmendReturn) => f(s)
@@ -224,7 +224,7 @@ class AmendReturnController @Inject() (
     }
 
   private def withStartingToAmendOrFillingOutReturn(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   )(f: Either[StartingToAmendReturn, (FillingOutReturn, AmendReturnData)] => Future[Result]): Future[Result] =
     request.sessionData.flatMap(_.journeyStatus) match {
       case Some(s: StartingToAmendReturn)                                   => f(Left(s))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/exemptionandlosses/ExemptionAndLossesController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/exemptionandlosses/ExemptionAndLossesController.scala
@@ -40,7 +40,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.FurtherReturnCalculationEligibility.{Eligible, Ineligible}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.{FurtherReturnCalculationEligibilityUtil, ReturnsService}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging.LoggerOps
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.{exemptionandlosses => pages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -76,7 +76,7 @@ class ExemptionAndLossesController @Inject() (
       DraftReturn,
       ExemptionAndLossesAnswers
     ) => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
 
       case Some((_, s: StartingToAmendReturn)) =>
@@ -198,7 +198,7 @@ class ExemptionAndLossesController @Inject() (
   )(
     updateAnswers: (A, ExemptionAndLossesAnswers) => ExemptionAndLossesAnswers
   )(implicit
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Future[Result] =
     if (requiredPreviousAnswer(currentAnswers).isDefined) {
       lazy val backLink = currentAnswers.fold(
@@ -254,7 +254,7 @@ class ExemptionAndLossesController @Inject() (
               val result = for {
                 _ <- returnsService.storeDraftReturn(updatedJourney)
                 _ <- EitherT(
-                       updateSession(sessionStore, request)(
+                       updateSession(sessionStore, request.toSession)(
                          _.copy(journeyStatus = Some(updatedJourney))
                        )
                      )
@@ -609,7 +609,7 @@ class ExemptionAndLossesController @Inject() (
                   val result = for {
                     _ <- returnsService.storeDraftReturn(newJourney)
                     _ <- EitherT(
-                           updateSession(sessionStore, request)(
+                           updateSession(sessionStore, request.toSession)(
                              _.copy(journeyStatus = Some(newJourney))
                            )
                          )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/gainorlossafterreliefs/GainOrLossAfterReliefsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/gainorlossafterreliefs/GainOrLossAfterReliefsController.scala
@@ -37,7 +37,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{ConditionalRadioUtils, F
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.{FurtherReturnCalculationEligibility, FurtherReturnCalculationEligibilityUtil, ReturnsService}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, views}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -167,7 +167,7 @@ class GainOrLossAfterReliefsController @Inject() (
                 val result = for {
                   _ <- returnsService.storeDraftReturn(updatedJourney)
                   _ <- EitherT(
-                         updateSession(sessionStore, request)(
+                         updateSession(sessionStore, request.toSession)(
                            _.copy(journeyStatus = Some(updatedJourney))
                          )
                        )
@@ -223,7 +223,7 @@ class GainOrLossAfterReliefsController @Inject() (
       DraftReturn,
       Option[AmountInPence]
     ) => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     request.sessionData.flatMap(_.journeyStatus) match {
       case Some(s: StartingToAmendReturn) =>
         convertFromStartingAmendToFillingOutReturn(s, sessionStore, errorHandler, uuidGenerator)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/initialgainorloss/InitialGainOrLossController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/initialgainorloss/InitialGainOrLossController.scala
@@ -37,7 +37,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{ConditionalRadioUtils, F
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging.LoggerOps
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, views}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -117,7 +117,7 @@ class InitialGainOrLossController @Inject() (
                 val result = for {
                   _ <- returnsService.storeDraftReturn(updatedJourney)
                   _ <- EitherT(
-                         updateSession(sessionStore, request)(
+                         updateSession(sessionStore, request.toSession)(
                            _.copy(journeyStatus = Some(updatedJourney))
                          )
                        )
@@ -180,7 +180,7 @@ class InitialGainOrLossController @Inject() (
       DraftSingleDisposalReturn,
       Option[AmountInPence]
     ) => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     request.sessionData.flatMap(_.journeyStatus) match {
       case Some(s: StartingToAmendReturn) =>
         markUnmetDependency(s, sessionStore, errorHandler)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/ChangeRepresenteeContactAddressController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/ChangeRepresenteeContactAddressController.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus, Se
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.{AuditService, UKAddressLookupService}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.address.AddressJourneyType.Returns.ChangingRepresenteeContactAddressJourney
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, views}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -82,7 +82,7 @@ class ChangeRepresenteeContactAddressController @Inject() (
     )
 
   def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Future[Result], (SessionData, ChangingRepresenteeContactAddressJourney)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, s: StartingNewDraftReturn)) =>
@@ -121,7 +121,7 @@ class ChangeRepresenteeContactAddressController @Inject() (
     isManuallyEnteredAddress: Boolean
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] = {
     val newContactDetails = journey.contactDetails.copy(address = address)
     val newAnswers        = journey.answers.fold(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/ChangeRepresenteeEmailController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/ChangeRepresenteeEmailController.scala
@@ -75,7 +75,7 @@ class ChangeRepresenteeEmailController @Inject() (
     )
 
   def validJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, ChangingRepresenteeEmail)] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((sessionData, s: StartingNewDraftReturn)) =>
@@ -109,7 +109,7 @@ class ChangeRepresenteeEmailController @Inject() (
     }
 
   override def validVerificationCompleteJourney(
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): Either[Result, (SessionData, ChangingRepresenteeEmail)] =
     validJourney(request)
 
@@ -118,7 +118,7 @@ class ChangeRepresenteeEmailController @Inject() (
     email: Email
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, JourneyStatus] =
     if (changingRepresenteeEmail.contactDetails.emailAddress === email) {
       EitherT.pure[Future, Error](changingRepresenteeEmail.journey.merge)
@@ -169,12 +169,12 @@ class ChangeRepresenteeEmailController @Inject() (
   override def auditEmailVerifiedEvent(
     changingRepresenteeEmail: ChangingRepresenteeEmail,
     email: Email
-  )(implicit hc: HeaderCarrier, request: Request[_]): Unit = ()
+  )(implicit hc: HeaderCarrier, request: Request[?]): Unit = ()
 
   override def auditEmailChangeAttempt(
     ChangingRepresenteeEmail: ChangingRepresenteeEmail,
     email: Email
-  )(implicit hc: HeaderCarrier, request: Request[_]): Unit = ()
+  )(implicit hc: HeaderCarrier, request: Request[?]): Unit = ()
 
   override def name(
     changingRepresenteeEmail: ChangingRepresenteeEmail

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/supportingevidence/SupportingEvidenceController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/supportingevidence/SupportingEvidenceController.scala
@@ -44,7 +44,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.upscan.UpscanService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging.LoggerOps
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.{supportingevidence => pages}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -84,7 +84,7 @@ class SupportingEvidenceController @Inject() (
       FillingOutReturn,
       SupportingEvidenceAnswers
     ) => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((_, s: StartingToAmendReturn)) =>
         convertFromStartingAmendToFillingOutReturn(s, sessionStore, errorHandler, uuidGenerator)
@@ -210,7 +210,7 @@ class SupportingEvidenceController @Inject() (
                 val result = for {
                   _ <- returnsService.storeDraftReturn(newJourney)
                   _ <- EitherT(
-                         updateSession(sessionStore, request)(_.copy(journeyStatus = Some(newJourney)))
+                         updateSession(sessionStore, request.toSession)(_.copy(journeyStatus = Some(newJourney)))
                        )
                 } yield ()
                 result.fold(
@@ -250,7 +250,7 @@ class SupportingEvidenceController @Inject() (
                 val result = for {
                   _ <- returnsService.storeDraftReturn(newJourney)
                   _ <- EitherT(
-                         updateSession(sessionStore, request)(
+                         updateSession(sessionStore, request.toSession)(
                            _.copy(journeyStatus = Some(newJourney))
                          )
                        )
@@ -375,7 +375,7 @@ class SupportingEvidenceController @Inject() (
     answers: IncompleteSupportingEvidenceAnswers,
     fillingOutReturn: FillingOutReturn
   )(implicit
-    request: RequestWithSessionData[_],
+    request: RequestWithSessionData[?],
     hc: HeaderCarrier
   ) = {
     val newAnswers =
@@ -404,7 +404,7 @@ class SupportingEvidenceController @Inject() (
     for {
       _ <- returnsService.storeDraftReturn(newJourney)
       _ <- EitherT(
-             updateSession(sessionStore, request)(
+             updateSession(sessionStore, request.toSession)(
                _.copy(journeyStatus = Some(newJourney))
              )
            )
@@ -449,7 +449,7 @@ class SupportingEvidenceController @Inject() (
         val result = for {
           _ <- returnsService.storeDraftReturn(newJourney)
           _ <- EitherT(
-                 updateSession(sessionStore, request)(
+                 updateSession(sessionStore, request.toSession)(
                    _.copy(journeyStatus = Some(newJourney))
                  )
                )
@@ -519,7 +519,7 @@ class SupportingEvidenceController @Inject() (
         val result = for {
           _ <- returnsService.storeDraftReturn(newJourney)
           _ <- EitherT(
-                 updateSession(sessionStore, request)(
+                 updateSession(sessionStore, request.toSession)(
                    _.copy(journeyStatus = Some(newJourney))
                  )
                )
@@ -537,7 +537,7 @@ class SupportingEvidenceController @Inject() (
 
   private def checkYourAnswersHandler(
     answers: SupportingEvidenceAnswers
-  )(implicit request: RequestWithSessionData[_]) =
+  )(implicit request: RequestWithSessionData[?]) =
     answers match {
       case IncompleteSupportingEvidenceAnswers(_, _, expiredEvidences) if expiredEvidences.nonEmpty =>
         Redirect(
@@ -625,7 +625,7 @@ class SupportingEvidenceController @Inject() (
             val result = for {
               _ <- returnsService.storeDraftReturn(updatedJourney)
               _ <- EitherT(
-                     updateSession(sessionStore, request)(
+                     updateSession(sessionStore, request.toSession)(
                        _.copy(journeyStatus = Some(updatedJourney))
                      )
                    )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsController.scala
@@ -42,7 +42,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{BooleanFormatter, Error,
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging.LoggerOps
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.{amend => amendPages, triage => triagePages}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -164,7 +164,7 @@ class CommonTriageQuestionsController @Inject() (
                              returnsService.storeDraftReturn(_)
                            )
                       _ <- EitherT(
-                             updateSession(sessionStore, request)(
+                             updateSession(sessionStore, request.toSession)(
                                _.copy(journeyStatus = Some(updatedState.merge))
                              )
                            )
@@ -218,7 +218,7 @@ class CommonTriageQuestionsController @Inject() (
   private def howManyPropertiesCommon(
     state: Either[StartingNewDraftReturn, FillingOutReturn],
     isFurtherOrAmendReturn: Boolean
-  )(implicit r: RequestWithSessionData[_]): Future[Result] = {
+  )(implicit r: RequestWithSessionData[?]): Future[Result] = {
     val form =
       getNumberOfProperties(state).fold(numberOfPropertiesForm)(
         numberOfPropertiesForm.fill
@@ -284,7 +284,7 @@ class CommonTriageQuestionsController @Inject() (
   private def howManyPropertiesSubmitCommon(
     state: Either[StartingNewDraftReturn, FillingOutReturn],
     isFurtherOrAmendReturn: Boolean
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     numberOfPropertiesForm
       .bindFromRequest()
       .fold(
@@ -317,7 +317,7 @@ class CommonTriageQuestionsController @Inject() (
                        returnsService.storeDraftReturn(_)
                      )
                 _ <- EitherT(
-                       updateSession(sessionStore, request)(
+                       updateSession(sessionStore, request.toSession)(
                          _.copy(journeyStatus = Some(updatedState.merge))
                        )
                      )
@@ -705,7 +705,7 @@ class CommonTriageQuestionsController @Inject() (
                            returnsService.storeDraftReturn(_)
                          )
                     _ <- EitherT(
-                           updateSession(sessionStore, request)(
+                           updateSession(sessionStore, request.toSession)(
                              _.copy(journeyStatus = Some(updatedState.merge))
                            )
                          )
@@ -892,7 +892,7 @@ class CommonTriageQuestionsController @Inject() (
                            returnsService.storeDraftReturn(_)
                          )
                     _ <- EitherT(
-                           updateSession(sessionStore, request)(
+                           updateSession(sessionStore, request.toSession)(
                              _.copy(journeyStatus = Some(updatedState.merge))
                            )
                          )
@@ -1255,7 +1255,7 @@ class CommonTriageQuestionsController @Inject() (
       SessionData,
       Either[StartingNewDraftReturn, FillingOutReturn]
     ) => Future[Result]
-  )(implicit request: RequestWithSessionData[_]): Future[Result] =
+  )(implicit request: RequestWithSessionData[?]): Future[Result] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {
       case Some((_, s: StartingToAmendReturn)) =>
         convertFromStartingAmendToFillingOutReturn(s, sessionStore, errorHandler, uuidGenerator)
@@ -1326,7 +1326,7 @@ object CommonTriageQuestionsController {
             List(TimeUtils.personalRepresentativeDateValidation(personalRepresentativeDetails, key))
           )
         )
-      )(ShareDisposalDate)(d => Some(d.value))
+      )(ShareDisposalDate.apply)(d => Some(d.value))
     )
   }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/FurtherReturnGuidanceController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/FurtherReturnGuidanceController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{SessionUpdates, ret
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingNewDraftReturn, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresentativeType
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{SessionData, TaxYear}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -116,7 +116,7 @@ class FurtherReturnGuidanceController @Inject() (
         )
     )
 
-  private def withJourneyState(request: RequestWithSessionData[_])(
+  private def withJourneyState(request: RequestWithSessionData[?])(
     f: (
       SessionData,
       Either[Either[StartingToAmendReturn, StartingNewDraftReturn], FillingOutReturn]

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/B64Html.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/B64Html.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class B64Html(value: String) extends AnyVal
+final case class B64Html(value: String)
 
 object B64Html {
   implicit val format: OFormat[B64Html] = Json.format[B64Html]

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/BooleanFormatter.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/BooleanFormatter.scala
@@ -21,7 +21,7 @@ import play.api.data.FormError
 import play.api.data.format.Formatter
 
 object BooleanFormatter {
-  //don't want to use out-of-box boolean formatter - that one defaults null values to false
+  // don't want to use out-of-box boolean formatter - that one defaults null values to false
   val formatter: Formatter[Boolean] = new Formatter[Boolean] {
 
     override val format: Option[(String, Nil.type)] = Some(("format.boolean", Nil))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/JourneyType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/JourneyType.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models
 
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait JourneyType
 
@@ -28,6 +27,14 @@ case object Returns extends JourneyType
 case object Amend extends JourneyType
 
 object JourneyType {
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[JourneyType] = derived.oformat()
+  implicit val format: Format[JourneyType] = new Format[JourneyType] {
+    override def reads(json: JsValue): JsResult[JourneyType] = json match {
+      case JsString("OnBoarding") => JsSuccess(OnBoarding)
+      case JsString("Returns")    => JsSuccess(Returns)
+      case JsString("Amend")      => JsSuccess(Amend)
+      case _                      => JsError("Invalid journey type")
+    }
+
+    override def writes(o: JourneyType): JsValue = JsString(o.toString)
+  }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/RetrievedUserType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/RetrievedUserType.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models
 
+import play.api.libs.json.{Format, JsError, JsObject, JsResult, JsValue, Json, OFormat, Reads, Writes}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.Email
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.*
 
 sealed trait RetrievedUserType extends Product with Serializable
 
@@ -55,4 +56,63 @@ object RetrievedUserType {
 
   final case class NonGovernmentGatewayRetrievedUser(authProvider: String) extends RetrievedUserType
 
+  implicit val trustFormat: OFormat[Trust]                                                                         = Json.format[Trust]
+  implicit val organisationUnregisteredTrustFormat: OFormat[OrganisationUnregisteredTrust]                         =
+    Json.format[OrganisationUnregisteredTrust]
+  implicit val individualWithInsufficientConfidenceLevelFormat: OFormat[IndividualWithInsufficientConfidenceLevel] =
+    Json.format[IndividualWithInsufficientConfidenceLevel]
+  implicit val agentFormat: OFormat[Agent]                                                                         = Json.format[Agent]
+  implicit val subscribedFormat: OFormat[Subscribed]                                                               = Json.format[Subscribed]
+  implicit val sautrFormat: Format[SAUTR]                                                                          = SAUTR.format
+  implicit val ninoFormat: Format[NINO]                                                                            = NINO.format
+  implicit val ggCredIdFormat: Format[GGCredId]                                                                    = GGCredId.format
+  implicit val cgtReferenceFormat: Format[CgtReference]                                                            = CgtReference.format
+  implicit val agentReferenceNumberFormat: Format[AgentReferenceNumber]                                            = AgentReferenceNumber.format
+  implicit val emailFormat: Format[Email]                                                                          = Email.format
+  implicit val nonGovernmentGatewayRetrievedUserFormat: OFormat[NonGovernmentGatewayRetrievedUser]                 =
+    Json.format[NonGovernmentGatewayRetrievedUser]
+  implicit val individualFormat: OFormat[Individual]                                                               = {
+    implicit val _: Format[Either[SAUTR, NINO]] =
+      Format(
+        Reads[Either[SAUTR, NINO]] { json =>
+          (json \ "left").validate[SAUTR].map(Left(_)) orElse
+            (json \ "right").validate[NINO].map(Right(_))
+        },
+        Writes {
+          case Left(sautr) => Json.obj("left" -> Json.toJson(sautr))
+          case Right(nino) => Json.obj("right" -> Json.toJson(nino))
+        }
+      )
+
+    Json.format[Individual]
+  }
+
+  implicit val format: OFormat[RetrievedUserType] = new OFormat[RetrievedUserType] {
+    override def reads(json: JsValue): JsResult[RetrievedUserType] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head match {
+          case ("Individual", value)                                => value.validate[Individual]
+          case ("Trust", value)                                     => value.validate[Trust]
+          case ("OrganisationUnregisteredTrust", value)             => value.validate[OrganisationUnregisteredTrust]
+          case ("IndividualWithInsufficientConfidenceLevel", value) =>
+            value.validate[IndividualWithInsufficientConfidenceLevel]
+          case ("Subscribed", value)                                => value.validate[Subscribed]
+          case ("Agent", value)                                     => value.validate[Agent]
+          case ("NonGovernmentGatewayRetrievedUser", value)         => value.validate[NonGovernmentGatewayRetrievedUser]
+          case (other, _)                                           => JsError(s"Unrecognized RetrievedUserType: $other")
+        }
+      case _                                    => JsError("Expected RetrievedUserType wrapper object with a single entry")
+    }
+
+    override def writes(o: RetrievedUserType): JsObject = o match {
+      case i: Individual                                => Json.obj("Individual" -> Json.toJson(i))
+      case t: Trust                                     => Json.obj("Trust" -> Json.toJson(t))
+      case o: OrganisationUnregisteredTrust             => Json.obj("OrganisationUnregisteredTrust" -> Json.toJson(o))
+      case i: IndividualWithInsufficientConfidenceLevel =>
+        Json.obj("IndividualWithInsufficientConfidenceLevel" -> Json.toJson(i))
+      case s: Subscribed                                => Json.obj("Subscribed" -> Json.toJson(s))
+      case a: Agent                                     => Json.obj("Agent" -> Json.toJson(a))
+      case n: NonGovernmentGatewayRetrievedUser         => Json.obj("NonGovernmentGatewayRetrievedUser" -> Json.toJson(n))
+    }
+  }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/TimeUtils.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/TimeUtils.scala
@@ -176,17 +176,17 @@ object TimeUtils {
 
   def govDisplayFormat(date: LocalDate)(implicit messages: Messages): String =
     s"""${date.getDayOfMonth} ${messages(
-      s"date.${date.getMonthValue}"
-    )} ${date.getYear}"""
+        s"date.${date.getMonthValue}"
+      )} ${date.getYear}"""
 
   def govShortDisplayFormat(
     date: LocalDate
   )(implicit messages: Messages): String =
     s"""${date.getDayOfMonth} ${messages(
-      s"date.short.${date.getMonthValue}"
-    )} ${date.getYear}"""
+        s"date.short.${date.getMonthValue}"
+      )} ${date.getYear}"""
 
-  implicit val localDateOrder: Order[LocalDate] = Order.from(_ compareTo _)
+  implicit val localDateOrder: Order[LocalDate] = Order.from(_ `compareTo` _)
 
   // what's the  start date of the tax year the given date falls into?
   def taxYearStart(date: LocalDate): LocalDate = {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/UnsuccessfulNameMatchAttempts.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/UnsuccessfulNameMatchAttempts.scala
@@ -58,7 +58,12 @@ object UnsuccessfulNameMatchAttempts {
     implicit val individualRepresenteeNameMatchDetailsFormat: OFormat[IndividualRepresenteeNameMatchDetails] =
       Json.format[IndividualRepresenteeNameMatchDetails]
 
+    implicit val nameMatchDetailsFormat: OFormat[NameMatchDetails] = Json.format[NameMatchDetails]
   }
+
+  implicit def unsuccessfulNameMatchAttemptsFormat[A <: NameMatchDetails : OFormat]
+    : OFormat[UnsuccessfulNameMatchAttempts[A]] = Json.format[UnsuccessfulNameMatchAttempts[A]]
+
   implicit def unsuccessfulNameMatchAttemptsReads[A <: NameMatchDetails : Reads]
     : Reads[UnsuccessfulNameMatchAttempts[A]] =
     Json.reads[UnsuccessfulNameMatchAttempts[A]]

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/UserType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/UserType.scala
@@ -17,21 +17,29 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait UserType extends Product with Serializable
 
 object UserType {
 
-  final case object Individual extends UserType
-  final case object Organisation extends UserType
-  final case object NonGovernmentGatewayUser extends UserType
-  final case object Agent extends UserType
+  case object Individual extends UserType
+  case object Organisation extends UserType
+  case object NonGovernmentGatewayUser extends UserType
+  case object Agent extends UserType
 
   implicit val eq: Eq[UserType] = Eq.fromUniversalEquals
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[UserType] = derived.oformat()
+  implicit val format: Format[UserType] = new Format[UserType] {
+    override def reads(json: JsValue): JsResult[UserType] = json match {
+      case JsString("Individual")               => JsSuccess(Individual)
+      case JsString("Organisation")             => JsSuccess(Organisation)
+      case JsString("NonGovernmentGatewayUser") => JsSuccess(NonGovernmentGatewayUser)
+      case JsString("Agent")                    => JsSuccess(Agent)
+      case _                                    => JsError("Invalid user type")
+    }
+
+    override def writes(o: UserType): JsValue = JsString(o.toString)
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/address/AddressLookupRequest.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/address/AddressLookupRequest.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address
 
 import play.api.data.Form
-import play.api.data.Forms.{optional, text, mapping => formMapping}
+import play.api.data.Forms.{mapping => formMapping, optional, text}
 
 final case class AddressLookupRequest(
   postcode: Postcode,
@@ -31,6 +31,6 @@ object AddressLookupRequest {
         "postcode" -> Postcode.mapping,
         "filter"   -> optional(text)
           .transform[Option[String]](_.filter(_.nonEmpty), identity)
-      )(AddressLookupRequest.apply)(AddressLookupRequest.unapply)
+      )(AddressLookupRequest.apply)(o => Some((o.postcode, o.filter)))
     )
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/address/AddressSource.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/address/AddressSource.scala
@@ -17,20 +17,28 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait AddressSource extends Product with Serializable
 
 object AddressSource {
 
-  final case object BusinessPartnerRecord extends AddressSource
+  case object BusinessPartnerRecord extends AddressSource
 
-  final case object ManuallyEntered extends AddressSource
+  case object ManuallyEntered extends AddressSource
 
   implicit val eq: Eq[AddressSource] = Eq.fromUniversalEquals[AddressSource]
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[AddressSource] = derived.oformat()
+  implicit val format: Format[AddressSource] = new Format[AddressSource] {
+    override def reads(json: JsValue): JsResult[AddressSource] = json match {
+      case JsString("BusinessPartnerRecord") => JsSuccess(BusinessPartnerRecord)
+      case JsString("ManuallyEntered")       => JsSuccess(ManuallyEntered)
+      case _                                 => JsError("Invalid address source")
+    }
 
+    override def writes(o: AddressSource): JsValue = o match {
+      case BusinessPartnerRecord => JsString("BusinessPartnerRecord")
+      case ManuallyEntered       => JsString("ManuallyEntered")
+    }
+  }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/email/EmailSource.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/email/EmailSource.scala
@@ -17,22 +17,33 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait EmailSource extends Product with Serializable
 
 object EmailSource {
 
-  final case object GovernmentGateway extends EmailSource
+  case object GovernmentGateway extends EmailSource
 
-  final case object BusinessPartnerRecord extends EmailSource
+  case object BusinessPartnerRecord extends EmailSource
 
-  final case object ManuallyEntered extends EmailSource
+  case object ManuallyEntered extends EmailSource
 
   implicit val eq: Eq[EmailSource] = Eq.fromUniversalEquals[EmailSource]
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[EmailSource] = derived.oformat()
+  implicit val format: Format[EmailSource] = new Format[EmailSource] {
+    override def reads(json: JsValue): JsResult[EmailSource] = json match {
+      case JsString("GovernmentGateway")     => JsSuccess(GovernmentGateway)
+      case JsString("BusinessPartnerRecord") => JsSuccess(BusinessPartnerRecord)
+      case JsString("ManuallyEntered")       => JsSuccess(ManuallyEntered)
+      case _                                 => JsError("Invalid email source")
+    }
+
+    override def writes(o: EmailSource): JsValue = o match {
+      case GovernmentGateway     => JsString("GovernmentGateway")
+      case BusinessPartnerRecord => JsString("BusinessPartnerRecord")
+      case ManuallyEntered       => JsString("ManuallyEntered")
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/finance/ChargeType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/finance/ChargeType.scala
@@ -17,35 +17,67 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait ChargeType extends Product with Serializable
 
 object ChargeType {
 
-  final case object UkResidentReturn extends ChargeType
-  final case object NonUkResidentReturn extends ChargeType
-  final case object DeltaCharge extends ChargeType
+  case object UkResidentReturn extends ChargeType
+  case object NonUkResidentReturn extends ChargeType
+  case object DeltaCharge extends ChargeType
 
-  final case object Interest extends ChargeType
+  case object Interest extends ChargeType
 
-  final case object LateFilingPenalty extends ChargeType
+  case object LateFilingPenalty extends ChargeType
 
-  final case object SixMonthLateFilingPenalty extends ChargeType
+  case object SixMonthLateFilingPenalty extends ChargeType
 
-  final case object TwelveMonthLateFilingPenalty extends ChargeType
+  case object TwelveMonthLateFilingPenalty extends ChargeType
 
-  final case object LatePaymentPenalty extends ChargeType
+  case object LatePaymentPenalty extends ChargeType
 
-  final case object SixMonthLatePaymentPenalty extends ChargeType
+  case object SixMonthLatePaymentPenalty extends ChargeType
 
-  final case object TwelveMonthLatePaymentPenalty extends ChargeType
+  case object TwelveMonthLatePaymentPenalty extends ChargeType
 
-  final case object PenaltyInterest extends ChargeType
+  case object PenaltyInterest extends ChargeType
 
   implicit val eq: Eq[ChargeType] = Eq.fromUniversalEquals
 
-  implicit val format: OFormat[ChargeType] = derived.oformat()
+  implicit val format: Format[ChargeType] = new Format[ChargeType] {
+    override def reads(json: JsValue): JsResult[ChargeType] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head match {
+          case ("UkResidentReturn", _)              => JsSuccess(UkResidentReturn)
+          case ("NonUkResidentReturn", _)           => JsSuccess(NonUkResidentReturn)
+          case ("DeltaCharge", _)                   => JsSuccess(DeltaCharge)
+          case ("Interest", _)                      => JsSuccess(Interest)
+          case ("LateFilingPenalty", _)             => JsSuccess(LateFilingPenalty)
+          case ("SixMonthLateFilingPenalty", _)     => JsSuccess(SixMonthLateFilingPenalty)
+          case ("TwelveMonthLateFilingPenalty", _)  => JsSuccess(TwelveMonthLateFilingPenalty)
+          case ("LatePaymentPenalty", _)            => JsSuccess(LatePaymentPenalty)
+          case ("SixMonthLatePaymentPenalty", _)    => JsSuccess(SixMonthLatePaymentPenalty)
+          case ("TwelveMonthLatePaymentPenalty", _) => JsSuccess(TwelveMonthLatePaymentPenalty)
+          case ("PenaltyInterest", _)               => JsSuccess(PenaltyInterest)
+          case (other, _)                           => JsError(s"Unrecognized ChargeType: $other")
+        }
+      case _                                    => JsError("Expected JSON object with a single ChargeType field")
+    }
+
+    override def writes(o: ChargeType): JsValue = o match {
+      case UkResidentReturn              => Json.obj("UkResidentReturn" -> Json.obj())
+      case NonUkResidentReturn           => Json.obj("NonUkResidentReturn" -> Json.obj())
+      case DeltaCharge                   => Json.obj("DeltaCharge" -> Json.obj())
+      case Interest                      => Json.obj("Interest" -> Json.obj())
+      case LateFilingPenalty             => Json.obj("LateFilingPenalty" -> Json.obj())
+      case SixMonthLateFilingPenalty     => Json.obj("SixMonthLateFilingPenalty" -> Json.obj())
+      case TwelveMonthLateFilingPenalty  => Json.obj("TwelveMonthLateFilingPenalty" -> Json.obj())
+      case LatePaymentPenalty            => Json.obj("LatePaymentPenalty" -> Json.obj())
+      case SixMonthLatePaymentPenalty    => Json.obj("SixMonthLatePaymentPenalty" -> Json.obj())
+      case TwelveMonthLatePaymentPenalty => Json.obj("TwelveMonthLatePaymentPenalty" -> Json.obj())
+      case PenaltyInterest               => Json.obj("PenaltyInterest" -> Json.obj())
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/finance/PaymentMethod.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/finance/PaymentMethod.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance
 
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait PaymentMethod extends Product with Serializable
 
@@ -73,6 +72,66 @@ object PaymentMethod {
 
   case object VoluntaryDirectPayments extends PaymentMethod
 
-  implicit val format: OFormat[PaymentMethod] = derived.oformat()
+  implicit val format: Format[PaymentMethod] = new Format[PaymentMethod] {
+    override def reads(json: JsValue): JsResult[PaymentMethod] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "BACS"                               => JsSuccess(BACS)
+          case "CHAPS"                              => JsSuccess(CHAPS)
+          case "Cheque"                             => JsSuccess(Cheque)
+          case "DebitCardByTelephone"               => JsSuccess(DebitCardByTelephone)
+          case "CreditCardByTelephone"              => JsSuccess(CreditCardByTelephone)
+          case "PTAOnlineWorldpayDebitCardPayment"  => JsSuccess(PTAOnlineWorldpayDebitCardPayment)
+          case "PTAOnlineWorldpayCreditCardPayment" => JsSuccess(PTAOnlineWorldpayCreditCardPayment)
+          case "GIROReceipts"                       => JsSuccess(GIROReceipts)
+          case "GIROCredits"                        => JsSuccess(GIROCredits)
+          case "ChequeReceipts"                     => JsSuccess(ChequeReceipts)
+          case "DirectDebit"                        => JsSuccess(DirectDebit)
+          case "FasterPayment"                      => JsSuccess(FasterPayment)
+          case "GiroBankReceipts"                   => JsSuccess(GiroBankReceipts)
+          case "GiroBankPostOffice"                 => JsSuccess(GiroBankPostOffice)
+          case "Paymaster"                          => JsSuccess(Paymaster)
+          case "BankLodgement"                      => JsSuccess(BankLodgement)
+          case "Incentive"                          => JsSuccess(Incentive)
+          case "LocalOfficePayment"                 => JsSuccess(LocalOfficePayment)
+          case "NilDeclarations"                    => JsSuccess(NilDeclarations)
+          case "OverpaymentsToDuty"                 => JsSuccess(OverpaymentsToDuty)
+          case "ReallocationFromOASToDuty"          => JsSuccess(ReallocationFromOASToDuty)
+          case "PaymentNotExpected"                 => JsSuccess(PaymentNotExpected)
+          case "Reallocation"                       => JsSuccess(Reallocation)
+          case "RepaymentInterestAllocated"         => JsSuccess(RepaymentInterestAllocated)
+          case "VoluntaryDirectPayments"            => JsSuccess(VoluntaryDirectPayments)
+          case other                                => JsError(s"Invalid payment method: $other")
+        }
+      case _                                    => JsError("Expected a JSON object with one PaymentMethod key")
+    }
 
+    override def writes(o: PaymentMethod): JsValue = o match {
+      case BACS                               => Json.obj("BACS" -> Json.obj())
+      case CHAPS                              => Json.obj("CHAPS" -> Json.obj())
+      case Cheque                             => Json.obj("Cheque" -> Json.obj())
+      case DebitCardByTelephone               => Json.obj("DebitCardByTelephone" -> Json.obj())
+      case CreditCardByTelephone              => Json.obj("CreditCardByTelephone" -> Json.obj())
+      case PTAOnlineWorldpayDebitCardPayment  => Json.obj("PTAOnlineWorldpayDebitCardPayment" -> Json.obj())
+      case PTAOnlineWorldpayCreditCardPayment => Json.obj("PTAOnlineWorldpayCreditCardPayment" -> Json.obj())
+      case GIROReceipts                       => Json.obj("GIROReceipts" -> Json.obj())
+      case GIROCredits                        => Json.obj("GIROCredits" -> Json.obj())
+      case ChequeReceipts                     => Json.obj("ChequeReceipts" -> Json.obj())
+      case DirectDebit                        => Json.obj("DirectDebit" -> Json.obj())
+      case FasterPayment                      => Json.obj("FasterPayment" -> Json.obj())
+      case GiroBankReceipts                   => Json.obj("GiroBankReceipts" -> Json.obj())
+      case GiroBankPostOffice                 => Json.obj("GiroBankPostOffice" -> Json.obj())
+      case Paymaster                          => Json.obj("Paymaster" -> Json.obj())
+      case BankLodgement                      => Json.obj("BankLodgement" -> Json.obj())
+      case Incentive                          => Json.obj("Incentive" -> Json.obj())
+      case LocalOfficePayment                 => Json.obj("LocalOfficePayment" -> Json.obj())
+      case NilDeclarations                    => Json.obj("NilDeclarations" -> Json.obj())
+      case OverpaymentsToDuty                 => Json.obj("OverpaymentsToDuty" -> Json.obj())
+      case ReallocationFromOASToDuty          => Json.obj("ReallocationFromOASToDuty" -> Json.obj())
+      case PaymentNotExpected                 => Json.obj("PaymentNotExpected" -> Json.obj())
+      case Reallocation                       => Json.obj("Reallocation" -> Json.obj())
+      case RepaymentInterestAllocated         => Json.obj("RepaymentInterestAllocated" -> Json.obj())
+      case VoluntaryDirectPayments            => Json.obj("VoluntaryDirectPayments" -> Json.obj())
+    }
+  }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/AgentReferenceNumber.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/AgentReferenceNumber.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class AgentReferenceNumber(value: String) extends AnyVal
+final case class AgentReferenceNumber(value: String)
 
 object AgentReferenceNumber {
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/CgtReference.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/CgtReference.scala
@@ -21,7 +21,7 @@ import play.api.data.Mapping
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationResult}
 import play.api.libs.json.{Json, OFormat}
 
-final case class CgtReference(value: String) extends AnyVal
+final case class CgtReference(value: String)
 
 object CgtReference {
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/DraftReturnId.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/DraftReturnId.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class DraftReturnId(value: String) extends AnyVal
+final case class DraftReturnId(value: String)
 
 object DraftReturnId {
   implicit val format: OFormat[DraftReturnId] = Json.format[DraftReturnId]

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/GGCredId.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/GGCredId.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class GGCredId(value: String) extends AnyVal
+final case class GGCredId(value: String)
 
 object GGCredId {
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/NINO.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/NINO.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids
 
 import play.api.libs.json.{Json, OFormat}
 
-final case class NINO(value: String) extends AnyVal
+final case class NINO(value: String)
 
 object NINO {
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/SAUTR.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/SAUTR.scala
@@ -23,7 +23,7 @@ import play.api.data.Forms.nonEmptyText
 import play.api.data.Mapping
 import play.api.libs.json.{Format, Json}
 
-final case class SAUTR(value: String) extends AnyVal
+final case class SAUTR(value: String)
 
 object SAUTR {
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/SapNumber.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/SapNumber.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Format
 
-final case class SapNumber(value: String) extends AnyVal
+final case class SapNumber(value: String)
 
 object SapNumber {
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/TRN.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/ids/TRN.scala
@@ -21,7 +21,7 @@ import play.api.data.Mapping
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationResult}
 import play.api.libs.json.{Format, Json}
 
-final case class TRN(value: String) extends AnyVal
+final case class TRN(value: String)
 
 object TRN {
 
@@ -38,7 +38,7 @@ object TRN {
 
     nonEmptyText
       .transform[String](_.trim, identity)
-      .verifying(Constraint { t: String =>
+      .verifying(Constraint { (t: String) =>
         validateTrn(t.replace(" ", ""))
       })
   }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/ContactName.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/ContactName.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name
 import cats.Eq
 import cats.instances.string._
 import cats.syntax.eq._
-import play.api.data.Forms.{nonEmptyText, mapping => formMapping}
+import play.api.data.Forms.{mapping => formMapping, nonEmptyText}
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationResult}
 import play.api.data.{Form, Mapping}
 import play.api.libs.functional.syntax._
@@ -54,7 +54,7 @@ object ContactName {
     Form(
       formMapping(
         "contactName" -> mapping
-      )(ContactName.apply)(ContactName.unapply)
+      )(ContactName.apply)(o => Some(o.value))
     )
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/ContactNameSource.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/ContactNameSource.scala
@@ -17,21 +17,29 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait ContactNameSource extends Product with Serializable
 
 object ContactNameSource {
 
-  final case object DerivedFromBusinessPartnerRecord extends ContactNameSource
+  case object DerivedFromBusinessPartnerRecord extends ContactNameSource
 
-  final case object ManuallyEntered extends ContactNameSource
+  case object ManuallyEntered extends ContactNameSource
 
-  implicit val eq: Eq[ContactNameSource] =
-    Eq.fromUniversalEquals[ContactNameSource]
+  implicit val eq: Eq[ContactNameSource] = Eq.fromUniversalEquals[ContactNameSource]
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[ContactNameSource] = derived.oformat()
+  implicit val format: Format[ContactNameSource] = new Format[ContactNameSource] {
+    override def reads(json: JsValue): JsResult[ContactNameSource] = json match {
+      case JsString("DerivedFromBusinessPartnerRecord") => JsSuccess(DerivedFromBusinessPartnerRecord)
+      case JsString("ManuallyEntered")                  => JsSuccess(ManuallyEntered)
+      case _                                            => JsError("Invalid contact name source")
+    }
+
+    override def writes(o: ContactNameSource): JsValue = o match {
+      case DerivedFromBusinessPartnerRecord => JsString("DerivedFromBusinessPartnerRecord")
+      case ManuallyEntered                  => JsString("ManuallyEntered")
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/IndividualName.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/IndividualName.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name
 import cats.Eq
 import cats.instances.string._
 import cats.syntax.eq._
-import play.api.data.Forms.{nonEmptyText, mapping => formMapping}
+import play.api.data.Forms.{mapping => formMapping, nonEmptyText}
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationResult}
 import play.api.data.{Form, Mapping}
 import play.api.libs.json.{Json, OFormat}
@@ -51,7 +51,7 @@ object IndividualName {
 
     nonEmptyText
       .transform[String](_.trim, identity)
-      .verifying(Constraint[String](validateName(_)))
+      .verifying(Constraint[String](validateName))
   }
 
   def form(firstNameKey: String, lastNameKey: String): Form[IndividualName] =
@@ -59,6 +59,6 @@ object IndividualName {
       formMapping(
         firstNameKey -> mapping,
         lastNameKey  -> mapping
-      )(IndividualName.apply)(IndividualName.unapply)
+      )(IndividualName.apply)(o => Some((o.firstName, o.lastName)))
     )
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/TrustName.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/TrustName.scala
@@ -21,7 +21,7 @@ import play.api.data.Mapping
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationResult}
 import play.api.libs.json.{Format, Json}
 
-final case class TrustName(value: String) extends AnyVal
+final case class TrustName(value: String)
 
 object TrustName {
 
@@ -40,7 +40,7 @@ object TrustName {
 
     nonEmptyText
       .transform[String](_.trim, identity)
-      .verifying(Constraint[String](validateTrustName(_)))
+      .verifying(Constraint[String](validateTrustName))
   }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/onboarding/NeedMoreDetailsDetails.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/onboarding/NeedMoreDetailsDetails.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding
 
-import julienrf.json.derived
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.NeedMoreDetailsDetails.AffinityGroup
 
 final case class NeedMoreDetailsDetails(
@@ -35,9 +34,18 @@ object NeedMoreDetailsDetails {
 
     case object Organisation extends AffinityGroup
 
-    @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-    implicit val format: OFormat[AffinityGroup] = derived.oformat()
+    implicit val format: Format[AffinityGroup] = new Format[AffinityGroup] {
+      override def reads(json: JsValue): JsResult[AffinityGroup] = json match {
+        case JsString("Individual")   => JsSuccess(Individual)
+        case JsString("Organisation") => JsSuccess(Organisation)
+        case _                        => JsError("Invalid affinity group")
+      }
 
+      override def writes(o: AffinityGroup): JsValue = o match {
+        case Individual   => JsString("Individual")
+        case Organisation => JsString("Organisation")
+      }
+    }
   }
 
   implicit val format: OFormat[NeedMoreDetailsDetails] = Json.format

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/onboarding/SubscriptionResponse.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/onboarding/SubscriptionResponse.scala
@@ -24,7 +24,7 @@ object SubscriptionResponse {
 
   final case class SubscriptionSuccessful(cgtReferenceNumber: String) extends SubscriptionResponse
 
-  final case object AlreadySubscribed extends SubscriptionResponse
+  case object AlreadySubscribed extends SubscriptionResponse
 
   implicit val subscriptionSuccessfulFormat: Format[SubscriptionSuccessful] =
     Json.format[SubscriptionSuccessful]

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/onboarding/iv/IvErrorStatus.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/onboarding/iv/IvErrorStatus.scala
@@ -20,23 +20,23 @@ sealed trait IvErrorStatus extends Product with Serializable
 
 object IvErrorStatus {
 
-  final case object Incomplete extends IvErrorStatus
+  case object Incomplete extends IvErrorStatus
 
-  final case object FailedMatching extends IvErrorStatus
+  case object FailedMatching extends IvErrorStatus
 
-  final case object FailedIV extends IvErrorStatus
+  case object FailedIV extends IvErrorStatus
 
-  final case object InsufficientEvidence extends IvErrorStatus
+  case object InsufficientEvidence extends IvErrorStatus
 
-  final case object LockedOut extends IvErrorStatus
+  case object LockedOut extends IvErrorStatus
 
-  final case object UserAborted extends IvErrorStatus
+  case object UserAborted extends IvErrorStatus
 
-  final case object Timeout extends IvErrorStatus
+  case object Timeout extends IvErrorStatus
 
-  final case object TechnicalIssue extends IvErrorStatus
+  case object TechnicalIssue extends IvErrorStatus
 
-  final case object PreconditionFailed extends IvErrorStatus
+  case object PreconditionFailed extends IvErrorStatus
 
   final case class Unknown(value: String) extends IvErrorStatus
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/AcquisitionDate.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/AcquisitionDate.scala
@@ -21,11 +21,10 @@ import play.api.libs.json.Format
 
 import java.time.LocalDate
 
-final case class AcquisitionDate(value: LocalDate) extends AnyVal
+final case class AcquisitionDate(value: LocalDate)
 
 object AcquisitionDate {
 
-  implicit val format: Format[AcquisitionDate] =
-    implicitly[Format[LocalDate]].inmap(AcquisitionDate(_), _.value)
+  implicit val format: Format[AcquisitionDate] = implicitly[Format[LocalDate]].inmap(AcquisitionDate(_), _.value)
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/AcquisitionMethod.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/AcquisitionMethod.scala
@@ -16,22 +16,39 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait AcquisitionMethod extends Product with Serializable
 
 object AcquisitionMethod {
 
-  final case object Bought extends AcquisitionMethod
+  case object Bought extends AcquisitionMethod
 
-  final case object Inherited extends AcquisitionMethod
+  case object Inherited extends AcquisitionMethod
 
-  final case object Gifted extends AcquisitionMethod
+  case object Gifted extends AcquisitionMethod
 
   final case class Other(value: String) extends AcquisitionMethod
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[AcquisitionMethod] = derived.oformat()
+  implicit val format: Format[AcquisitionMethod] = new Format[AcquisitionMethod] {
+    override def reads(json: JsValue): JsResult[AcquisitionMethod] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head match {
+          case ("Bought", _)    => JsSuccess(Bought)
+          case ("Inherited", _) => JsSuccess(Inherited)
+          case ("Gifted", _)    => JsSuccess(Gifted)
+          case ("Other", value) => (value \ "value").validate[String].map(Other(_))
+          case (other, _)       => JsError(s"Unrecognized acquisition method: $other")
+        }
+      case _                                    => JsError("Expected JSON object with one AcquisitionMethod key")
+    }
+
+    override def writes(o: AcquisitionMethod): JsValue = o match {
+      case Bought       => Json.obj("Bought" -> Json.obj())
+      case Inherited    => Json.obj("Inherited" -> Json.obj())
+      case Gifted       => Json.obj("Gifted" -> Json.obj())
+      case Other(value) => Json.obj("Other" -> Json.obj("value" -> value))
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/AssetType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/AssetType.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait AssetType extends Product with Serializable
 
@@ -34,6 +33,25 @@ object AssetType {
 
   implicit val eq: Eq[AssetType] = Eq.fromUniversalEquals
 
-  implicit val format: OFormat[AssetType] = derived.oformat()
+  implicit val format: Format[AssetType] = new Format[AssetType] {
+    override def reads(json: JsValue): JsResult[AssetType] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "Residential"      => JsSuccess(Residential)
+          case "NonResidential"   => JsSuccess(NonResidential)
+          case "IndirectDisposal" => JsSuccess(IndirectDisposal)
+          case "MixedUse"         => JsSuccess(MixedUse)
+          case other              => JsError(s"Invalid asset type: $other")
+        }
+      case _                                    => JsError("Expected JSON object with one AssetType key")
+    }
+
+    override def writes(o: AssetType): JsValue = o match {
+      case Residential      => Json.obj("Residential" -> Json.obj())
+      case NonResidential   => Json.obj("NonResidential" -> Json.obj())
+      case IndirectDisposal => Json.obj("IndirectDisposal" -> Json.obj())
+      case MixedUse         => Json.obj("MixedUse" -> Json.obj())
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/CalculatedGlarBreakdown.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/CalculatedGlarBreakdown.scala
@@ -39,7 +39,7 @@ object CalculatedGlarBreakdown {
     def totalReliefs: AmountInPence                       = c.privateResidentReliefs ++ c.lettingRelief
     def initialGainOrLoss: AmountInPence                  = propertyDisposalAmountLessCosts -- propertyAcquisitionAmountPlusCosts
 
-    def acquisitionOrRebased: AmountInPence = {
+    def acquisitionOrRebased: AmountInPence   = {
       val initialGainOrLossRebase = (c.shouldUseRebase, c.rebasedAcquisitionPrice) match {
         case (true, Some(rebasedAcquisitionPrice)) => rebasedAcquisitionPrice
         case (false, _)                            => c.acquisitionPrice

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/CompleteReturn.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/CompleteReturn.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
 import cats.syntax.eq._
-import julienrf.json.derived
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.EitherUtils.eitherFormat
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TaxYear
@@ -435,25 +434,63 @@ object CompleteReturn {
         Some(None)
     }
 
-  implicit val format: OFormat[CompleteReturn] = {
-    implicit val singleDisposalTriageFormat: OFormat[CompleteSingleDisposalTriageAnswers]              = Json.format
-    implicit val multipleDisposalsTriageFormat: OFormat[CompleteMultipleDisposalsTriageAnswers]        = Json.format
-    implicit val ukAddressFormat: OFormat[UkAddress]                                                   = Json.format
-    implicit val examplePropertyDetailsFormat: OFormat[CompleteExamplePropertyDetailsAnswers]          = Json.format
-    implicit val disposalDetailsFormat: OFormat[CompleteDisposalDetailsAnswers]                        = Json.format
-    implicit val acquisitionDetailsFormat: OFormat[CompleteAcquisitionDetailsAnswers]                  = Json.format
-    implicit val reliefDetailsFormat: OFormat[CompleteReliefDetailsAnswers]                            =
-      Json.format
-    implicit val exemptionAndLossesFormat: OFormat[CompleteExemptionAndLossesAnswers]                  = Json.format
-    implicit val nonCalculatedYearToDateLiabilityFormat: OFormat[CompleteNonCalculatedYTDAnswers]      = Json.format
-    implicit val calculatedYearToDateLiabilityFormat: OFormat[CompleteCalculatedYTDAnswers]            = Json.format
-    implicit val supportingDocumentsFormat: OFormat[CompleteSupportingEvidenceAnswers]                 = Json.format
-    implicit val representeeAnswersFormat: OFormat[CompleteRepresenteeAnswers]                         =
-      Json.format
-    implicit val exampleCompanyDetailsAnswersFormat: OFormat[CompleteExampleCompanyDetailsAnswers]     = Json.format
-    implicit val mixedUsePropertyDetailsAnswersFormat: OFormat[CompleteMixedUsePropertyDetailsAnswers] = Json.format
+  import DraftReturn.*
 
-    derived.oformat()
+  implicit val singleDisposalTriageFormat: OFormat[CompleteSingleDisposalTriageAnswers]                       = Json.format
+  implicit val multipleDisposalsTriageFormat: OFormat[CompleteMultipleDisposalsTriageAnswers]                 = Json.format
+  implicit val ukAddressFormat: OFormat[UkAddress]                                                            = Json.format
+  implicit val examplePropertyDetailsFormat: OFormat[CompleteExamplePropertyDetailsAnswers]                   = Json.format
+  implicit val disposalDetailsFormat: OFormat[CompleteDisposalDetailsAnswers]                                 = Json.format
+  implicit val acquisitionDetailsFormat: OFormat[CompleteAcquisitionDetailsAnswers]                           = Json.format
+  implicit val reliefDetailsFormat: OFormat[CompleteReliefDetailsAnswers]                                     = Json.format
+  implicit val exemptionAndLossesFormat: OFormat[CompleteExemptionAndLossesAnswers]                           = Json.format
+  implicit val nonCalculatedYearToDateLiabilityFormat: OFormat[CompleteNonCalculatedYTDAnswers]               = Json.format
+  implicit val calculatedYearToDateLiabilityFormat: OFormat[CompleteCalculatedYTDAnswers]                     = Json.format
+  implicit val supportingDocumentsFormat: OFormat[CompleteSupportingEvidenceAnswers]                          = Json.format
+  implicit val representeeAnswersFormat: OFormat[CompleteRepresenteeAnswers]                                  = Json.format
+  implicit val exampleCompanyDetailsAnswersFormat: OFormat[CompleteExampleCompanyDetailsAnswers]              = Json.format
+  implicit val mixedUsePropertyDetailsAnswersFormat: OFormat[CompleteMixedUsePropertyDetailsAnswers]          = Json.format
+  implicit val completeMultipleDisposalsReturnFormat: OFormat[CompleteMultipleDisposalsReturn]                = Json.format
+  implicit val completeMultipleIndirectDisposalsReturnFormat: OFormat[CompleteMultipleIndirectDisposalReturn] =
+    Json.format
+  implicit val completeSingleDisposalReturnFormat: OFormat[CompleteSingleDisposalReturn]                      = Json.format
+  implicit val completeSingleMixedUseDisposalReturnFormat: OFormat[CompleteSingleMixedUseDisposalReturn]      = Json.format
+  implicit val completeSingleIndirectDisposalReturnFormat: OFormat[CompleteSingleIndirectDisposalReturn]      = Json.format
+
+  implicit val format: OFormat[CompleteReturn] = new OFormat[CompleteReturn] {
+    override def reads(json: play.api.libs.json.JsValue): play.api.libs.json.JsResult[CompleteReturn] =
+      json match {
+        case play.api.libs.json.JsObject(fields) if fields.size == 1 =>
+          fields.head match {
+            case ("CompleteMultipleDisposalsReturn", value)        =>
+              value.validate[CompleteMultipleDisposalsReturn]
+            case ("CompleteSingleDisposalReturn", value)           =>
+              value.validate[CompleteSingleDisposalReturn]
+            case ("CompleteSingleIndirectDisposalReturn", value)   =>
+              value.validate[CompleteSingleIndirectDisposalReturn]
+            case ("CompleteMultipleIndirectDisposalReturn", value) =>
+              value.validate[CompleteMultipleIndirectDisposalReturn]
+            case ("CompleteSingleMixedUseDisposalReturn", value)   =>
+              value.validate[CompleteSingleMixedUseDisposalReturn]
+            case (other, _)                                        =>
+              play.api.libs.json.JsError(s"Unrecognized CompleteReturn type: $other")
+          }
+        case _                                                       =>
+          play.api.libs.json.JsError("Expected a CompleteReturn wrapper object with a single entry")
+      }
+
+    override def writes(c: CompleteReturn): play.api.libs.json.JsObject = c match {
+      case m: CompleteMultipleDisposalsReturn        =>
+        play.api.libs.json.Json.obj("CompleteMultipleDisposalsReturn" -> play.api.libs.json.Json.toJson(m))
+      case s: CompleteSingleDisposalReturn           =>
+        play.api.libs.json.Json.obj("CompleteSingleDisposalReturn" -> play.api.libs.json.Json.toJson(s))
+      case s: CompleteSingleIndirectDisposalReturn   =>
+        play.api.libs.json.Json.obj("CompleteSingleIndirectDisposalReturn" -> play.api.libs.json.Json.toJson(s))
+      case m: CompleteMultipleIndirectDisposalReturn =>
+        play.api.libs.json.Json.obj("CompleteMultipleIndirectDisposalReturn" -> play.api.libs.json.Json.toJson(m))
+      case s: CompleteSingleMixedUseDisposalReturn   =>
+        play.api.libs.json.Json.obj("CompleteSingleMixedUseDisposalReturn" -> play.api.libs.json.Json.toJson(s))
+    }
   }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/CompletionDate.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/CompletionDate.scala
@@ -17,15 +17,16 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
 import cats.Eq
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.*
 
 import java.time.LocalDate
 
-final case class CompletionDate(value: LocalDate) extends AnyVal
+final case class CompletionDate(value: LocalDate)
 
 object CompletionDate {
 
-  implicit val format: OFormat[CompletionDate] = Json.format
-  implicit val eq: Eq[CompletionDate]          = Eq.fromUniversalEquals
+  implicit val format: OFormat[CompletionDate] = Json.format[CompletionDate]
+
+  implicit val eq: Eq[CompletionDate] = Eq.fromUniversalEquals
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/DateOfDeath.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/DateOfDeath.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Format
 
 import java.time.LocalDate
 
-final case class DateOfDeath(value: LocalDate) extends AnyVal
+final case class DateOfDeath(value: LocalDate)
 
 object DateOfDeath {
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/DisposalMethod.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/DisposalMethod.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait DisposalMethod extends Product with Serializable
 
@@ -32,7 +31,23 @@ object DisposalMethod {
 
   implicit val eq: Eq[DisposalMethod] = Eq.fromUniversalEquals
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[DisposalMethod] = derived.oformat()
+  implicit val format: Format[DisposalMethod] = new Format[DisposalMethod] {
+    override def reads(json: JsValue): JsResult[DisposalMethod] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "Sold"   => JsSuccess(Sold)
+          case "Gifted" => JsSuccess(Gifted)
+          case "Other"  => JsSuccess(Other)
+          case other    => JsError(s"Invalid disposal method: $other")
+        }
+      case _                                    => JsError("Expected JSON object with one DisposalMethod key")
+    }
+
+    override def writes(o: DisposalMethod): JsValue = o match {
+      case Sold   => Json.obj("Sold" -> Json.obj())
+      case Gifted => Json.obj("Gifted" -> Json.obj())
+      case Other  => Json.obj("Other" -> Json.obj())
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/DraftReturn.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/DraftReturn.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TimeUtils
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
@@ -255,7 +254,48 @@ object DraftReturn {
 
   implicit val ukAddressFormat: OFormat[UkAddress] = Json.format[UkAddress]
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[DraftReturn] = derived.oformat()
+  implicit val singleReturnFormat: OFormat[DraftSingleDisposalReturn]                      = Json.format[DraftSingleDisposalReturn]
+  implicit val singleIndirectReturnFormat: OFormat[DraftSingleIndirectDisposalReturn]      =
+    Json.format[DraftSingleIndirectDisposalReturn]
+  implicit val singleMixedReturnFormat: OFormat[DraftSingleMixedUseDisposalReturn]         =
+    Json.format[DraftSingleMixedUseDisposalReturn]
+  implicit val multipleReturnFormat: OFormat[DraftMultipleDisposalsReturn]                 = Json.format[DraftMultipleDisposalsReturn]
+  implicit val multipleIndirectReturnFormat: OFormat[DraftMultipleIndirectDisposalsReturn] =
+    Json.format[DraftMultipleIndirectDisposalsReturn]
+
+  implicit val format: OFormat[DraftReturn] = new OFormat[DraftReturn] {
+    override def reads(json: JsValue): JsResult[DraftReturn] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head match {
+          case ("DraftSingleDisposalReturn", value)            =>
+            value.validate[DraftSingleDisposalReturn]
+          case ("DraftMultipleDisposalsReturn", value)         =>
+            value.validate[DraftMultipleDisposalsReturn]
+          case ("DraftSingleIndirectDisposalReturn", value)    =>
+            value.validate[DraftSingleIndirectDisposalReturn]
+          case ("DraftMultipleIndirectDisposalsReturn", value) =>
+            value.validate[DraftMultipleIndirectDisposalsReturn]
+          case ("DraftSingleMixedUseDisposalReturn", value)    =>
+            value.validate[DraftSingleMixedUseDisposalReturn]
+          case (other, _)                                      =>
+            JsError(s"Unrecognized DraftReturn type: $other")
+        }
+      case _                                    =>
+        JsError("Expected a DraftReturn wrapper object with a single entry")
+    }
+
+    override def writes(d: DraftReturn): JsObject = d match {
+      case s: DraftSingleDisposalReturn            =>
+        Json.obj("DraftSingleDisposalReturn" -> Json.toJson(s))
+      case m: DraftMultipleDisposalsReturn         =>
+        Json.obj("DraftMultipleDisposalsReturn" -> Json.toJson(m))
+      case s: DraftSingleIndirectDisposalReturn    =>
+        Json.obj("DraftSingleIndirectDisposalReturn" -> Json.toJson(s))
+      case m: DraftMultipleIndirectDisposalsReturn =>
+        Json.obj("DraftMultipleIndirectDisposalsReturn" -> Json.toJson(m))
+      case s: DraftSingleMixedUseDisposalReturn    =>
+        Json.obj("DraftSingleMixedUseDisposalReturn" -> Json.toJson(s))
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/IndividualUserType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/IndividualUserType.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait IndividualUserType extends Product with Serializable
 
@@ -41,7 +40,43 @@ object IndividualUserType {
 
   implicit val representativeTypeEq: Eq[RepresentativeType] = Eq.fromUniversalEquals
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[IndividualUserType] = derived.oformat()
+  implicit val representativeTypeFormat: Format[RepresentativeType] = new Format[RepresentativeType] {
+    override def reads(json: JsValue): JsResult[RepresentativeType] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "Capacitor"                             => JsSuccess(Capacitor)
+          case "PersonalRepresentative"                => JsSuccess(PersonalRepresentative)
+          case "PersonalRepresentativeInPeriodOfAdmin" => JsSuccess(PersonalRepresentativeInPeriodOfAdmin)
+          case other                                   => JsError(s"Invalid representative type: $other")
+        }
+      case _                                    => JsError("Expected JSON object with one RepresentativeType key")
+    }
 
+    override def writes(r: RepresentativeType): JsValue = r match {
+      case Capacitor                             => Json.obj("Capacitor" -> Json.obj())
+      case PersonalRepresentative                => Json.obj("PersonalRepresentative" -> Json.obj())
+      case PersonalRepresentativeInPeriodOfAdmin => Json.obj("PersonalRepresentativeInPeriodOfAdmin" -> Json.obj())
+    }
+  }
+
+  implicit val individualUserTypeFormat: Format[IndividualUserType] = new Format[IndividualUserType] {
+    override def reads(json: JsValue): JsResult[IndividualUserType] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "Self"                                  => JsSuccess(Self)
+          case "Capacitor"                             => JsSuccess(Capacitor)
+          case "PersonalRepresentative"                => JsSuccess(PersonalRepresentative)
+          case "PersonalRepresentativeInPeriodOfAdmin" => JsSuccess(PersonalRepresentativeInPeriodOfAdmin)
+          case other                                   => JsError(s"Invalid individual user type: $other")
+        }
+      case _                                    => JsError("Expected JSON object with one IndividualUserType key")
+    }
+
+    override def writes(o: IndividualUserType): JsValue = o match {
+      case Self                                  => Json.obj("Self" -> Json.obj())
+      case Capacitor                             => Json.obj("Capacitor" -> Json.obj())
+      case PersonalRepresentative                => Json.obj("PersonalRepresentative" -> Json.obj())
+      case PersonalRepresentativeInPeriodOfAdmin => Json.obj("PersonalRepresentativeInPeriodOfAdmin" -> Json.obj())
+    }
+  }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/NumberOfProperties.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/NumberOfProperties.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait NumberOfProperties extends Product with Serializable
 
@@ -30,7 +29,17 @@ object NumberOfProperties {
 
   implicit val eq: Eq[NumberOfProperties] = Eq.fromUniversalEquals
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[NumberOfProperties] = derived.oformat()
+  implicit val format: Format[NumberOfProperties] = new Format[NumberOfProperties] {
+    override def reads(json: JsValue): JsResult[NumberOfProperties] = json match {
+      case JsString("One")         => JsSuccess(One)
+      case JsString("MoreThanOne") => JsSuccess(MoreThanOne)
+      case _                       => JsError("Invalid number of properties")
+    }
+
+    override def writes(o: NumberOfProperties): JsValue = o match {
+      case One         => JsString("One")
+      case MoreThanOne => JsString("MoreThanOne")
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ReturnType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ReturnType.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.*
 
 sealed trait ReturnType
 
@@ -44,7 +43,23 @@ object ReturnType {
 
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[ReturnType] = derived.oformat()
+  implicit val format: Format[ReturnType] = new Format[ReturnType] {
+    override def reads(json: JsValue): JsResult[ReturnType] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "FirstReturn"   => JsSuccess(FirstReturn)
+          case "FurtherReturn" => JsSuccess(FurtherReturn)
+          case "AmendedReturn" => JsSuccess(AmendedReturn)
+          case other           => JsError(s"Invalid return type: $other")
+        }
+      case _                                    => JsError("Expected JSON object with one ReturnType key")
+    }
+
+    override def writes(o: ReturnType): JsValue = o match {
+      case FirstReturn   => Json.obj("FirstReturn" -> Json.obj())
+      case FurtherReturn => Json.obj("FurtherReturn" -> Json.obj())
+      case AmendedReturn => Json.obj("AmendedReturn" -> Json.obj())
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/TaxYearExchanged.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/TaxYearExchanged.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
 import cats.Eq
-import julienrf.json.derived
-import play.api.libs.json.OFormat
+import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TaxYear
 
 final case class TaxYearExchanged(year: Int) extends Product with Serializable
@@ -32,6 +31,6 @@ object TaxYearExchanged {
 
   val differentTaxYears: TaxYearExchanged = TaxYearExchanged(-1)
 
-  implicit val format: OFormat[TaxYearExchanged] = derived.oformat()
+  implicit val format: OFormat[TaxYearExchanged] = Json.format[TaxYearExchanged]
   implicit val eq: Eq[TaxYearExchanged]          = Eq.fromUniversalEquals
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/YearToDateLiabilityAnswers.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/YearToDateLiabilityAnswers.scala
@@ -16,10 +16,9 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 
-import julienrf.json.derived
 import monocle.Lens
-import monocle.macros.Lenses
-import play.api.libs.json.OFormat
+import monocle.macros.GenLens
+import play.api.libs.json._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.UpscanUpload
 
@@ -32,9 +31,11 @@ object YearToDateLiabilityAnswers {
 
   sealed trait NonCalculatedYTDAnswers extends YearToDateLiabilityAnswers
 
+  import CalculatedYTDAnswers.*
+  import NonCalculatedYTDAnswers.*
+
   object NonCalculatedYTDAnswers {
 
-    @Lenses
     final case class IncompleteNonCalculatedYTDAnswers(
       taxableGainOrLoss: Option[AmountInPence],
       hasEstimatedDetails: Option[Boolean],
@@ -51,6 +52,16 @@ object YearToDateLiabilityAnswers {
     ) extends NonCalculatedYTDAnswers
 
     object IncompleteNonCalculatedYTDAnswers {
+      val taxDue                         = GenLens[IncompleteNonCalculatedYTDAnswers](_.taxDue)
+      val expiredEvidence                = GenLens[IncompleteNonCalculatedYTDAnswers](_.expiredEvidence)
+      val checkForRepayment              = GenLens[IncompleteNonCalculatedYTDAnswers](_.checkForRepayment)
+      val mandatoryEvidence              = GenLens[IncompleteNonCalculatedYTDAnswers](_.mandatoryEvidence)
+      val taxableGainOrLoss              = GenLens[IncompleteNonCalculatedYTDAnswers](_.taxableGainOrLoss)
+      val yearToDateLiability            = GenLens[IncompleteNonCalculatedYTDAnswers](_.yearToDateLiability)
+      val pendingUpscanUpload            = GenLens[IncompleteNonCalculatedYTDAnswers](_.pendingUpscanUpload)
+      val hasEstimatedDetails            = GenLens[IncompleteNonCalculatedYTDAnswers](_.hasEstimatedDetails)
+      val yearToDateLiabilityCalculation = GenLens[IncompleteNonCalculatedYTDAnswers](_.yearToDateLiabilityCalculation)
+
       val empty: IncompleteNonCalculatedYTDAnswers =
         IncompleteNonCalculatedYTDAnswers(None, None, None, None, None, None, None, None, None, None, None, None)
 
@@ -71,6 +82,8 @@ object YearToDateLiabilityAnswers {
           c.taxableGainOrLossCalculation,
           c.yearToDateLiabilityCalculation
         )
+
+      implicit val format: OFormat[IncompleteNonCalculatedYTDAnswers] = Json.format[IncompleteNonCalculatedYTDAnswers]
     }
 
     final case class CompleteNonCalculatedYTDAnswers(
@@ -102,7 +115,7 @@ object YearToDateLiabilityAnswers {
       def unset[A](
         fieldLens: IncompleteNonCalculatedYTDAnswers.type => Lens[IncompleteNonCalculatedYTDAnswers, Option[A]]
       ): IncompleteNonCalculatedYTDAnswers =
-        fieldLens(IncompleteNonCalculatedYTDAnswers).set(None)(
+        fieldLens(IncompleteNonCalculatedYTDAnswers).replace(None)(
           fold(identity, IncompleteNonCalculatedYTDAnswers.fromCompleteAnswers)
         )
     }
@@ -111,7 +124,6 @@ object YearToDateLiabilityAnswers {
 
   object CalculatedYTDAnswers {
 
-    @Lenses
     final case class IncompleteCalculatedYTDAnswers(
       estimatedIncome: Option[AmountInPence],
       personalAllowance: Option[AmountInPence],
@@ -124,6 +136,15 @@ object YearToDateLiabilityAnswers {
     ) extends CalculatedYTDAnswers
 
     object IncompleteCalculatedYTDAnswers {
+      val taxDue              = GenLens[IncompleteCalculatedYTDAnswers](_.taxDue)
+      val calculatedTaxDue    = GenLens[IncompleteCalculatedYTDAnswers](_.calculatedTaxDue)
+      val estimatedIncome     = GenLens[IncompleteCalculatedYTDAnswers](_.estimatedIncome)
+      val expiredEvidence     = GenLens[IncompleteCalculatedYTDAnswers](_.expiredEvidence)
+      val mandatoryEvidence   = GenLens[IncompleteCalculatedYTDAnswers](_.mandatoryEvidence)
+      val personalAllowance   = GenLens[IncompleteCalculatedYTDAnswers](_.personalAllowance)
+      val hasEstimatedDetails = GenLens[IncompleteCalculatedYTDAnswers](_.hasEstimatedDetails)
+      val pendingUpscanUpload = GenLens[IncompleteCalculatedYTDAnswers](_.pendingUpscanUpload)
+
       val empty: IncompleteCalculatedYTDAnswers =
         IncompleteCalculatedYTDAnswers(
           None,
@@ -177,7 +198,7 @@ object YearToDateLiabilityAnswers {
       def unset[A](
         fieldLens: IncompleteCalculatedYTDAnswers.type => Lens[IncompleteCalculatedYTDAnswers, Option[A]]
       ): IncompleteCalculatedYTDAnswers =
-        fieldLens(IncompleteCalculatedYTDAnswers).set(None)(
+        fieldLens(IncompleteCalculatedYTDAnswers).replace(None)(
           fold(identity, IncompleteCalculatedYTDAnswers.fromCompleteAnswers)
         )
 
@@ -205,7 +226,38 @@ object YearToDateLiabilityAnswers {
 
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  implicit val format: OFormat[YearToDateLiabilityAnswers] = derived.oformat()
+  implicit val completeCalculatedFormat: OFormat[CompleteCalculatedYTDAnswers]     =
+    Json.format[CompleteCalculatedYTDAnswers]
+  implicit val inCompleteCalculatedFormat: OFormat[IncompleteCalculatedYTDAnswers] =
+    Json.format[IncompleteCalculatedYTDAnswers]
+  implicit val calculatedFormat: OFormat[CalculatedYTDAnswers]                     = Json.format[CalculatedYTDAnswers]
+
+  implicit val completeNonCalculatedFormat: OFormat[CompleteNonCalculatedYTDAnswers]     =
+    Json.format[CompleteNonCalculatedYTDAnswers]
+  implicit val inCompleteNonCalculatedFormat: OFormat[IncompleteNonCalculatedYTDAnswers] =
+    Json.format[IncompleteNonCalculatedYTDAnswers]
+  implicit val nonCalculatedFormat: OFormat[NonCalculatedYTDAnswers]                     = Json.format[NonCalculatedYTDAnswers]
+
+  implicit val format: OFormat[YearToDateLiabilityAnswers] = new OFormat[YearToDateLiabilityAnswers] {
+    override def reads(json: JsValue): JsResult[YearToDateLiabilityAnswers] = json match {
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head match {
+          case ("CompleteCalculatedYTDAnswers", value)      => value.validate[CompleteCalculatedYTDAnswers]
+          case ("IncompleteCalculatedYTDAnswers", value)    => value.validate[IncompleteCalculatedYTDAnswers]
+          case ("CompleteNonCalculatedYTDAnswers", value)   => value.validate[CompleteNonCalculatedYTDAnswers]
+          case ("IncompleteNonCalculatedYTDAnswers", value) => value.validate[IncompleteNonCalculatedYTDAnswers]
+          case (other, _)                                   => JsError(s"Unknown YearToDateLiabilityAnswers subtype: $other")
+        }
+      case _                                    =>
+        JsError("Expected wrapper object with one YearToDateLiabilityAnswers subtype key")
+    }
+
+    override def writes(o: YearToDateLiabilityAnswers): JsObject = o match {
+      case c: CompleteCalculatedYTDAnswers      => Json.obj("CompleteCalculatedYTDAnswers" -> Json.toJson(c))
+      case i: IncompleteCalculatedYTDAnswers    => Json.obj("IncompleteCalculatedYTDAnswers" -> Json.toJson(i))
+      case c: CompleteNonCalculatedYTDAnswers   => Json.obj("CompleteNonCalculatedYTDAnswers" -> Json.toJson(c))
+      case i: IncompleteNonCalculatedYTDAnswers => Json.obj("IncompleteNonCalculatedYTDAnswers" -> Json.toJson(i))
+    }
+  }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/NameMatchRetryStore.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/NameMatchRetryStore.scala
@@ -25,6 +25,8 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, UnsuccessfulNameM
 import uk.gov.hmrc.mongo.cache.{CacheIdType, MongoCacheRepository}
 import uk.gov.hmrc.mongo.{MongoComponent, TimestampSupport}
 
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UnsuccessfulNameMatchAttempts._
+
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/AuditService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/AuditService.scala
@@ -33,7 +33,7 @@ trait AuditService {
     ec: ExecutionContext,
     hc: HeaderCarrier,
     writes: Writes[A],
-    request: Request[_]
+    request: Request[?]
   ): Unit
 
 }
@@ -49,7 +49,7 @@ class AuditServiceImpl @Inject() (auditConnector: AuditConnector) extends AuditS
     ec: ExecutionContext,
     hc: HeaderCarrier,
     writes: Writes[A],
-    request: Request[_]
+    request: Request[?]
   ): Unit = {
     val extendedDataEvent = ExtendedDataEvent(
       auditSource = "cgt-property-disposals",

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/UKAddressLookupService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/UKAddressLookupService.scala
@@ -119,7 +119,7 @@ class UKAddressLookupServiceImpl @Inject() (
       )
   }
 
-  def mkString(p: RawAddress) = p.lines.mkString(" ").toLowerCase()
+  def mkString(p: RawAddress): String = p.lines.mkString(" ").toLowerCase()
 
   // Find numbers in proposed address in order of significance, from rightmost to leftmost.
   // Pad with None to ensure we never return an empty sequence

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/onboarding/IvService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/onboarding/IvService.scala
@@ -61,7 +61,7 @@ class IvServiceImpl @Inject() (connector: IvConnector, metrics: Metrics)(implici
 
 object IvServiceImpl {
 
-  final case class IvStatusResponse(result: String) extends AnyVal
+  final case class IvStatusResponse(result: String)
 
   implicit val reads: Reads[IvStatusResponse] = Json.reads
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/FurtherReturnCalculationEligibilityUtil.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/FurtherReturnCalculationEligibilityUtil.scala
@@ -56,7 +56,7 @@ trait FurtherReturnCalculationEligibilityUtil {
 
   def isEligibleForFurtherReturnOrAmendCalculation(fillingOutReturn: FillingOutReturn)(implicit
     hc: HeaderCarrier,
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): EitherT[Future, Error, FurtherReturnCalculationEligibility]
 
 }
@@ -100,7 +100,7 @@ class FurtherReturnCalculationEligibilityUtilImpl @Inject() (
     fillingOutReturn: FillingOutReturn
   )(implicit
     headerCarrier: HeaderCarrier,
-    request: RequestWithSessionData[_]
+    request: RequestWithSessionData[?]
   ): EitherT[Future, Error, FurtherReturnCalculationEligibility] =
     for {
       updatedFillingOutReturn <- filterPreviousTaxYearReturns(fillingOutReturn)
@@ -126,7 +126,7 @@ class FurtherReturnCalculationEligibilityUtilImpl @Inject() (
       _                       <- if (updatedJourney === updatedFillingOutReturn) {
                                    EitherT.pure[Future, Error](())
                                  } else {
-                                   EitherT(updateSession(sessionStore, request)(_.copy(journeyStatus = Some(updatedJourney))))
+                                   EitherT(updateSession(sessionStore, request.toSession)(_.copy(journeyStatus = Some(updatedJourney))))
                                  }
     } yield eligibility
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/PaymentsService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/PaymentsService.scala
@@ -48,7 +48,7 @@ trait PaymentsService {
     backUrl: Call
   )(implicit
     headerCarrier: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, PaymentsJourney]
 
 }
@@ -70,7 +70,7 @@ class PaymentsServiceImpl @Inject() (
     backUrl: Call
   )(implicit
     headerCarrier: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, PaymentsJourney] =
     connector
       .startPaymentJourney(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsService.scala
@@ -53,7 +53,7 @@ trait ReturnsService {
     fillingOutReturn: FillingOutReturn
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, Unit]
 
   def getDraftReturns(
@@ -100,7 +100,7 @@ class ReturnsServiceImpl @Inject() (
     fillingOutReturn: FillingOutReturn
   )(implicit
     hc: HeaderCarrier,
-    request: Request[_]
+    request: Request[?]
   ): EitherT[Future, Error, Unit] =
     if (fillingOutReturn.isAmendReturn) {
       EitherT.pure(())

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/DmsSubmissionController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/DmsSubmissionController.scala
@@ -42,7 +42,7 @@ class DmsSubmissionController @Inject() (
     with SessionUpdates
     with Logging {
 
-  private def withSubscribedUser(request: RequestWithSessionData[_])(
+  private def withSubscribedUser(request: RequestWithSessionData[?])(
     f: (SessionData, Subscribed) => Future[Result]
   ): Future[Result] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/JourneyStatusController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/JourneyStatusController.scala
@@ -40,7 +40,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.TaxYearService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.testonly.JourneyStatusController._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.Logging._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, toFuture}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.{Logging, given}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -94,7 +94,7 @@ class JourneyStatusController @Inject() (
                 disposalDate <- getDisposalDate
                 triageAnswers = toSingleDisposalTriageAnswers(answers, disposalDate)
                 _            <- EitherT(
-                                  updateSession(sessionStore, request)(
+                                  updateSession(sessionStore, request.toSession)(
                                     _.copy(journeyStatus =
                                       Some(
                                         newReturn.copy(newReturnTriageAnswers = Right(triageAnswers))
@@ -135,7 +135,7 @@ class JourneyStatusController @Inject() (
       None
     )
 
-  private def withStartingNewReturn(request: RequestWithSessionData[_])(
+  private def withStartingNewReturn(request: RequestWithSessionData[?])(
     f: (SessionData, StartingNewDraftReturn) => Future[Result]
   ): Future[Result] =
     request.sessionData.flatMap(s => s.journeyStatus.map(s -> _)) match {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/TestOnlyDraftReturnsConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/testonly/TestOnlyDraftReturnsConnector.scala
@@ -42,7 +42,7 @@ class TestOnlyDraftReturnsConnectorImpl @Inject() (
   implicit val hc: HeaderCarrier = HeaderCarrier()
   private val baseUrl            = servicesConfig.baseUrl("cgt-property-disposals")
 
-  def deleteDraftReturnsUrl(cgtReference: String) =
+  def deleteDraftReturnsUrl(cgtReference: String): String =
     s"$baseUrl/test-only/cgt-property-disposals/draftReturn/$cgtReference"
 
   def deleteDraftReturn(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/util/JsErrorOps.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/util/JsErrorOps.scala
@@ -28,8 +28,7 @@ object JsErrorOps {
 
 class JsErrorOps(val error: JsError) extends AnyVal {
 
-  /**
-    * Create a legible string describing the error suitable for debugging purposes
+  /** Create a legible string describing the error suitable for debugging purposes
     */
   def prettyPrint(): String =
     error.errors

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/util/package.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/util/package.scala
@@ -17,10 +17,12 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend
 
 import play.api.mvc.Result
-
 import scala.concurrent.Future
+import scala.language.implicitConversions
 
 package object util {
+
+  given Conversion[Result, Future[Result]] = (r: Result) => Future.successful(r)
 
   implicit def toFuture: Result => Future[Result] = r => Future.successful(r)
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/accessibility_statement.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/accessibility_statement.scala.html
@@ -25,7 +25,7 @@
 )
 
 @()(implicit
-  request: Request[_],
+  request: Request[?],
   messages: Messages,
   viewConfig: ViewConfig
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/details_updated.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/details_updated.scala.html
@@ -26,7 +26,7 @@
     accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.account_menu_govuk
 )
 
-@(detailChanged: SubscriptionDetail)(implicit request: RequestWithSessionData[_], messages:Messages)
+@(detailChanged: SubscriptionDetail)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @title = @{messages(s"account.manageYourDetails.$detailChanged.changed")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/home.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/home.scala.html
@@ -40,7 +40,7 @@
         viewHelpers: ViewHelpers
 )
 
-@(subscribed: Subscribed)(implicit request:RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(subscribed: Subscribed)(implicit request:RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages(s"account.home.title")}
 @hasRecentlyAmendedReturn = @{subscribed.sentReturns.exists(r => r.isRecentlyAmended === true)}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/manage_your_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/manage_your_details.scala.html
@@ -34,7 +34,7 @@ accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.acco
 )
 
 
-@(details: SubscribedDetails)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(details: SubscribedDetails)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @fullName = @{details.name.fold(_.value, n => s"${n.firstName} ${n.lastName}")}
 @title = @{messages("account.manageYourDetails.title", fullName)}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/signed_out.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/account/signed_out.scala.html
@@ -26,7 +26,7 @@
   govukButton: GovukButton
 )
 
-@()(implicit messages: Messages, appConfig: ViewConfig, request: Request[_])
+@()(implicit messages: Messages, appConfig: ViewConfig, request: Request[?])
 
 @title = @{messages("signed-out.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_nonUk_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_nonUk_address.scala.html
@@ -60,7 +60,7 @@
     submit: Call,
     addressJourneyType: AddressJourneyType,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"nonUkAddress"}
 @line1Key = @{s"$key-line1"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_postcode.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_postcode.scala.html
@@ -44,7 +44,7 @@
     addressJourneyType: AddressJourneyType,
     isATrust: Boolean,
     representativeType: Option[RepresentativeType]
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"postcode"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_uk_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/enter_uk_address.scala.html
@@ -37,7 +37,7 @@
         govukInput: GovukInput
 )
 
-@(form: Form[UkAddress], backLink: Call, submit: Call, enterPostcode: Call, addressJourneyType: AddressJourneyType, isATrust: Boolean, representativeType: Option[RepresentativeType], isAmend: Boolean)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[UkAddress], backLink: Call, submit: Call, enterPostcode: Call, addressJourneyType: AddressJourneyType, isATrust: Boolean, representativeType: Option[RepresentativeType], isAmend: Boolean)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"address"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/exit_page.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/exit_page.scala.html
@@ -24,7 +24,7 @@
     layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink : Call)(implicit request:RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink : Call)(implicit request:RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
  @key = @{"non-uk-resident.change-address-to-uk-address"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/isUk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/isUk.scala.html
@@ -31,7 +31,7 @@
  yesNo: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.yes_no_govuk,
 )
 
-@(form: Form[Boolean], backLink: Call, submit: Call, addressJourneyType: AddressJourneyType)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[Boolean], backLink: Call, submit: Call, addressJourneyType: AddressJourneyType)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"isUk"}
 @isAgent = @{ request.userType.contains(Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/select_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/address/select_address.scala.html
@@ -46,7 +46,7 @@
   isATrust: Boolean,
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"address-select"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agent_no_enrolment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agent_no_enrolment.scala.html
@@ -28,7 +28,7 @@
 )
 
 @()(implicit
-  request: Request[_],
+  request: Request[?],
   messages: Messages,
   viewConfig: ViewConfig
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/confirm_client.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/confirm_client.scala.html
@@ -28,7 +28,7 @@
         formWrapper: FormWithCSRF
 )
 
-@(clientDetails: SubscribedDetails, backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(clientDetails: SubscribedDetails, backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("agent.confirm-client.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_client_cgt_ref.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_client_cgt_ref.scala.html
@@ -33,7 +33,7 @@
         govukInput: GovukInput
 )
 
-@(form: Form[CgtReference])(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(form: Form[CgtReference])(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"cgtReference"}
 @title = @{messages("agent.enter-client-cgt-ref.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_country.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_country.scala.html
@@ -30,7 +30,7 @@
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary_govuk
 )
 
-@(form: Form[Country])(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[Country])(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("agent.enter-client-country.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_postcode.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/enter_postcode.scala.html
@@ -31,7 +31,7 @@
         govukErrorSummary: GovukErrorSummary,
 )
 
-@(form: Form[Postcode])(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[Postcode])(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"postcode"}
 @title = @{messages("agent.enter-client-postcode.title")}
@@ -39,9 +39,8 @@
 
 @layout(title, hasErrors = hasErrors, backLinkUrl = Some(routes.AgentAccessController.enterClientsCgtRef().url)) {
 
-  @{
-    if(form.hasGlobalErrors) {
-      govukErrorSummary(ErrorSummary(
+    @if(form.hasGlobalErrors) {
+      @govukErrorSummary(ErrorSummary(
         title = Text(messages("error.summary.heading")),
         attributes = Map("data-spec" -> "errorSummaryDisplay"),
         errorList = form.globalErrors.map { error =>
@@ -52,9 +51,8 @@
         }
       ))
     } else if (form.hasErrors) {
-      errorSummary(form)
+      @errorSummary(form)
     }
-  }
 
  @formWrapper(routes.AgentAccessController.enterClientsPostcodeSubmit(), Symbol("novalidate") -> "novalidate") {
   @govukInput(Input(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/too_many_attempts.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/agents/too_many_attempts.scala.html
@@ -21,7 +21,7 @@
 
 @this(layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout)
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("agent.too-many-attempts.title")}
 @enterCgtRefCall = @{routes.AgentAccessController.enterClientsCgtRef()}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/AutoCompleteType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/AutoCompleteType.scala
@@ -20,46 +20,46 @@ sealed trait AutoCompleteType {
   val value: String
 }
 object AutoCompleteType {
-  final case object On extends AutoCompleteType {
+  case object On extends AutoCompleteType {
     val value: String = "on"
   }
-  final case object FirstName extends AutoCompleteType {
+  case object FirstName extends AutoCompleteType {
     val value: String = "given-name"
   }
-  final case object LastName extends AutoCompleteType {
+  case object LastName extends AutoCompleteType {
     val value: String = "family-name"
   }
-  final case object ContactName extends AutoCompleteType {
+  case object ContactName extends AutoCompleteType {
     val value: String = "name"
   }
-  final case object Email extends AutoCompleteType {
+  case object Email extends AutoCompleteType {
     val value: String = "email"
   }
-  final case object TrustName extends AutoCompleteType {
+  case object TrustName extends AutoCompleteType {
     val value: String = "organization"
   }
-  final case object StreetAddress extends AutoCompleteType {
+  case object StreetAddress extends AutoCompleteType {
     val value: String = "street-address"
   }
-  final case object AddressLine1 extends AutoCompleteType {
+  case object AddressLine1 extends AutoCompleteType {
     val value: String = "address-line1"
   }
-  final case object AddressLine2 extends AutoCompleteType {
+  case object AddressLine2 extends AutoCompleteType {
     val value: String = "address-line2"
   }
-  final case object AddressLevel2 extends AutoCompleteType {
+  case object AddressLevel2 extends AutoCompleteType {
     val value: String = "address-level2"
   }
-  final case object AddressLevel1 extends AutoCompleteType {
+  case object AddressLevel1 extends AutoCompleteType {
     val value: String = "address-level1"
   }
-  final case object Country extends AutoCompleteType {
+  case object Country extends AutoCompleteType {
     val value: String = "country"
   }
-  final case object CountryName extends AutoCompleteType {
+  case object CountryName extends AutoCompleteType {
     val value: String = "country-name"
   }
-  final case object Postcode extends AutoCompleteType {
+  case object Postcode extends AutoCompleteType {
     val value: String = "postal-code"
   }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/calculation_row.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/calculation_row.scala.html
@@ -27,6 +27,10 @@
 <span class="calc-total">
  @{MoneyUtils.formatAmountOfMoneyWithPoundSign(total.abs().inPounds())}
  @if(showGainType) {
-  @{if (total.isNegative) s"(${messages("generic.loss")})" else if (!total.isZero) s"(${messages("generic.gain")})"}
+  @if(total.isNegative) {
+    (@messages("generic.loss"))
+  } else if(!total.isZero) {
+    (@messages("generic.gain"))
+  }
  }
 </span>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/country_code_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/country_code_govuk.scala.html
@@ -27,7 +27,7 @@
 
 @(
   countryCodes: List[Country.CountryCode],
-  form: Form[_],
+  form: Form[?],
   label: String,
   helpText: Option[Html] = None,
   labelAsHeading: Boolean = false

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/error_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/error_summary_govuk.scala.html
@@ -21,7 +21,7 @@
 @this(govukErrorSummary : GovukErrorSummary)
 
 @(
-        form: Form[_],
+        form: Form[?],
         customErrorKey: Option[String] = None,
         userKeyOnly: String = "",
         dateField: Option[String] = None
@@ -33,7 +33,7 @@
   errorList = form.errors.map { error =>
       ErrorLink(
         href = Some(s"#${if(dateField.isDefined && dateField.getOrElse("").matches(error.key)) { s"${error.key}-day" } else { error.key }}"),
-        content = Text(messages(s"${customErrorKey.getOrElse(error.key)}$userKeyOnly.${error.message}", error.args: _*))
+        content = Text(messages(s"${customErrorKey.getOrElse(error.key)}$userKeyOnly.${error.message}", error.args *))
       )
   }
 ))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/taskLink.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/components/taskLink.scala.html
@@ -43,5 +43,5 @@
 }
 
 <strong class="govuk-tag @classNameWithIsLink._1">
-@messages(s"task-list.$state")
+@messages(s"task-list.$state").toUpperCase
 </strong>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/landing_page.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/landing_page.scala.html
@@ -26,7 +26,7 @@
         govukButton: GovukButton
 )
 
-@()(implicit messages: Messages, appConfig: ViewConfig, request: Request[_])
+@()(implicit messages: Messages, appConfig: ViewConfig, request: Request[?])
 
 @title = @{
     messages("landingPage.title")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/already_subscribed_with_different_gg_account.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/already_subscribed_with_different_gg_account.scala.html
@@ -23,7 +23,7 @@
 
 @this(layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout, viewHelpers: ViewHelpers)
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@()(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("alreadySubscribedWithDifferentGGAccount.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/change_gg_account.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/change_gg_account.scala.html
@@ -29,7 +29,7 @@
 @(
   backLink: Call
 )(implicit
-  request: RequestWithSubscriptionReady[_],
+  request: RequestWithSubscriptionReady[?],
   messages: Messages,
   appConfig: ViewConfig
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/contactname/contact_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/contactname/contact_name.scala.html
@@ -38,7 +38,7 @@
   showAccountMenu: Boolean
 )(
   implicit
-  request: RequestWithSessionData[_],
+  request: RequestWithSessionData[?],
   messages: Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_a_nino.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_a_nino.scala.html
@@ -29,7 +29,7 @@
  formWrapper: FormWithCSRF
 )
 
-@(form: Form[Boolean])(implicit request:RequestWithSessionData [_], messages: Messages)
+@(form: Form[Boolean])(implicit request:RequestWithSessionData [?], messages: Messages)
 
 @key = @{"hasNino"}
 @title = @{messages("haveANino.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_an_sa_utr.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/do_you_have_an_sa_utr.scala.html
@@ -31,7 +31,7 @@
   formWrapper: FormWithCSRF
 )
 
-@(form: Form[Boolean], backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[Boolean], backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"hasSaUtr"}
 @title = @{messages("haveAnSaUtr.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/check_your_inbox.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/check_your_inbox.scala.html
@@ -36,7 +36,7 @@
   enterEmailSubmit: Call,
   resent: Boolean,
   emailJourneyType: EmailJourneyType
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{
   val prefix = if (resent) s"${messages("confirmEmail.resent")} " else ""

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/email_verified.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/email_verified.scala.html
@@ -28,7 +28,7 @@
   govukButton: GovukButton
 )
 
-@(email: Email, continueCall: Call, emailJourneyType: EmailJourneyType)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(email: Email, continueCall: Call, emailJourneyType: EmailJourneyType)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("confirmEmail.verified.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/enter_email.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/email/enter_email.scala.html
@@ -31,7 +31,7 @@
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary_govuk
 )
 
-@(form: Form[SubmitEmailDetails], emailJourneyType: EmailJourneyType, backLink: Option[Call], submit: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[SubmitEmailDetails], emailJourneyType: EmailJourneyType, backLink: Option[Call], submit: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"email"}
 @title = @{ messages("email.title") }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/enter_sa_utr_and_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/enter_sa_utr_and_name.scala.html
@@ -30,7 +30,7 @@
  viewHelpers: ViewHelpers
 )
 
-@(form: Form[IndividualSautrNameMatchDetails], backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[IndividualSautrNameMatchDetails], backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("enterSaUtr.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
@@ -40,20 +40,18 @@
 
 @layout(title, backLinkUrl = Some(backLink.url), hasErrors = hasErrors) {
 
- @{
-   if(form.hasGlobalErrors) {
-    viewHelpers.govukErrorSummary(ErrorSummary(
-     errorList = form.globalErrors.map { error =>
-      ErrorLink(
-       href = Some(s"#$saUtrKey"),
-       content = Text(messages(s"${error.message}"))
-      )
-     }
-    ))
-   } else if (form.hasErrors) {
-    errorSummary(form)
-   }
- }
+@if(form.hasGlobalErrors) {
+ @viewHelpers.govukErrorSummary(ErrorSummary(
+  errorList = form.globalErrors.map { error =>
+   ErrorLink(
+    href = Some(s"#$saUtrKey"),
+    content = Text(messages(s"${error.message}"))
+   )
+  }
+ ))
+} else if (form.hasErrors) {
+ @errorSummary(form)
+}
 
  <span class="govuk-caption-xl">@messages("subscription.caption")</span>
  <h1 class="govuk-heading-xl">@title</h1>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/failed_iv.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/failed_iv.scala.html
@@ -26,7 +26,7 @@
         viewHelpers: ViewHelpers
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("iv.failedIv.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/failed_matching.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/failed_matching.scala.html
@@ -26,7 +26,7 @@
         viewHelpers: ViewHelpers
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("iv.failedMatching.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/insufficient_evidence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/insufficient_evidence.scala.html
@@ -23,7 +23,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+@()(implicit request: RequestWithSessionData[?], messages: Messages, viewConfig: ViewConfig)
 
 @title = @{messages("iv.insufficientEvidence.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/locked_out.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/locked_out.scala.html
@@ -21,7 +21,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("iv.lockedOut.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/precondition_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/precondition_failed.scala.html
@@ -21,7 +21,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("iv.preconditionFailed.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/technical_iv_issues.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/technical_iv_issues.scala.html
@@ -26,7 +26,7 @@
         viewHelpers: ViewHelpers
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("iv.technicalIssue.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/time_out.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/time_out.scala.html
@@ -26,7 +26,7 @@
         viewHelpers: ViewHelpers
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("iv.timeout.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/user_aborted.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/iv/user_aborted.scala.html
@@ -26,7 +26,7 @@
         viewHelpers: ViewHelpers
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("iv.userAborted.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/name/enter_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/name/enter_name.scala.html
@@ -31,7 +31,7 @@
         accountMenu: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.account_menu_govuk
 )
 
-@(form: Form[IndividualName], backLink: Call, submit: Call, showAccountMenu: Boolean)(implicit request:RequestWithSessionData[_], messages: Messages)
+@(form: Form[IndividualName], backLink: Call, submit: Call, showAccountMenu: Boolean)(implicit request:RequestWithSessionData[?], messages: Messages)
 
 @firstNameKey = @{"firstName"}
 @lastNameKey = @{"lastName"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/register_your_trust.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/register_your_trust.scala.html
@@ -24,7 +24,7 @@
   layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("registerTrust.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/registration/check_your_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/registration/check_your_details.scala.html
@@ -28,7 +28,7 @@
         addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.address_display_govuk
 )
 
-@(details: RegistrationDetails)(implicit request:RequestWithSessionData[_], messages: Messages)
+@(details: RegistrationDetails)(implicit request:RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("registration.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/registration/select_entity_type.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/registration/select_entity_type.scala.html
@@ -30,7 +30,7 @@
         viewHelpers: ViewHelpers,
         govukRadios: GovukRadios
 )
-@(form: Form[EntityType], backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[EntityType], backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @toMessage(entityType: EntityType) = @{
   entityType match {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/check_your_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/check_your_details.scala.html
@@ -28,7 +28,7 @@
         addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.address_display_govuk
 )
 
-@(details: SubscriptionDetails)(implicit request: RequestWithSubscriptionReady[_], messages: Messages)
+@(details: SubscriptionDetails)(implicit request: RequestWithSubscriptionReady[?], messages: Messages)
 @affinity = @{details.name.fold(_ => "organisation", _ => "individual")}
 @title = @{messages(s"subscription.${affinity}.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/do_you_have_a_trn.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/do_you_have_a_trn.scala.html
@@ -30,7 +30,7 @@ layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout,
     formWrapper: FormWithCSRF
 )
 
-@(form: Form[Boolean], backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[Boolean], backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"hasTrn"}
 @title = @{messages("haveATrn.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/do_you_want_to_report_for_a_trust.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/do_you_want_to_report_for_a_trust.scala.html
@@ -29,7 +29,7 @@
         yesNo: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.yes_no_govuk
 )
 
-@(form: Form[Boolean], backLink: Call)(implicit request:RequestWithSessionData[_], messages: Messages)
+@(form: Form[Boolean], backLink: Call)(implicit request:RequestWithSessionData[?], messages: Messages)
 
 @key = @{"isReportingForATrust"}
 @title = @{messages("isReportingForATrust.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/enter_trn_and_trust_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/enter_trn_and_trust_name.scala.html
@@ -31,7 +31,7 @@
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary_govuk
 )
 
-@(form: Form[TrustNameMatchDetails], backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(form: Form[TrustNameMatchDetails], backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("enterTrn.title")}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
@@ -40,20 +40,18 @@
 
 @layout(title, backLinkUrl = Some(backLink.url), hasErrors = hasErrors) {
 
-  @{
-    if(form.hasGlobalErrors) {
-      viewHelpers.govukErrorSummary(ErrorSummary(
-        errorList = form.globalErrors.map { error =>
-          ErrorLink(
-            href = Some(s"#$trnKey"),
-            content = Text(messages(s"${error.message}"))
-          )
-        }
-      ))
-    } else if (form.hasErrors) {
-      errorSummary(form)
+@if(form.hasGlobalErrors) {
+  @viewHelpers.govukErrorSummary(ErrorSummary(
+    errorList = form.globalErrors.map { error =>
+      ErrorLink(
+        href = Some(s"#$trnKey"),
+        content = Text(messages(s"${error.message}"))
+      )
     }
-  }
+  ))
+} else if (form.hasErrors) {
+  @errorSummary(form)
+}
 
   <span class="govuk-caption-xl">@messages("subscription.caption")</span>
   <h1 class="govuk-heading-xl">@title</h1>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/report_with_corporate_tax.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/report_with_corporate_tax.scala.html
@@ -22,7 +22,7 @@
 
 @this(layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout)
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("reportCorpTax.title")}
 @layout(title, backLinkUrl = Some(backLink.url)) {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/subscribed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/subscribed.scala.html
@@ -30,7 +30,7 @@
 
 @(accountDetails: SubscribedDetails)(
   implicit
-  request: RequestWithSessionData[_],
+  request: RequestWithSessionData[?],
   messages: Messages,
   appConfig: ViewConfig
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/too_many_trn_name_match_attempts.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/subscription/too_many_trn_name_match_attempts.scala.html
@@ -23,7 +23,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@()(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("enterTrn.tooManyAttempts.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/too_many_name_match_attempts.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/too_many_name_match_attempts.scala.html
@@ -23,7 +23,7 @@
   layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("enterSaUtr.tooManyAttempts.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/we_need_more_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/we_need_more_details.scala.html
@@ -24,7 +24,7 @@
  govukButton: GovukButton
 )
 
-@(details: NeedMoreDetailsDetails)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(details: NeedMoreDetailsDetails)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("weNeedMoreDetails.title")}
 @affinity = @{details.affinityGroup match {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/we_only_support_gg.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/we_only_support_gg.scala.html
@@ -21,7 +21,7 @@
 
 @this(layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout)
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("weOnlySupportGG.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/wrong_gg_account_for_trust.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/onboarding/wrong_gg_account_for_trust.scala.html
@@ -24,7 +24,7 @@
  layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @title = @{messages("wrongAccountForTrusts.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_date.scala.html
@@ -41,7 +41,7 @@
     representativeType: Option[RepresentativeType],
     assetType: AssetType,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"acquisitionDate"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_fees.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_fees.scala.html
@@ -53,7 +53,7 @@
   isAmend: Boolean,
   isShare: Boolean,
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages,
   appConfig: ViewConfig
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_method.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_method.scala.html
@@ -43,7 +43,7 @@
     representativeType: Option[RepresentativeType],
     assetType: AssetType,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"acquisitionMethod"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/acquisition_price.scala.html
@@ -48,7 +48,7 @@
   isAmend: Boolean,
   isShare: Boolean,
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages: Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/check_your_answers.scala.html
@@ -40,7 +40,7 @@
     representativeType: Option[RepresentativeType],
     assetType: AssetType,
     isShare: Boolean,
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("acquisitionDetails.cya.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/improvement_costs.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/improvement_costs.scala.html
@@ -49,7 +49,7 @@
   isAmend: Boolean,
   isShare: Boolean,
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/period_of_admin_market_value.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/period_of_admin_market_value.scala.html
@@ -43,7 +43,7 @@
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/rebased_acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/rebased_acquisition_price.scala.html
@@ -49,7 +49,7 @@
   assetType: AssetType,
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages,
   appConfig: ViewConfig
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/should_use_rebase.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/should_use_rebase.scala.html
@@ -45,7 +45,7 @@
         isAmend: Boolean,
         isATrust: Boolean,
         wasAUkResident: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "shouldUseRebase" }
 @assetTypeKey = @{assetType match {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/acquisitiondetails/summary_govuk.scala.html
@@ -43,7 +43,7 @@
     representativeType: Option[RepresentativeType],
     assetType: AssetType,
     isShare: Boolean,
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 
 @userKey = @{
@@ -103,49 +103,47 @@
 @cyaSection() {
   @if(!isPeriodOfAdmin) {
       @cyaRow(
-      messages(s"acquisitionMethod$userKey$assetTypeKey.title"),
-      Html(acquisitionMethodAndPriceTitle._1),
-      Some(cyaChange(
-      messages("acquisitionMethod.cyaChange"),
-      routes.AcquisitionDetailsController.acquisitionMethod().url
-      )),
-      "acquisitionMethod"
+          messages(s"acquisitionMethod$userKey$assetTypeKey.title"),
+          Html(acquisitionMethodAndPriceTitle._1),
+          Some(cyaChange(
+          messages("acquisitionMethod.cyaChange"),
+          routes.AcquisitionDetailsController.acquisitionMethod().url
+          )),
+          "acquisitionMethod"
       )
+      @cyaRow(
+        messages(s"acquisitionDate$userKey$assetTypeKey.title"),
+        Html(TimeUtils.govDisplayFormat(answers.acquisitionDate.value)),
+        Some(cyaChange(
+          messages("acquisitionDate.cyaChange"),
+          routes.AcquisitionDetailsController.acquisitionDate().url
+        )),
+        "acquisitionDate"
+      )
+  }
+
+
+@if(isPeriodOfAdmin) {
   @cyaRow(
-    messages(s"acquisitionDate$userKey$assetTypeKey.title"),
-    Html(TimeUtils.govDisplayFormat(answers.acquisitionDate.value)),
-    Some(cyaChange(
-      messages("acquisitionDate.cyaChange"),
-      routes.AcquisitionDetailsController.acquisitionDate().url
-    )),
-    "acquisitionDate"
+      messages(s"periodOfAdminMarketValue$assetTypeKey$shareKey.title", acquisitionDate),
+      Html(MoneyUtils.formatAmountOfMoneyWithPoundSign(answers.acquisitionPrice.inPounds())),
+      Some(cyaChange(
+          messages("periodOfAdminMarketValue.cyaChange", acquisitionDate),
+          routes.AcquisitionDetailsController.periodOfAdminMarketValue().url
+      )),
+      "periodOfAdminMarketValue"
   )
-  }
-
-
-  @{
-      if(isPeriodOfAdmin) {
-          cyaRow(
-              messages(s"periodOfAdminMarketValue$assetTypeKey$shareKey.title", acquisitionDate),
-              Html(MoneyUtils.formatAmountOfMoneyWithPoundSign(answers.acquisitionPrice.inPounds())),
-              Some(cyaChange(
-                  messages("periodOfAdminMarketValue.cyaChange", acquisitionDate),
-                  routes.AcquisitionDetailsController.periodOfAdminMarketValue().url
-              )),
-              "periodOfAdminMarketValue"
-          )
-      } else if((isUk && !canRebase) || !isUk) {
-          cyaRow(
-              acquisitionMethodAndPriceTitle._2,
-              Html(MoneyUtils.formatAmountOfMoneyWithPoundSign(answers.acquisitionPrice.inPounds())),
-              Some(cyaChange(
-                  acquisitionMethodAndPriceTitle._3,
-                  routes.AcquisitionDetailsController.acquisitionPrice().url
-              )),
-              "acquisitionPrice"
-          )
-      }
-  }
+} else if((isUk && !canRebase) || !isUk) {
+  @cyaRow(
+      acquisitionMethodAndPriceTitle._2,
+      Html(MoneyUtils.formatAmountOfMoneyWithPoundSign(answers.acquisitionPrice.inPounds())),
+      Some(cyaChange(
+          acquisitionMethodAndPriceTitle._3,
+          routes.AcquisitionDetailsController.acquisitionPrice().url
+      )),
+      "acquisitionPrice"
+  )
+}
 
 @if(canRebase) {
   @answers.rebasedAcquisitionPrice.map{ rebasedValue =>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/acquisition_price.scala.html
@@ -44,7 +44,7 @@
     dateOfDeath: Option[DateOfDeath],
     isAmend: Boolean,
     addressCaption: String
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "multipleDisposalsAcquisitionPrice" }
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_date.scala.html
@@ -41,7 +41,7 @@
   isAmend: Boolean,
   addressCaption: String
 
-)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, viewConfig: ViewConfig)
 
 @key = @{"multipleDisposalsDisposalDate"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }
@@ -68,7 +68,7 @@
    helpText = Some(Html(messages(s"$key$userKey.helpText"))),
    errorKey = errorKey.map(e => {
        if(e.message == "error.tooFarInPast") {
-           messages(s"${e.key}.${e.message}", e.args:_*)
+           messages(s"${e.key}.${e.message}", e.args *)
        } else {
            s"${e.key}.${e.message}"
        }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/disposal_price.scala.html
@@ -44,7 +44,7 @@
         representativeType: Option[RepresentativeType],
         isAmend: Boolean,
         addressCaption: String
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{
     "multipleDisposalsDisposalPrice"

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/does_property_have_uprn.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/does_property_have_uprn.scala.html
@@ -27,7 +27,6 @@
         submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button_govuk,
         errorSummary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.error_summary_govuk,
         formHelper: FormWithCSRF,
-        govukDetails: GovukDetails,
         yesNo: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.yes_no_govuk,
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
@@ -36,7 +35,7 @@
     form: Form[Boolean],
     backLink: Call,
     isSingleDisposal: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"doesPropertyHaveUPRN"}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/enter_property_address.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/enter_property_address.scala.html
@@ -39,7 +39,7 @@
     backLink: Call,
     isSingleDisposal: Boolean,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"noUPRN"}
 @line1Key = @{"address-line1"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/enter_uprn.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/enter_uprn.scala.html
@@ -39,7 +39,7 @@
     backLink: Call,
     isSingleDisposal: Boolean,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"enterUPRN"}
 @line1Key = @{s"$key-line1"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/has_valid_postcode.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/has_valid_postcode.scala.html
@@ -35,7 +35,7 @@
     backLink: Call,
     isSingleDisposal: Boolean,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"hasValidPostcode"}
 @journeyContext = @{ if(isSingleDisposal) "singleDisposal" else "multipleDisposals" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_check_your_answers.scala.html
@@ -38,7 +38,7 @@ summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.address.mul
     firstTimeVisiting: Boolean,
     addressCaption: String,
     propertyCount: Int,
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 
 @title = @{messages("returns.property-address.cya.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_guidance.scala.html
@@ -35,7 +35,7 @@
     backLink: Call,
     isATrust: Boolean,
     representativeType: Option[RepresentativeType]
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"property-details.multiple-disposals.guidance"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_disposals_summary_govuk.scala.html
@@ -38,7 +38,7 @@ addressDisplay: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.a
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     dateOfDeath: Option[DateOfDeath]
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 @userKey = @{

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_indirect_disposals_acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_indirect_disposals_acquisition_price.scala.html
@@ -36,7 +36,7 @@
     form: Form[BigDecimal],
     backLink: Call,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "multipleIndirectDisposalsAcquisitionPrice" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_indirect_disposals_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_indirect_disposals_check_your_answers.scala.html
@@ -28,7 +28,7 @@
     summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.address.multiple_indirect_disposals_summary_govuk
 )
 
-@(answers: CompleteExampleCompanyDetailsAnswers)(implicit request: RequestWithSessionData[_], messages:Messages)
+@(answers: CompleteExampleCompanyDetailsAnswers)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 
 @title = @{messages("returns.company-address.cya.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_indirect_disposals_disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_indirect_disposals_disposal_price.scala.html
@@ -36,7 +36,7 @@
     form: Form[BigDecimal],
     backLink: Call,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "multipleIndirectDisposalsDisposalPrice" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_indirect_disposals_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/multiple_indirect_disposals_guidance.scala.html
@@ -28,7 +28,7 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
 
-@(backLink: Call, isPeriodOfAdmin: Boolean)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(backLink: Call, isPeriodOfAdmin: Boolean)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"company-details.multiple-indirect-disposals.guidance"}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_disposal_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_disposal_check_your_answers.scala.html
@@ -28,7 +28,7 @@
         summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.address.single_disposal_summary_govuk
 )
 
-@(propertyAddress: UkAddress, shouldAskIfPostcodeExists: Boolean)(implicit request: RequestWithSessionData[_], messages:Messages)
+@(propertyAddress: UkAddress, shouldAskIfPostcodeExists: Boolean)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 
 @title = @{messages("returns.property-address.cya.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_indirect_disposal_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_indirect_disposal_check_your_answers.scala.html
@@ -28,7 +28,7 @@ layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout,
   summary: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.returns.address.single_indirect_disposal_summary_govuk
 )
 
-@(companyAddress: Address)(implicit request: RequestWithSessionData[_], messages:Messages)
+@(companyAddress: Address)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @title = @{messages("companyDetails.cya.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_acquisition_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_acquisition_price.scala.html
@@ -43,7 +43,7 @@
     representativeType: Option[RepresentativeType],
     dateOfDeath: Option[DateOfDeath],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "singleMixedUseDisposalsAcquisitionPrice" }
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_check_your_answers.scala.html
@@ -33,7 +33,7 @@
 @(
         answers: CompleteMixedUsePropertyDetailsAnswers,
         representativeType: Option[RepresentativeType],
-        dateOfDeath: Option[DateOfDeath])(implicit request: RequestWithSessionData[_], messages:Messages)
+        dateOfDeath: Option[DateOfDeath])(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @title = @{messages("singleMixedUse.cya.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_disposal_price.scala.html
@@ -42,7 +42,7 @@
  isATrust: Boolean,
  representativeType: Option[RepresentativeType],
  isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "singleMixedUseDisposalsDisposalPrice" }
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/address/single_mixed_use_guidance.scala.html
@@ -30,7 +30,7 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
 
-@(backLink: Call, representativeType: Option[RepresentativeType])(implicit request: RequestWithSessionData[_], messages: Messages)
+@(backLink: Call, representativeType: Option[RepresentativeType])(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"singleMixedUse.guidance"}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/check_your_answers.scala.html
@@ -39,7 +39,7 @@
     isIndirectDisposal: Boolean,
     isFurtherOrAmendReturn: Option[Boolean],
     backLink: Call
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "amendCya" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/confirm_cancel.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/confirm_cancel.scala.html
@@ -29,7 +29,7 @@
         yesNo: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.yes_no_govuk,
 )
 
-@(form: Form[Boolean], backLink: Call, submit: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[Boolean], backLink: Call, submit: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"confirmCancelAmendReturn"}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/have_you_already_sent_self_assesment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/have_you_already_sent_self_assesment.scala.html
@@ -39,7 +39,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     taxYearStartYear: Int
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"alreadySentSelfAssessment"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }
@@ -84,7 +84,7 @@
             errorKey = form.error(key).map(e => s"$userErrorKey${e.message}"),
             selected = form.value,
             helpText = None,
-            errorMessage = form.error(key).map(e => messages(s"${e.key}.$userErrorKey${e.message}", e.args:_*) )
+            errorMessage = form.error(key).map(e => messages(s"${e.key}.$userErrorKey${e.message}", e.args *) )
         )
 
         @submitButton(messages(if (hasCreatedDraftReturn) "button.saveAndContinue" else "button.continue"))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/self_assessment_already_submitted.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/self_assessment_already_submitted.scala.html
@@ -32,7 +32,7 @@
     isATrust: Boolean,
     taxYearStart: Int,
     representativeType: Option[RepresentativeType]
-)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages: Messages, viewConfig: ViewConfig)
 
 @key = @{"selfAssessmentAlreadySubmitted"}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/unmet_dependency.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/amend/unmet_dependency.scala.html
@@ -28,7 +28,7 @@
         govukButton: GovukButton
         )
 
-@(backLink: Call, key: String)(implicit messages:Messages, request: RequestWithSessionData[_])
+@(backLink: Call, key: String)(implicit messages:Messages, request: RequestWithSessionData[?])
 
 @title = @{messages(s"$key.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/check_all_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/check_all_answers.scala.html
@@ -66,7 +66,7 @@
     showSubmissionDetails: Boolean,
     hideEstimatesQuestion: Boolean,
     furtherOrAmendReturnCalculationEligibility: Option[FurtherReturnCalculationEligibility]
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @subscribedDetails = @{ fillingOutReturn.subscribedDetails }
 @representativeType = @{ completeReturn.representativeType }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/complete_return_summary.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/complete_return_summary.scala.html
@@ -50,7 +50,7 @@
         isFurtherOrAmendReturn: Option[Boolean],
         isAmend: Boolean,
         returnSummaryClass: Option[String] = None
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key= @{ "viewReturn" }
 @showAnnualExemptAmount = @{ !(isFurtherOrAmendReturn.contains(true) && completeReturn.exemptionAndLossesAnswers.annualExemptAmount.isZero) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/confirmation_of_submission.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/confirmation_of_submission.scala.html
@@ -47,7 +47,7 @@
         govukTable: GovukTable
 )
 
-@(justSubmittedReturn: JustSubmittedReturn)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+@(justSubmittedReturn: JustSubmittedReturn)(implicit request: RequestWithSessionData[?], messages:Messages, viewConfig: ViewConfig)
 
 @key=@{"confirmationOfSubmission"}
 @title = @{ messages(s"$key.title") }
@@ -207,15 +207,15 @@
       None,
       "property-address-table"
     )
-    @{if(showDueDate && deltaCharge.isEmpty) {
-      justSubmittedReturn.submissionResponse.charge.map { charge =>
-        cyaRow(
+    @if(showDueDate && deltaCharge.isEmpty) {
+      @justSubmittedReturn.submissionResponse.charge.map { charge =>
+        @cyaRow(
           messages(s"$key.taxDue"),
           Html(TimeUtils.govDisplayFormat(charge.dueDate)),
           None,
           "tax-due-date-table"
         )
-      }}
+      }
     }
   }
 
@@ -321,7 +321,9 @@
           } else {
             <p class="govuk-hint">@messages(s"$key${if(isATrust && isAgent) ".trust" else ""}.paymentNotice")</p>
           }
-          @{if (!isAgent) payNowButton }
+          @if(!isAgent) {
+            @payNowButton
+          }
         }
       }
     }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/check_your_answers.scala.html
@@ -37,7 +37,7 @@
     representativeType: Option[RepresentativeType],
     isIndirectDisposal: Boolean,
     isShare: Boolean,
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("returns.disposal-details.cya.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_fees.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_fees.scala.html
@@ -43,7 +43,7 @@
     isIndirectDisposal: Boolean,
     isAmend: Boolean,
     isShare: Boolean,
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "disposalFees" }
 @indirectKey = @{ if(isIndirectDisposal) ".indirect" else ""}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_price.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/disposal_price.scala.html
@@ -45,7 +45,7 @@
   isIndirectDisposal: Boolean,
   isAmend: Boolean,
   isShare: Boolean,
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 @userKey = @{

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/how_much_did_you_own.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/how_much_did_you_own.scala.html
@@ -42,7 +42,7 @@
     isATrust: Boolean ,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 @userKey = @{

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/disposaldetails/summary_govuk.scala.html
@@ -37,7 +37,7 @@
     representativeType: Option[RepresentativeType],
     isIndirectDisposal: Boolean,
     isShare: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/annual_exempt_amount.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/annual_exempt_amount.scala.html
@@ -50,7 +50,7 @@
     representativeType: Option[RepresentativeType],
     isAmend: Boolean,
     isFurtherOrAmendReturn: Option[Boolean]
-)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @key = @{ "annualExemptAmount" }
 @furtherReturnKey = @{if(isFurtherOrAmendReturn.contains(true)) ".furtherReturn" else ""}
@@ -116,7 +116,7 @@
           content = Text("£")
         )),
         errorMessage = form.error(key).map(e => ErrorMessage(
-          content = Text(messages(s"$key$userKey.${e.message}", e.args: _*)),
+          content = Text(messages(s"$key$userKey.${e.message}", e.args *)),
           visuallyHiddenText = Some(messages("generic.error"))
         )),
         autocomplete = Some(AutoCompleteType.On.value)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/check_your_answers.scala.html
@@ -36,7 +36,7 @@
     representativeType: Option[RepresentativeType],
     isFurtherOrAmendReturn: Option[Boolean],
     showAnnualExemptAmount: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{
     messages("exemptionsAndLosses.cya.title")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/further_return_in_year_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/further_return_in_year_losses.scala.html
@@ -42,7 +42,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "inYearLosses" }
 @valueKey = @{ "inYearLossesValue" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/further_return_previous_years_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/further_return_previous_years_losses.scala.html
@@ -47,7 +47,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @key = @{ "previousYearsLosses" }
 @valueKey = @{ "previousYearsLossesValue" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/in_year_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/in_year_losses.scala.html
@@ -49,7 +49,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @key = @{ "inYearLosses" }
 @valueKey = @{ "inYearLossesValue" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/previous_years_losses.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/previous_years_losses.scala.html
@@ -48,7 +48,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @key = @{ "previousYearsLosses" }
 @valueKey = @{ "previousYearsLossesValue" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/exemptionandlosses/summary_govuk.scala.html
@@ -39,7 +39,7 @@
     representativeType: Option[RepresentativeType],
     isFurtherOrAmendReturn: Option[Boolean],
     showAnnualExemptAmount: Boolean
-)(implicit messages: Messages, request: RequestWithSessionData[_])
+)(implicit messages: Messages, request: RequestWithSessionData[?])
 
 @furtherReturnKey = @{ if(isFurtherOrAmendReturn.contains(true)) ".furtherReturn" else "" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/check_your_answers.scala.html
@@ -34,7 +34,7 @@
         isATrust: Boolean,
         representativeType: Option[RepresentativeType],
         isMultipleDisposal: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{
     messages("gainOrLossAfterReliefs.cya.title")

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/gain_or_loss_after_reliefs.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/gain_or_loss_after_reliefs.scala.html
@@ -47,7 +47,7 @@
     isMultipleDisposal: Boolean,
     isAmend: Boolean,
     glarCalulatorInput: Option[CalculatedGlarBreakdown]
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{ "gainOrLossAfterReliefs" }
 @gainKey = @{ "gainAfterReliefs" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/gainorlossafterreliefs/summary_govuk.scala.html
@@ -35,7 +35,7 @@ cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_ch
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isMultipleDisposal: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @isAgent = @{request.userType.contains(UserType.Agent)}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/check_your_answers.scala.html
@@ -30,7 +30,7 @@
 )
 
 @(answers: AmountInPence, isATrust: Boolean,
-        representativeType: Option[RepresentativeType])(implicit request: RequestWithSessionData[_], messages: Messages)
+        representativeType: Option[RepresentativeType])(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("initialGainOrLoss.cya.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/initial_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/initial_gain_or_loss.scala.html
@@ -44,7 +44,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{ "initialGainOrLoss" }
 @gainKey = @{ "gain" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/initialgainorloss/summary_govuk.scala.html
@@ -30,7 +30,7 @@ cyaRow: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_row_g
 cyaChange: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.cya_change_govuk,
 )
 
-@(answers: AmountInPence, isATrust: Boolean, representativeType: Option[RepresentativeType])(implicit request: RequestWithSessionData[_], messages: Messages)
+@(answers: AmountInPence, isATrust: Boolean, representativeType: Option[RepresentativeType])(implicit request: RequestWithSessionData[?], messages: Messages)
 @isAgent = @{request.userType.contains(UserType.Agent)}
 
 @userKey = @{

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/multiple_draft_return_exit.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/multiple_draft_return_exit.scala.html
@@ -25,7 +25,7 @@
  govukButton: GovukButton
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
  @key=@{"multiple-draft.exit"}
  @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/partials/account_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/partials/account_name.scala.html
@@ -22,7 +22,7 @@
 
 @this(caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption_govuk)
 
-@(fillingOutReturn: FillingOutReturn)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(fillingOutReturn: FillingOutReturn)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @isAnAgent = @{ request.userType.contains(UserType.Agent)}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/check_your_answers.scala.html
@@ -33,7 +33,7 @@
   answers: CompleteReliefDetailsAnswers,
   isATrust: Boolean,
   representativeType: Option[RepresentativeType]
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("reliefDetails.cya.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/lettings_relief.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/lettings_relief.scala.html
@@ -34,7 +34,6 @@
         formWrapper: FormWithCSRF,
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk,
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption_govuk,
-        details: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.details_govuk,
         govukRadios: GovukRadios,
         govukInput: GovukInput
 )
@@ -45,7 +44,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @key = @{ "lettingsRelief" }
 @valueKey = @{"lettingsReliefValue"}
@@ -81,7 +80,7 @@
       content = Text("£")
     )),
     errorMessage = form.error(valueKey).map(e => ErrorMessage(
-      content = Text(messages(s"$valueKey.${e.message}", e.args: _*)),
+      content = Text(messages(s"$valueKey.${e.message}", e.args *)),
       visuallyHiddenText = Some(messages("generic.error"))
     )),
     autocomplete = Some(AutoCompleteType.On.value)
@@ -127,7 +126,7 @@
       ),
       errorMessage = form.error(key).map(e =>
         ErrorMessage(
-          content = Text(messages(s"$key$userKey.${e.message}", e.args: _*)),
+          content = Text(messages(s"$key$userKey.${e.message}", e.args *)),
           visuallyHiddenText = Some(messages("generic.error"))
         )
       )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/other_reliefs.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/other_reliefs.scala.html
@@ -43,7 +43,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"otherReliefs"}
 @nameKey = @{"otherReliefsName"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/private_residents_relief.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/private_residents_relief.scala.html
@@ -45,7 +45,7 @@
   isATrust: Boolean,
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @key = @{ "privateResidentsRelief" }
 @valueKey = @{"privateResidentsReliefValue"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/reliefdetails/summary_govuk.scala.html
@@ -36,7 +36,7 @@
   answers: CompleteReliefDetailsAnswers,
   isATrust: Boolean,
   representativeType: Option[RepresentativeType]
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/change_contact_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/change_contact_name.scala.html
@@ -38,7 +38,7 @@
   displayReturnToSummaryLink: Boolean,
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages: Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_contact_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_contact_details.scala.html
@@ -38,7 +38,7 @@
 @(
         contactDetails: RepresenteeContactDetails,
         displayReturnToSummaryLink: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{ "representeeContactDetails" }
 @title = @{messages(s"$key.title") }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/check_your_answers.scala.html
@@ -35,7 +35,7 @@
     answers: CompleteRepresenteeAnswers,
     representativeType: RepresentativeType,
     backLink: Call
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 
 @title = @{messages("representee.cya.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/confirm_person.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/confirm_person.scala.html
@@ -44,7 +44,7 @@
     form: Form[Boolean],
     backLink: Call,
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("representeeConfirmPerson.title")}
 @key = @{"confirmed"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_date_of_death.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_date_of_death.scala.html
@@ -38,7 +38,7 @@
   displayReturnToSummaryLink: Boolean,
   isAmend: Boolean
 )(
-  implicit request:RequestWithSessionData[_],
+  implicit request:RequestWithSessionData[?],
   messages: Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_name.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_name.scala.html
@@ -42,7 +42,7 @@
    representativeType: RepresentativeType,
    displayReturnToSummaryLink: Boolean,
    isAmend: Boolean
-)(implicit request:RequestWithSessionData[_], messages: Messages)
+)(implicit request:RequestWithSessionData[?], messages: Messages)
 
 @key = @{ "representee.enterName" }
 @representativeTypeInterpolator = @{

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_reference_number.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/enter_reference_number.scala.html
@@ -34,7 +34,7 @@
         govukInput : GovukInput
 )
 
-@(form: Form[RepresenteeReferenceId], backLink: Call, displayReturnToSummaryLink: Boolean, isAmend: Boolean)(implicit request: RequestWithSessionData[_], messages:Messages)
+@(form: Form[RepresenteeReferenceId], backLink: Call, displayReturnToSummaryLink: Boolean, isAmend: Boolean)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "representeeReferenceIdType" }
 @ninoKey = @{ "representeeNino" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/is_first_return.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/is_first_return.scala.html
@@ -36,7 +36,7 @@
         govukButton: GovukButton
 )
 
-@(form: Form[Boolean], backLink: Call, displayReturnToSummaryLink: Boolean, representativeType: RepresentativeType, isAmend: Boolean)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(form: Form[Boolean], backLink: Call, displayReturnToSummaryLink: Boolean, representativeType: RepresentativeType, isAmend: Boolean)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"representeeIsFirstReturn"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/name_match_error.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/name_match_error.scala.html
@@ -26,7 +26,7 @@
 )
 
 @()(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/too_many_name_match_failures.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/representee/too_many_name_match_failures.scala.html
@@ -22,7 +22,7 @@
 )
 
 @()(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/return_saved.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/return_saved.scala.html
@@ -28,7 +28,7 @@ govukButton: GovukButton,
 govukWarningText: GovukWarningText
 )
 
-@(draftReturn: DraftReturn, isATrust: Boolean)(implicit request: RequestWithSessionData[_], messages:Messages)
+@(draftReturn: DraftReturn, isATrust: Boolean)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"draftReturnSaved"}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/submit_return_error.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/submit_return_error.scala.html
@@ -25,7 +25,7 @@
     submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button_govuk
 )
 
-@()(implicit request: RequestWithSessionData[_], messages: Messages)
+@()(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"submitReturnError"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/check_your_answers.scala.html
@@ -31,7 +31,7 @@
   answers: CompleteSupportingEvidenceAnswers,
   maxUploads: Int
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages: Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/do_you_want_to_upload.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/do_you_want_to_upload.scala.html
@@ -38,7 +38,7 @@
   isAmend: Boolean,
   dueRepayment: Boolean = false
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages: Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/expired.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/expired.scala.html
@@ -28,7 +28,7 @@
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption_govuk
 )
 
-@(expired: List[SupportingEvidence])(implicit request: RequestWithSessionData[_], messages: Messages)
+@(expired: List[SupportingEvidence])(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"supporting-evidence.expired"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_failed.scala.html
@@ -26,7 +26,7 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
 
-@()(implicit request:RequestWithSessionData[_], messages:Messages)
+@()(implicit request:RequestWithSessionData[?], messages:Messages)
 @key = @{"supporting-evidence.scan-failed"}
 @title = @{messages(s"$key.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_progress.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/scan_progress.scala.html
@@ -28,7 +28,7 @@
     returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
 
-@(upscanUpload : UpscanUpload)(implicit request:RequestWithSessionData[_], messages:Messages)
+@(upscanUpload : UpscanUpload)(implicit request:RequestWithSessionData[?], messages:Messages)
 
     @key = @{"supporting-evidence.scan-progress"}
     @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload.scala.html
@@ -33,7 +33,7 @@
     backLink: Call,
     isAmend: Boolean,
     isReplaymentDue: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"supporting-evidence.upload"}
 @field = @{"file"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/supportingevidence/upload_failed.scala.html
@@ -26,7 +26,7 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk,
 )
 
-@()(implicit request:RequestWithSessionData[_], messages:Messages)
+@()(implicit request:RequestWithSessionData[?], messages:Messages)
 
     @key = @{"supporting-evidence.upload-failed"}
     @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/multiple_disposals_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/multiple_disposals_task_list.scala.html
@@ -37,7 +37,7 @@
 @(
     draftReturn: DraftMultipleDisposalsReturn,
     fillingOutReturn: FillingOutReturn
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("service.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/multiple_indirect_disposals_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/multiple_indirect_disposals_task_list.scala.html
@@ -37,7 +37,7 @@
 @(
     draftReturn: DraftMultipleIndirectDisposalsReturn,
     fillingOutReturn: FillingOutReturn
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("service.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_disposal_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_disposal_task_list.scala.html
@@ -44,7 +44,7 @@
 @(
     draftReturn: DraftSingleDisposalReturn,
     fillingOutReturn: FillingOutReturn
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("service.title")}
 
@@ -147,7 +147,7 @@
           case n: NonCalculatedYTDAnswers => n.fold(_ => InProgress, _ => Complete)
       }
 
-      case _ => TaskListStatus.CannotStart
+    case _ => TaskListStatus.CannotStart
   }
 }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_indirect_disposal_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_indirect_disposal_task_list.scala.html
@@ -37,7 +37,7 @@
 @(
     draftReturn: DraftSingleIndirectDisposalReturn,
     fillingOutReturn: FillingOutReturn
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("service.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_mixed_use_disposal_task_list.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/tasklist/single_mixed_use_disposal_task_list.scala.html
@@ -37,7 +37,7 @@
 @(
         draftReturn: DraftSingleMixedUseDisposalReturn,
         fillingOutReturn: FillingOutReturn
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("service.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/amend_who_are_you_submitting_for_exit_page.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/amend_who_are_you_submitting_for_exit_page.scala.html
@@ -24,7 +24,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"who-are-you-reporting-for-exit-page"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/cannot_amend_residential_status_for_asset_type.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/cannot_amend_residential_status_for_asset_type.scala.html
@@ -27,7 +27,7 @@
 )
 
 @(backLink: Call,
-        isATrust: Boolean)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+        isATrust: Boolean)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 
 @key = @{"cannotAmendResidentialStatusForAssetType"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_of_shares.scala.html
@@ -36,7 +36,7 @@
         displayReturnToSummaryLink: Boolean,
         submit: Call,
         isAmend: Boolean
-)(implicit request:RequestWithSessionData[_], messages: Messages)
+)(implicit request:RequestWithSessionData[?], messages: Messages)
 
 @key = @{ "sharesDisposalDate" }
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_non_uk_residents.scala.html
@@ -24,7 +24,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call, cutoffTaxYear: Long)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call, cutoffTaxYear: Long)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"disposalDateTooEarly"}
 @title = @{messages(s"$key.non-uk.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposal_date_too_early_uk_residents.scala.html
@@ -24,7 +24,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call, cutoffTaxYear: Long)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call, cutoffTaxYear: Long)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"disposalDateTooEarly"}
 @title = @{messages(s"$key.uk.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposaldate_in_different_taxyear.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/disposaldate_in_different_taxyear.scala.html
@@ -24,7 +24,7 @@
     layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request:RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request:RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @key = @{ "disposalDateInDifferentTaxYear" }
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/exchangedate_incompatible_taxyears.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/exchangedate_incompatible_taxyears.scala.html
@@ -25,7 +25,7 @@
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption_govuk
 )
 
-@(backLink: Call)(implicit request:RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request:RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @key = @{ "multipleDisposalsExchangeDateInDifferentTaxYear" }
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/have_you_already_sent_self_assesment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/have_you_already_sent_self_assesment.scala.html
@@ -40,7 +40,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     taxYearStartYear: Int
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"alreadySentSelfAssessment"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }
@@ -86,7 +86,7 @@
             errorKey = form.error(key).map(e => s"$userErrorKey${e.message}"),
             selected = form.value,
             helpText = None,
-            errorMessage = form.error(key).map(e => messages(s"${e.key}.$userErrorKey${e.message}", e.args:_*) )
+            errorMessage = form.error(key).map(e => messages(s"${e.key}.$userErrorKey${e.message}", e.args *) )
         )
 
         @submitButton(messages(if (hasCreatedDraftReturn) "button.saveAndContinue" else "button.continue"))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/how_many_properties.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/how_many_properties.scala.html
@@ -43,7 +43,7 @@
     representativeType: Option[RepresentativeType],
     isAmend: Boolean,
         isFurtherOrAmendReturn: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"numberOfProperties"}
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/asset_type_for_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/asset_type_for_non_uk_residents.scala.html
@@ -41,7 +41,7 @@
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/check_you_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/check_you_answers.scala.html
@@ -36,7 +36,7 @@
    isATrust: Boolean,
    representeeAnswers: Option[RepresenteeAnswers],
    firstTimeVisiting: Boolean,
-)(implicit request:RequestWithSessionData[_], messages:Messages)
+)(implicit request:RequestWithSessionData[?], messages:Messages)
 
 @title = @{messages("multipleDisposals.triage.cya.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/completion_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/completion_date.scala.html
@@ -41,7 +41,7 @@
   backLink: Call,
   hasCreatedDraftReturn: Boolean,
   isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, viewConfig: ViewConfig)
 
 @key = @{"multipleDisposalsCompletionDate"}
 @hasErrors = @{form.hasErrors}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/country_of_residence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/country_of_residence.scala.html
@@ -45,7 +45,7 @@
         representativeType: Option[RepresentativeType],
         representeeAnswers: Option[RepresenteeAnswers],
         isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/exchanged_different_tax_years.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/exchanged_different_tax_years.scala.html
@@ -24,7 +24,7 @@
     mainTemplate: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"multipleDisposalsExchangedInDifferentTaxYears"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/guidance.scala.html
@@ -39,7 +39,7 @@ govukButton: GovukButton
   hasCreatedDraftReturn: Boolean,
   isATrust: Boolean,
   representativeType: Option[RepresentativeType]
-)(implicit request:RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request:RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 @userKey = @{

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/how_many_properties.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/how_many_properties.scala.html
@@ -39,7 +39,7 @@
   hasCreatedDraftReturn: Boolean,
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages: Messages,
   appConfig: ViewConfig
 )

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/summary_govuk.scala.html
@@ -35,7 +35,7 @@
     answers: CompleteMultipleDisposalsTriageAnswers,
     isATrust: Boolean,
     representeeAnswers: Option[RepresenteeAnswers]
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @representativeType = @{answers.representativeType()}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/tax_year_exchanged.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/tax_year_exchanged.scala.html
@@ -41,7 +41,7 @@
     hasCreatedDraftReturn: Boolean,
     isAmend: Boolean,
     availableTaxYears: List[Int]
-)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, viewConfig: ViewConfig)
 
 @key = @{"multipleDisposalsTaxYear"}
 @inPageTitle = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_all_properties_residential.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_all_properties_residential.scala.html
@@ -38,7 +38,7 @@
   hasCreatedDraftReturn: Boolean,
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages
 )
 
@@ -77,7 +77,7 @@
       errorKey = form.error(key).map(e => e.message),
       selected = form.value,
       helpText = Some(Html(messages(s"$key.helpText"))),
-      errorMessage = form.error(key).map(e => messages(s"${e.key}.${e.message}", e.args:_*) )
+      errorMessage = form.error(key).map(e => messages(s"${e.key}.${e.message}", e.args *) )
     )
 
     @govukDetails(Details(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_you_a_uk_resident.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/multipledisposals/were_you_a_uk_resident.scala.html
@@ -43,7 +43,7 @@
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages,
   viewConfig: ViewConfig
 )
@@ -102,7 +102,7 @@
       errorKey = form.error(key).map(e => s"$userErrorKey${e.message}"),
       selected = form.value,
       helpText = Some(Html(messages(s"$key.helpText"))).filterNot(_ => isPeriodOfAdmin),
-      errorMessage = form.error(key).map(e => messages(s"${e.key}.$userErrorKey${e.message}", e.args:_*) )
+      errorMessage = form.error(key).map(e => messages(s"${e.key}.$userErrorKey${e.message}", e.args *) )
     )
 
     <p class="govuk-body">@Html(messages(s"$key$userKey.link", viewConfig.workOurYouResidenceStatusUrl))</p>

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/previous_return_exists_with_same_completion_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/previous_return_exists_with_same_completion_date.scala.html
@@ -30,7 +30,7 @@
 )
 
 
-@(previousReturn: ReturnSummary, backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages)
+@(previousReturn: ReturnSummary, backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"previousReturnExistsWithSameCompletionDate"}
 @title = @{ messages(s"$key.title") }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/previous_return_exists_with_same_completion_date_amend.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/previous_return_exists_with_same_completion_date_amend.scala.html
@@ -24,7 +24,7 @@
         layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout
 )
 
-@(backLink: Call)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+@(backLink: Call)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{"previousReturnExistsWithSameCompletionDate.amend"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/self_assessment_already_submitted.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/self_assessment_already_submitted.scala.html
@@ -32,7 +32,7 @@
     isATrust: Boolean,
     taxYearStart: Int,
     representativeType: Option[RepresentativeType]
-)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages: Messages, viewConfig: ViewConfig)
 
 @key = @{"selfAssessmentAlreadySubmitted"}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/asset_type_for_non_uk_residents.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/asset_type_for_non_uk_residents.scala.html
@@ -41,7 +41,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"assetTypeForNonUkResidents"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/check_your_answers.scala.html
@@ -36,7 +36,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     representeeAnswers: Option[RepresenteeAnswers]
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @title = @{messages("triage.check-your-answers.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/completion_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/completion_date.scala.html
@@ -43,7 +43,7 @@
   isATrust: Boolean,
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, viewConfig: ViewConfig)
 
 @key = @{"completionDate"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/country_of_residence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/country_of_residence.scala.html
@@ -46,7 +46,7 @@
     representativeType: Option[RepresentativeType],
     representeeAnswers: Option[RepresenteeAnswers],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, appConfig: ViewConfig)
 
 @messageKey = @{"triage.enterCountry"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/did_you_dispose_of_residential_property.scala.html
@@ -42,7 +42,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"didYouDisposeOfResidentialProperty"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date.scala.html
@@ -44,7 +44,7 @@
   isATrust: Boolean,
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, viewConfig: ViewConfig)
 
 @key = @{"disposalDate"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date_of_shares.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/disposal_date_of_shares.scala.html
@@ -31,7 +31,7 @@
    returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
 
-@(form: Form[ShareDisposalDate], backLink: Call, displayReturnToSummaryLink: Boolean, submit: Call, isAmend: Boolean)(implicit request:RequestWithSessionData[_], messages: Messages)
+@(form: Form[ShareDisposalDate], backLink: Call, displayReturnToSummaryLink: Boolean, submit: Call, isAmend: Boolean)(implicit request:RequestWithSessionData[?], messages: Messages)
 
 @key = @{ "sharesDisposalDate" }
 @hasErrors = @{form.hasErrors || form.hasGlobalErrors}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/have_you_already_sent_self_assesment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/have_you_already_sent_self_assesment.scala.html
@@ -40,7 +40,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     taxYearStartYear: Int
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{"alreadySentSelfAssessment"}
 @isAgent = @{ request.userType.contains(UserType.Agent) }
@@ -86,7 +86,7 @@
             errorKey = form.error(key).map(e => s"$userErrorKey${e.message}"),
             selected = form.value,
             helpText = None,
-            errorMessage = form.error(key).map(e => messages(s"${e.key}.$userErrorKey${e.message}", e.args:_*) )
+            errorMessage = form.error(key).map(e => messages(s"${e.key}.$userErrorKey${e.message}", e.args *) )
         )
 
         @submitButton(messages(if (hasCreatedDraftReturn) "button.saveAndContinue" else "button.continue"))

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/how_did_you_dispose.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/how_did_you_dispose.scala.html
@@ -40,7 +40,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/summary_govuk.scala.html
@@ -35,7 +35,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     representeeAnswers: Option[RepresenteeAnswers]
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/were_you_a_uk_resident.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/singledisposals/were_you_a_uk_resident.scala.html
@@ -43,7 +43,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, viewConfig: ViewConfig)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 @key = @{"wereYouAUKResident"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/uk_resident_can_only_dispose_residential.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/uk_resident_can_only_dispose_residential.scala.html
@@ -29,7 +29,7 @@
 
 @(backLink: Call,
         isATrust: Boolean,
-representativeType: Option[RepresentativeType])(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+representativeType: Option[RepresentativeType])(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 
 @key = @{"ukResidentCanOnlyReportResidential"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/who_are_you_reporting_for.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/triage/who_are_you_reporting_for.scala.html
@@ -36,7 +36,7 @@
 )
 
 
-@(form: Form[IndividualUserType], backLink: Option[Call], displayReturnToSummaryLink: Boolean, isAmend: Boolean)(implicit request: RequestWithSessionData[_], messages:Messages)
+@(form: Form[IndividualUserType], backLink: Option[Call], displayReturnToSummaryLink: Boolean, isAmend: Boolean)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 @key = @{"individualUserType"}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/view_return.scala.html
@@ -49,7 +49,7 @@
     representativeType: Option[RepresentativeType],
     isIndirectDisposal: Boolean,
     returnType: ReturnType
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @title = @{messages("viewReturn.title")}
 @amountOwed = @{returnSummary.mainReturnChargeAmount}
@@ -113,14 +113,14 @@ if(completeReturn.isIndirectDisposal) messages(s"$key.companyAddress")
             None,
             "date-sent-table"
         )
-        @{if(amountOwed.isPositive) {
-            cyaRow(
+        @if(amountOwed.isPositive) {
+            @cyaRow(
                 messages(s"$key.returnReference"),
                 Html(returnSummary.submissionId),
                 None,
                 "return-reference-table"
             )
-        }}
+        }
         @cyaRow(
             propertyAddressLabel,
             completeReturn match {

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_check_your_answers.scala.html
@@ -37,7 +37,7 @@
         representativeType: Option[RepresentativeType],
         wasUkResident: Boolean,
         hideEstimatesQuestion: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 
 @title = @{messages("ytdLiability.cya.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/calculated_summary_govuk.scala.html
@@ -38,7 +38,7 @@
     representativeType: Option[RepresentativeType],
     wasUkResident: Boolean,
     hideEstimatesQuestion: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @taxYearStartYear = @{taxYear.startDateInclusive.getYear.toString}
 @taxYearEndYear = @{taxYear.endDateExclusive.getYear.toString}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/estimated_income.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/estimated_income.scala.html
@@ -44,7 +44,7 @@
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages:Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/expired_mandatory_evidence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/expired_mandatory_evidence.scala.html
@@ -27,7 +27,7 @@
         caption: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.caption_govuk
 )
 
-@(expired : MandatoryEvidence, isFurtherOrAmendReturn: Option[Boolean])(implicit request: RequestWithSessionData[_], messages: Messages)
+@(expired : MandatoryEvidence, isFurtherOrAmendReturn: Option[Boolean])(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{ "mandatoryEvidenceExpired" }
 @title = @{ messages(s"$key.title") }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_check_tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_check_tax_due.scala.html
@@ -38,7 +38,7 @@
     previousYearToDateLiability: AmountInPence,
     taxOwedOnOriginalReturn: Option[AmountInPence],
     isATrust: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "nonCalculatedTaxDue" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_enter_tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_enter_tax_due.scala.html
@@ -42,7 +42,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     isAmendReturn: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "nonCalculatedTaxDue" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_taxable_gain_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_taxable_gain_guidance.scala.html
@@ -34,7 +34,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     taxYear: Option[TaxYear]
-)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{ "taxableGainOrLossGuidance" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_taxable_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/further_return_taxable_gain_or_loss.scala.html
@@ -52,7 +52,7 @@
         taxYear: TaxYear,
         isAmend: Boolean,
         taxableGainOrLossCalculation: Option[(TaxableGainOrLossCalculation, CompleteExemptionAndLossesAnswers)]
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 @key = @{ "taxableGainOrLoss" }
 @gainKey = @{ "taxableGain" }
 @lossKey = @{ "netLoss" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/has_estimated_details.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/has_estimated_details.scala.html
@@ -38,7 +38,7 @@
   isFurtherOrAmendReturn: Option[Boolean],
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages: Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/mandatory_evidence_scan_progress.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/mandatory_evidence_scan_progress.scala.html
@@ -27,7 +27,7 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
 
-@(isFurtherOrAmendReturn: Option[Boolean])(implicit request: RequestWithSessionData[_], messages: Messages)
+@(isFurtherOrAmendReturn: Option[Boolean])(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @key = @{"mandatoryEvidence.scan-progress"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_check_your_answers.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_check_your_answers.scala.html
@@ -40,7 +40,7 @@
     taxYear: TaxYear,
     hideEstimatesQuestion: Boolean,
         wasUkResident: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @title = @{messages("ytdLiability.cya.title")}
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_enter_tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_enter_tax_due.scala.html
@@ -43,7 +43,7 @@
         isATrust: Boolean,
         wasUkResident: Boolean,
         isMultiple: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages: Messages, viewConfig: ViewConfig)
 
 @key = @{
     "nonCalculatedTaxDue"

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_summary_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/non_calculated_summary_govuk.scala.html
@@ -42,7 +42,7 @@
     taxYear: TaxYear,
     hideEstimatesQuestion: Boolean,
         wasUkResident: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @isAgent = @{ request.userType.contains(UserType.Agent) }
 @userKey = @{

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/tax_owed_workings.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/tax_owed_workings.scala.html
@@ -32,7 +32,7 @@
     taxYear: TaxYear,
     isATrust: Boolean,
     isPeriodOfAdmin: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @taxableIncome = @{ calculatedTax match {
   case _: CalculatedTaxDue.NonGainCalculatedTaxDue => None

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/year_to_date_liability_workings_govuk.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/partials/year_to_date_liability_workings_govuk.scala.html
@@ -30,7 +30,7 @@
     taxYear: TaxYear,
     isATrust: Boolean,
     isPeriodOfAdmin: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages)
+)(implicit request: RequestWithSessionData[?], messages: Messages)
 
 @taxableIncome = @{ yearToDateLiabilityCalculation.taxableIncome }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/personal_allowance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/personal_allowance.scala.html
@@ -45,7 +45,7 @@
     wasUkResident: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages:Messages, viewConfig: ViewConfig)
 
 @key = @{ "personalAllowance" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/repayment.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/repayment.scala.html
@@ -41,7 +41,7 @@
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
 )(
-  implicit request: RequestWithSessionData[_],
+  implicit request: RequestWithSessionData[?],
   messages: Messages
 )
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/tax_due.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/tax_due.scala.html
@@ -62,7 +62,7 @@
   isATrust: Boolean,
   representativeType: Option[RepresentativeType],
   isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages: Messages, viewConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages: Messages, viewConfig: ViewConfig)
 
 @key = @{ "taxDue" }
 @agreeKey = @{ "agreeWithCalculation" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/taxable_gain_or_loss.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/taxable_gain_or_loss.scala.html
@@ -45,7 +45,7 @@
     isMultiple: Boolean,
     representativeType: Option[RepresentativeType],
     isAmend: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "taxableGainOrLoss" }
 @gainKey = @{ "taxableGain" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence.scala.html
@@ -36,7 +36,7 @@
     isAmend: Boolean,
     isMultipleDisposal: Boolean,
     isRepaymentDue: Boolean
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
     @key = @{ "mandatoryEvidence" }
     @fieldId = @{ "file" }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence_failed.scala.html
@@ -26,7 +26,7 @@
         formWrapper: FormWithCSRF
 )
 
-@()(implicit request:RequestWithSessionData[_], messages:Messages)
+@()(implicit request:RequestWithSessionData[?], messages:Messages)
 
 @key = @{"mandatoryEvidence.failed"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence_scan_failed.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/upload_mandatory_evidence_scan_failed.scala.html
@@ -26,7 +26,7 @@
         returnToSummaryLink: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.return_to_summary_link_govuk
 )
 
-@()(implicit request:RequestWithSessionData[_], messages:Messages)
+@()(implicit request:RequestWithSessionData[?], messages:Messages)
 
 @key = @{"mandatoryEvidence.scan-failed"}
 @title = @{messages(s"$key.title")}

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/year_to_date_liability.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/year_to_date_liability.scala.html
@@ -47,7 +47,7 @@
     representativeType: Option[RepresentativeType],
     isAmend: Boolean,
     yearToDateLiabilityCalculation: Option[YearToDateLiabilityCalculation]
-)(implicit request: RequestWithSessionData[_], messages:Messages)
+)(implicit request: RequestWithSessionData[?], messages:Messages)
 
 @key = @{ "yearToDateLiability" }
 @isAgent = @{ request.userType.contains(UserType.Agent) }
@@ -144,7 +144,7 @@
         )),
         errorMessage = form.error(key).map(e =>
         ErrorMessage(
-          content = Text(messages(s"${customErrorKey.getOrElse(key)}.${e.message}", e.args: _*)),
+          content = Text(messages(s"${customErrorKey.getOrElse(key)}.${e.message}", e.args *)),
           visuallyHiddenText = Some(messages("generic.error"))
         )),
         autocomplete = Some(AutoCompleteType.On.value)
@@ -167,7 +167,7 @@
         )),
         errorMessage = form.error(key).map(e =>
         ErrorMessage(
-        content = Text(messages(s"${customErrorKey.getOrElse(key)}.${e.message}", e.args: _*)),
+        content = Text(messages(s"${customErrorKey.getOrElse(key)}.${e.message}", e.args *)),
         visuallyHiddenText = Some(messages("generic.error"))
         )),
         autocomplete = Some(AutoCompleteType.On.value)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/year_to_date_liability_guidance.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/returns/ytdliability/year_to_date_liability_guidance.scala.html
@@ -34,7 +34,7 @@
     isATrust: Boolean,
     representativeType: Option[RepresentativeType],
     taxYear: Option[TaxYear]
-)(implicit request: RequestWithSessionData[_], messages: Messages, appConfig: ViewConfig)
+)(implicit request: RequestWithSessionData[?], messages: Messages, appConfig: ViewConfig)
 
 @key = @{ "yearToDateLiabilityGuidance" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/testonly/set_return_state.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/testonly/set_return_state.scala.html
@@ -30,7 +30,7 @@
   submitButton: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.components.submit_button_govuk,
 )
 
-@(form: Form[Answers])(implicit request:Request[_], messages:Messages)
+@(form: Form[Answers])(implicit request:Request[?], messages:Messages)
 
 @title = @{ "Set journey status" }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/timed_out.scala.html
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/views/timed_out.scala.html
@@ -22,7 +22,7 @@
 
 @this(layout: uk.gov.hmrc.cgtpropertydisposalsfrontend.views.html.Layout, viewHelpers: ViewHelpers)
 
-@()(implicit messages:Messages, request: Request[_])
+@()(implicit messages:Messages, request: Request[?])
 
 @title = @{messages("timed-out.title")}
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val microservice = Project("cgt-property-disposals-frontend", file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
-    scalaVersion := "2.13.16",
+    scalaVersion := "3.6.4",
     majorVersion := 2,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test(),
     onLoadMessage := "",
@@ -18,11 +18,15 @@ lazy val microservice = Project("cgt-property-disposals-frontend", file("."))
     Test / testOptions += Tests.Argument(
       TestFrameworks.ScalaTest,
       "-oNCHPQR",
-      "-u", "target/test-reports",
-      "-h", "target/test-reports/html-report"),
-    scalacOptions ++= "-Wconf:src=routes/.*:s" :: "-Wconf:cat=unused-imports&src=html/.*:s"
-                      :: "-Ymacro-annotations" :: "-Xlint:-byname-implicit" :: Nil,
+      "-u",
+      "target/test-reports",
+      "-h",
+      "target/test-reports/html-report"
+    ),
+    scalacOptions ++= Seq(
+      "-Wconf:src=routes/.*:s",
+      "-Wconf:msg=unused import&src=html/.*:s",
+      "-source:3.5"
+    )
   )
   .settings(CodeCoverageSettings.settings *)
-
-libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,26 +2,27 @@ import sbt.*
 
 object AppDependencies {
   val playVersion      = "play-30"
-  val bootstrapVersion = "9.11.0"
+  val bootstrapVersion = "9.12.0"
   val mongoVersion     = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"                %% s"play-frontend-hmrc-$playVersion" % "8.5.0",
-    "uk.gov.hmrc"                %% s"bootstrap-frontend-$playVersion" % bootstrapVersion,
-    "uk.gov.hmrc.mongo"          %% s"hmrc-mongo-$playVersion"         % mongoVersion,
-    "uk.gov.hmrc"                %% s"domain-$playVersion"             % "10.0.0",
-    "org.typelevel"              %% "cats-core"                        % "2.12.0",
-    "org.julienrf"               %% "play-json-derived-codecs"         % "11.0.0",
-    "com.github.julien-truffaut" %% "monocle-core"                     % "2.1.0",
-    "com.github.julien-truffaut" %% "monocle-macro"                    % "2.1.0"
+    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion" % "12.1.0",
+    "uk.gov.hmrc"       %% s"bootstrap-frontend-$playVersion" % bootstrapVersion,
+    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"         % mongoVersion,
+    "uk.gov.hmrc"       %% s"domain-$playVersion"             % "10.0.0",
+    "org.typelevel"     %% "cats-core"                        % "2.12.0",
+    "dev.optics"        %% "monocle-core"                     % "3.1.0",
+    "dev.optics"        %% "monocle-macro"                    % "3.1.0"
   )
 
   def test(scope: String = "test"): Seq[ModuleID] = Seq(
-    "org.jsoup"                   % "jsoup"                         % "1.18.3"         % scope,
-    "org.scalamock"              %% "scalamock"                     % "5.2.0"          % scope,
-    "org.scalatestplus"          %% "scalacheck-1-18"               % "3.2.19.0"       % scope,
-    "uk.gov.hmrc.mongo"          %% s"hmrc-mongo-test-$playVersion" % mongoVersion     % scope,
-    "com.github.alexarchambault" %% "scalacheck-shapeless_1.16"     % "1.3.1"          % scope,
-    "uk.gov.hmrc"                %% s"bootstrap-test-$playVersion"  % bootstrapVersion % scope
+    "org.jsoup"           % "jsoup"                         % "1.19.1"         % scope,
+    "org.scalamock"      %% "scalamock"                     % "6.0.0"          % scope,
+    "org.scalatest"      %% "scalatest"                     % "3.2.19"         % scope,
+    "org.scalacheck"     %% "scalacheck"                    % "1.18.1"         % scope,
+    "io.github.martinhh" %% "scalacheck-derived"            % "0.8.2"          % scope,
+    "org.scalatestplus"   % "scalacheck-1-18_3"             % "3.2.19.0"       % scope,
+    "uk.gov.hmrc.mongo"  %% s"hmrc-mongo-test-$playVersion" % mongoVersion     % scope,
+    "uk.gov.hmrc"        %% s"bootstrap-test-$playVersion"  % bootstrapVersion % scope exclude ("org.playframework", "play-json_2.13")
   )
 }

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -6,7 +6,7 @@ object CodeCoverageSettings {
   private val excludedPackages: Seq[String] = Seq(
     "<empty>",
     ".*Reverse.*",
-    ".*(config|testonly|views).*",
+    ".*(config|testonly|views|models).*",
     ".*(BuildInfo|Routes).*"
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,10 +4,10 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       %% "sbt-auto-build"        % "3.24.0")
-addSbtPlugin("uk.gov.hmrc"       %% "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework" %% "sbt-plugin"            % "3.0.6")
-addSbtPlugin("org.scalameta"     %% "sbt-scalafmt"          % "2.4.0")
-addSbtPlugin("org.scoverage"     %% "sbt-scoverage"         % "2.3.0")
+addSbtPlugin("uk.gov.hmrc"       %% "sbt-auto-build"     % "3.24.0")
+addSbtPlugin("uk.gov.hmrc"       %% "sbt-distributables" % "2.6.0")
+addSbtPlugin("org.playframework" %% "sbt-plugin"         % "3.0.7")
+addSbtPlugin("org.scalameta"     %% "sbt-scalafmt"       % "2.5.4")
+addSbtPlugin("org.scoverage"     %% "sbt-scoverage"      % "2.3.1")
 
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/AddressLookupConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/AddressLookupConnectorSpec.scala
@@ -73,7 +73,7 @@ class AddressLookupConnectorSpec extends AnyWordSpec with Matchers with Connecto
           town = "town",
           county = Some("county"),
           postcode = "ABC 123"
-        ) pipe (List(_)) pipe AddressLookupResponse pipe (Right(_)))
+        ) pipe (List(_)) pipe AddressLookupResponse.apply pipe (Right(_)))
     }
 
     "Return error if Reject if JSON is missing fields" in {

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/onboarding/CGTPropertyDisposalsConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/onboarding/CGTPropertyDisposalsConnectorImplSpec.scala
@@ -27,10 +27,10 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TelephoneNumber
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Postcode
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.Email
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.CgtReference
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{ContactName, IndividualName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.BusinessPartnerRecordRequest

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/returns/ReturnsConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/returns/ReturnsConnectorImplSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.returns
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Tables.Table
@@ -26,15 +26,15 @@ import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.returns.ReturnsConnector.DeleteDraftReturnsRequest
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.Error
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.draftReturnGen
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen.{taxableGainOrLossCalculationGen, taxableGainOrLossCalculationRequestGen, yearToDateLiabilityCalculationGen, yearToDateLiabilityCalculationRequestGen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen.{calculateCgtTaxDueRequestGen, listReturnsResponseGen, submitReturnRequestGen, submitReturnResponseGen}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.taxYearGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen.calculatedTaxDueGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.CgtReference
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsServiceImpl.{GetDraftReturnResponse, ListReturnsResponse}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.TaxYearServiceImpl.{AvailableTaxYearsResponse, TaxYearResponse, taxYearResponseFormat}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.util.ConnectorSupport
@@ -232,7 +232,7 @@ class ReturnsConnectorImplSpec extends AnyWordSpec with Matchers with ConnectorS
 
           result shouldBe
             Left(Error(s"GET to http://localhost:$wireMockPort/returns/CGT12345678/${date.format(dateFormatter)}/${date
-              .format(dateFormatter)} came back with with status $status"))
+                .format(dateFormatter)} came back with with status $status"))
         }
       }
     }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/upscan/UpscanConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/upscan/UpscanConnectorImplSpec.scala
@@ -28,7 +28,7 @@ import play.api.mvc.Call
 import play.api.test.Helpers._
 import play.api.{Application, Configuration}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.Error
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.{UploadReference, UpscanInitiateRequest, UpscanUpload}

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/AddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/AddressControllerSpec.scala
@@ -28,11 +28,11 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.{NonUkAddress, UkAddress}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, AddressLookupResult, Country, Postcode}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.AgentReferenceNumber
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
@@ -85,7 +85,7 @@ trait AddressControllerSpec[A <: AddressJourneyType]
 
   private val postcode = Postcode("AB1 2CD")
 
-  def ukAddress(i: Int): UkAddress                       =
+  def ukAddress(i: Int): UkAddress =
     UkAddress(s"$i the Street", Some("The Town"), None, None, postcode)
 
   private val (_, lastAddress, lastAddressIndex, addresses) = {
@@ -93,7 +93,7 @@ trait AddressControllerSpec[A <: AddressJourneyType]
     val last = ukAddress(5)
     (head, last, 4, head :: ((2 to 4).map(ukAddress).toList ::: List(last)))
   }
-  protected val addressLookupResult: AddressLookupResult = AddressLookupResult(postcode, None, addresses)
+  protected val addressLookupResult: AddressLookupResult    = AddressLookupResult(postcode, None, addresses)
 
   protected lazy val sessionWithValidJourneyStatus: SessionData =
     SessionData.empty.copy(journeyStatus = Some(controller.toJourneyStatus(validJourneyStatus)))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/AuthSupport.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 
 import play.api.Configuration
-import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, EmptyRetrieval, Retrieval, ~}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.EnrolmentConfig._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.EnrolmentConfig.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ErrorHandler
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.actions.AuthenticatedActionWithRetrievedData
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.SAUTR
@@ -31,7 +31,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.{ExecutionContext, Future}
 
 trait AuthSupport {
-  this: ControllerSpec with SessionSupport =>
+  this: ControllerSpec & SessionSupport =>
 
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
@@ -73,14 +73,12 @@ trait AuthSupport {
     retrievedCredentials: Option[Credentials]
   ): Unit =
     mockAuth(EmptyPredicate, expectedRetrievals)(
-      Future successful (
-        new ~(retrievedConfidenceLevel, retrievedAffinityGroup) and
-          retrievedNino and
-          retrievedSautr and
-          retrievedEmail and
-          Enrolments(retrievedEnrolments) and
-          retrievedCredentials
-      )
+      Future successful new ~(retrievedConfidenceLevel, retrievedAffinityGroup)
+        .and(retrievedNino)
+        .and(retrievedSautr)
+        .and(retrievedEmail)
+        .and(Enrolments(retrievedEnrolments))
+        .and(retrievedCredentials)
     )
 
   def mockAuthWithCl200AndWithAllIndividualRetrievals(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/BusinessPartnerRecordServiceSupport.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/BusinessPartnerRecordServiceSupport.scala
@@ -26,14 +26,14 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.Future
 
 trait BusinessPartnerRecordServiceSupport {
-  this: ControllerSpec with SessionSupport =>
+  this: ControllerSpec & SessionSupport =>
 
   private val mockBusinessPartnerRecordService = mock[BusinessPartnerRecordService]
   def mockGetBusinessPartnerRecord(
     businessPartnerRecordRequest: BusinessPartnerRecordRequest,
     expectedBusinessPartnerRecordResponse: Either[Error, BusinessPartnerRecordResponse],
     lang: Lang
-  ): Unit                                      =
+  ): Unit =
     (mockBusinessPartnerRecordService
       .getBusinessPartnerRecord(_: BusinessPartnerRecordRequest, _: Lang)(
         _: HeaderCarrier

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/ContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/ContactNameControllerSpec.scala
@@ -36,7 +36,7 @@ import scala.concurrent.Future
 trait ContactNameControllerSpec[J <: JourneyStatus]
     extends ContactNameFormValidationTests
     with RedirectToStartBehaviour {
-  this: ControllerSpec with AuthSupport with SessionSupport with ScalaCheckDrivenPropertyChecks =>
+  this: ControllerSpec & AuthSupport & SessionSupport & ScalaCheckDrivenPropertyChecks =>
 
   val controller: ContactNameController[J]
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/EmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/EmailControllerSpec.scala
@@ -52,7 +52,7 @@ trait EmailControllerSpec[JourneyType <: EmailJourneyType] extends ControllerSpe
 
   protected val mockUpdateEmail: Option[(JourneyType, JourneyType, Either[Error, Unit]) => Unit]
 
-  protected val controller: EmailController[JourneyType]
+  protected lazy val controller: EmailController[JourneyType]
 
   protected implicit val messagesApi: MessagesApi
 
@@ -80,7 +80,7 @@ trait EmailControllerSpec[JourneyType <: EmailJourneyType] extends ControllerSpe
       .returning(EitherT.fromEither[Future](result))
 
   private def mockUuidGenerator(uuid: UUID): CallHandler0[UUID] =
-    (mockUuidGenerator.nextId _: () => UUID).expects().returning(uuid)
+    (() => mockUuidGenerator.nextId()).expects().returning(uuid)
 
   private lazy val sessionDataWithValidJourneyStatus =
     SessionData.empty

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/AccountControllerSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, Contro
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.SessionData
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeAddressControllerSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.ggCredIdGen
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.{SubscribedDetails, SubscribedUpdateDetails}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, UserType}
@@ -45,6 +45,8 @@ class SubscribedChangeAddressControllerSpec
     with ScalaCheckDrivenPropertyChecks
     with RedirectToStartBehaviour {
 
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
   val subscribedDetails: SubscribedDetails =
     sample[SubscribedDetails].copy(address = ukAddress(1))
 
@@ -58,7 +60,7 @@ class SubscribedChangeAddressControllerSpec
     )
   )
 
-  protected override lazy val controller: SubscribedChangeAddressController =
+  protected override val controller: SubscribedChangeAddressController =
     instanceOf[SubscribedChangeAddressController]
 
   lazy implicit val messagesApi: MessagesApi = controller.messagesApi
@@ -114,7 +116,7 @@ class SubscribedChangeAddressControllerSpec
     "handling requests to submit the is UK page" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.isUkSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -145,7 +147,7 @@ class SubscribedChangeAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -171,7 +173,7 @@ class SubscribedChangeAddressControllerSpec
     "handling requests to submit the enter non UK address page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterNonUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -200,7 +202,7 @@ class SubscribedChangeAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -242,7 +244,7 @@ class SubscribedChangeAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.selectAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeContactNameControllerSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ContactNameControllerSpec, ControllerSpec, SessionSupport}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.ContactName
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedUpdateDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus}
@@ -57,7 +57,7 @@ class SubscribedChangeContactNameControllerSpec
 
   override val validJourney: Subscribed = sample[Subscribed]
 
-  override val mockUpdateContactName: Option[(Subscribed, Subscribed, Either[Error, Unit]) => Unit] = Some({
+  override val mockUpdateContactName: Option[(Subscribed, Subscribed, Either[Error, Unit]) => Unit] = Some {
     case (
           oldDetails: Subscribed,
           newDetails: Subscribed,
@@ -69,7 +69,7 @@ class SubscribedChangeContactNameControllerSpec
           oldDetails.subscribedDetails
         )
       )(r)
-  })
+  }
 
   override def updateContactName(
     journey: Subscribed,
@@ -93,7 +93,7 @@ class SubscribedChangeContactNameControllerSpec
       behave like enterContactNameSubmit(
         data =>
           controller.enterContactNameSubmit()(
-            FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+            FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
           ),
         controllers.accounts.routes.AccountController.contactNameUpdated()
       )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedChangeEmailControllerSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.Email
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailJourneyType.ManagingSubscription.ChangingAccountEmail
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.UUIDGenerator
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedUpdateDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus}
@@ -45,6 +45,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+
 class SubscribedChangeEmailControllerSpec
     extends EmailControllerSpec[ChangingAccountEmail]
     with ScalaCheckDrivenPropertyChecks
@@ -61,8 +62,7 @@ class SubscribedChangeEmailControllerSpec
   override val validVerificationCompleteJourneyStatus: ChangingAccountEmail =
     validJourneyStatus
 
-  override lazy val controller: SubscribedChangeEmailController =
-    instanceOf[SubscribedChangeEmailController]
+  override lazy val controller: SubscribedChangeEmailController = instanceOf[SubscribedChangeEmailController]
 
   override val overrideBindings: List[GuiceableModule] =
     List[GuiceableModule](
@@ -92,7 +92,7 @@ class SubscribedChangeEmailControllerSpec
   }
 
   override val mockUpdateEmail: Option[(ChangingAccountEmail, ChangingAccountEmail, Either[Error, Unit]) => Unit] =
-    Some({
+    Some {
       case (
             oldDetails: ChangingAccountEmail,
             newDetails: ChangingAccountEmail,
@@ -104,9 +104,9 @@ class SubscribedChangeEmailControllerSpec
             oldDetails.journey.subscribedDetails
           )
         )(r)
-    })
+    }
 
-  implicit lazy val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messagesApi: MessagesApi = controller.messagesApi
 
   def redirectToStartBehaviour(performAction: () => Future[Result]): Unit =
     redirectToStartWhenInvalidJourney(
@@ -133,7 +133,7 @@ class SubscribedChangeEmailControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.enterEmailSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -149,8 +149,7 @@ class SubscribedChangeEmailControllerSpec
 
     "handling requests to display the check your inbox page" must {
 
-      def performAction(): Future[Result] =
-        controller.checkYourInbox()(FakeRequest())
+      def performAction(): Future[Result] = controller.checkYourInbox()(FakeRequest())
 
       behave like redirectToStartBehaviour(() => performAction())
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedWithoutIdChangeContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/SubscribedWithoutIdChangeContactNameControllerSpec.scala
@@ -59,10 +59,10 @@ class SubscribedWithoutIdChangeContactNameControllerSpec
       case _             => false
     }
 
-  override lazy val controller: SubscribedWithoutIdChangeContactNameController =
+  override val controller: SubscribedWithoutIdChangeContactNameController =
     instanceOf[SubscribedWithoutIdChangeContactNameController]
 
-  override lazy val validJourney: Subscribed = Subscribed(
+  override val validJourney: Subscribed = Subscribed(
     SubscribedDetails(
       Right(IndividualName("Joe", "Smith")),
       Email("joe.smith@gmail.com"),
@@ -89,7 +89,7 @@ class SubscribedWithoutIdChangeContactNameControllerSpec
     )
   }
 
-  override val mockUpdateName: Option[(Subscribed, Subscribed, Either[Error, Unit]) => Unit] = Some({
+  override val mockUpdateName: Option[(Subscribed, Subscribed, Either[Error, Unit]) => Unit] = Some {
     case (
           oldDetails: Subscribed,
           newDetails: Subscribed,
@@ -101,7 +101,7 @@ class SubscribedWithoutIdChangeContactNameControllerSpec
           oldDetails.subscribedDetails
         )
       )(r)
-  })
+  }
 
   implicit lazy val messagesApi: MessagesApi = controller.messagesApi
 
@@ -118,7 +118,7 @@ class SubscribedWithoutIdChangeContactNameControllerSpec
       behave like enterNameSubmit(
         data =>
           controller.enterIndividualNameSubmit()(
-            FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+            FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
           ),
         controllers.accounts.routes.AccountController.contactNameUpdated()
       )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/accounts/homepage/HomePageControllerSpec.scala
@@ -38,16 +38,17 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.MoneyUtils.format
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.taxYearGen
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
@@ -60,7 +61,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTri
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.CalculatedYTDAnswers.CompleteCalculatedYTDAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.CompleteNonCalculatedYTDAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus, SessionData, TaxYear, UserType, Returns => ReturnsJourneyType}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus, Returns => ReturnsJourneyType, SessionData, TaxYear, UserType}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.{PaymentsService, ReturnsService}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -156,7 +157,7 @@ class HomePageControllerSpec
           _: Call
         )(
           _: HeaderCarrier,
-          _: Request[_]
+          _: Request[?]
         )
       )
       .expects(cgtReference, chargeReference, amount, dueDate, returnUrl, backUrl, *, *)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/AuthenticatedActionSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/AuthenticatedActionSpec.scala
@@ -46,7 +46,7 @@ class AuthenticatedActionSpec extends ControllerSpec with MockFactory with Sessi
     val request = new MessagesRequest[A](r, stub[MessagesApi])
     authenticatedAction.invokeBlock(
       request,
-      { a: AuthenticatedRequest[A] =>
+      { (a: AuthenticatedRequest[A]) =>
         a.request.messagesApi shouldBe request.messagesApi
         Future.successful(Ok)
       }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SessionDataActionSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SessionDataActionSpec.scala
@@ -46,7 +46,7 @@ class SessionDataActionSpec extends ControllerSpec with SessionSupport {
     def performAction(): Future[Result] =
       action.invokeBlock(
         authenticatedRequest,
-        { r: RequestWithSessionData[_] =>
+        { (r: RequestWithSessionData[?]) =>
           r.sessionData shouldBe Some(sessionData)
           r.messagesApi shouldBe messagesRequest.messagesApi
           Future.successful(Ok)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SessionDataActionWithRetrievedDataSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SessionDataActionWithRetrievedDataSpec.scala
@@ -64,7 +64,7 @@ class SessionDataActionWithRetrievedDataSpec extends ControllerSpec with Session
     def performAction(): Future[Result] =
       action.invokeBlock(
         authenticatedRequest,
-        { r: RequestWithSessionDataAndRetrievedData[_] =>
+        { (r: RequestWithSessionDataAndRetrievedData[?]) =>
           r.messagesApi shouldBe messagesRequest.messagesApi
           r.sessionData shouldBe sessionData.copy(userType = Some(Individual))
           Future.successful(Ok)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SubscriptionReadyActionSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/actions/SubscriptionReadyActionSpec.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscriptio
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SessionDataGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionDetails
@@ -58,7 +58,7 @@ class SubscriptionReadyActionSpec extends ControllerSpec with SessionSupport {
 
       action.invokeBlock(
         authenticatedRequest,
-        { r: RequestWithSubscriptionReady[_] =>
+        { (r: RequestWithSubscriptionReady[?]) =>
           r.sessionData       shouldBe sessionData
           r.subscriptionReady shouldBe SubscriptionReady(
             subscriptionDetails,

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/agents/AgentAccessControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/agents/AgentAccessControllerSpec.scala
@@ -38,12 +38,12 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscribed
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.{NonUkAddress, UkAddress}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Country, Postcode}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.agents.UnsuccessfulVerifierAttempts
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, CgtReference, GGCredId}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{DraftSingleDisposalReturn, ReturnSummary}
@@ -259,7 +259,7 @@ class AgentAccessControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterClientsCgtRefSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -349,7 +349,7 @@ class AgentAccessControllerSpec
         "the cgt reference is valid and the agent has permission to access the client " +
           "but the session data cannot be updated" in {
             val clientDetails =
-              newClientDetails(validCgtReference, sample[Address](addressGen))
+              newClientDetails(validCgtReference, sample[Address])
 
             inSequence {
               mockAuthWithNoRetrievals()
@@ -614,7 +614,7 @@ class AgentAccessControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterClientsPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -998,7 +998,7 @@ class AgentAccessControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterClientsCountrySubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -1038,7 +1038,7 @@ class AgentAccessControllerSpec
             )
           }
 
-          val result = performAction(formData: _*)
+          val result = performAction(formData*)
           status(result) shouldBe BAD_REQUEST
           val content = contentAsString(result)
           content should include(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/InsufficientConfidenceLevelControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/InsufficientConfidenceLevelControllerSpec.scala
@@ -34,11 +34,11 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscriptio
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AlreadySubscribedWithDifferentGGAccount, NewEnrolmentCreatedForMissingEnrolment}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UnsuccessfulNameMatchAttempts.NameMatchDetails.IndividualSautrNameMatchDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameMatchGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameMatchGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{CgtReference, GGCredId, SAUTR}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
@@ -85,10 +85,10 @@ class InsufficientConfidenceLevelControllerSpec
       mockBprNameMatchService
         .getNumberOfUnsuccessfulAttempts[IndividualSautrNameMatchDetails](
           _: GGCredId
-        )(
+        )(using
           _: Reads[IndividualSautrNameMatchDetails],
           _: HeaderCarrier,
-          _: Request[_]
+          _: Request[?]
         )
       )
       .expects(ggCredId, *, *, *)
@@ -114,7 +114,7 @@ class InsufficientConfidenceLevelControllerSpec
           _: Lang
         )(
           _: HeaderCarrier,
-          _: Request[_]
+          _: Request[?]
         )
       )
       .expects(
@@ -204,7 +204,7 @@ class InsufficientConfidenceLevelControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.doYouHaveNINOSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like commonBehaviour(() => performAction())
@@ -502,7 +502,7 @@ class InsufficientConfidenceLevelControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.doYouHaveSaUtrSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like commonBehaviour(() => performAction())
@@ -820,13 +820,13 @@ class InsufficientConfidenceLevelControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterSautrAndNameSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like commonBehaviour(() => performAction())
 
       behave like nameFormValidationTests(
-        data => performAction(data :+ ("saUtr" -> validSautr.value): _*),
+        data => performAction(data :+ ("saUtr" -> validSautr.value)*),
         () =>
           inSequence {
             mockAuthWithNoRetrievals()

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RedirectToStartBehaviour.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RedirectToStartBehaviour.scala
@@ -32,7 +32,7 @@ import java.util.UUID
 import scala.concurrent.Future
 
 trait RedirectToStartBehaviour {
-  this: ControllerSpec with AuthSupport with SessionSupport with ScalaCheckDrivenPropertyChecks =>
+  this: ControllerSpec & AuthSupport & SessionSupport & ScalaCheckDrivenPropertyChecks =>
 
   def redirectToStartWhenInvalidJourney(
     performAction: () => Future[Result],
@@ -55,7 +55,7 @@ trait RedirectToStartBehaviour {
         implicit val journeyStatusArb: Arbitrary[JourneyStatus] =
           arb(journeyStatusGen)
 
-        forAll { j: JourneyStatus =>
+        forAll { (j: JourneyStatus) =>
           val fixture = j match {
             case f: FillingOutReturn =>
               f.copy(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/RegistrationControllerSpec.scala
@@ -42,7 +42,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.EmailGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{CgtReference, GGCredId, SapNumber}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{ContactName, ContactNameSource, IndividualName}
@@ -171,7 +171,7 @@ class RegistrationControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.selectEntityTypeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       val sessionData =
@@ -665,7 +665,7 @@ class RegistrationControllerSpec
         SessionData.empty.copy(journeyStatus = Some(registrationReady))
       val subscriptionSuccessfulResponse = sample[SubscriptionSuccessful]
       val sapNumber                      = sample[SapNumber]
-      val subscriptionDetails = {
+      val subscriptionDetails            = {
         val details = registrationReady.registrationDetails
         SubscriptionDetails(
           Right(details.name),

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/StartControllerSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding
 
 import cats.data.EitherT
-import cats.instances.future._
+import cats.instances.future.*
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.Configuration
 import play.api.i18n.{Lang, MessagesApi}
@@ -26,35 +26,36 @@ import play.api.inject.guice.GuiceableModule
 import play.api.libs.json.Writes
 import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.ConfidenceLevel.L50
-import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.retrieve.Credentials
-import uk.gov.hmrc.cgtpropertydisposalsfrontend._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.EnrolmentConfig._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.email.{routes => emailRoutes}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.{routes => onboardingRoutes}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.EnrolmentConfig.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.email.routes as emailRoutes
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.routes as onboardingRoutes
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport, StartController, agents}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.{IndividualMissingEmail, RegistrationReady}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AgentStatus, AgentWithoutAgentEnrolment, AlreadySubscribedWithDifferentGGAccount, FillingOutReturn, JustSubmittedReturn, NewEnrolmentCreatedForMissingEnrolment, NonGovernmentGatewayJourney, RegistrationStatus, StartingNewDraftReturn, StartingToAmendReturn, SubmitReturnFailed, SubmittingReturn, Subscribed, SubscriptionStatus, ViewingReturn}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, AddressSource, Postcode}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.{Email, EmailSource}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{ContactName, ContactNameSource, IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.audit.{HandOffTIvEvent, WrongGGAccountEvent}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.BusinessPartnerRecordRequest._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.BusinessPartnerRecordRequest.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.{BusinessPartnerRecord, BusinessPartnerRecordRequest, BusinessPartnerRecordResponse}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.{NeedMoreDetailsDetails, SubscribedDetails, SubscriptionDetails}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.CompleteSingleDisposalReturn
@@ -160,7 +161,7 @@ class StartControllerSpec
         _: ExecutionContext,
         _: HeaderCarrier,
         _: Writes[A],
-        _: Request[_]
+        _: Request[?]
       ))
       .expects(auditType, event, transactionName, *, *, *, *)
       .returning(())
@@ -3345,7 +3346,7 @@ class StartControllerSpec
 
       def performAction(sessionData: Seq[(String, String)]): Future[Result] =
         controller.signOutAndRegisterForGG()(
-          FakeRequest().withSession(sessionData: _*).withMethod("GET")
+          FakeRequest().withSession(sessionData*).withMethod("GET")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -3379,7 +3380,7 @@ class StartControllerSpec
 
       def performAction(sessionData: Seq[(String, String)]): Future[Result] =
         controller.signOutAndSignIn()(
-          FakeRequest().withSession(sessionData: _*).withMethod("GET")
+          FakeRequest().withSession(sessionData*).withMethod("GET")
         )
 
       behave like redirectToStartWhenInvalidJourney(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/SubscriptionControllerSpec.scala
@@ -33,9 +33,9 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{AlreadySub
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{CgtReference, GGCredId}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionResponse.{AlreadySubscribed, SubscriptionSuccessful}

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/RegistrationChangeAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/RegistrationChangeAddressControllerSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.address.{
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.RegistrationReady
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.registrationReadyGen
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, UserType}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.views.address.AddressJourneyType.Onboarding.RegistrationReadyAddressJourney
 
@@ -43,7 +43,7 @@ class RegistrationChangeAddressControllerSpec
     Generators.sample[RegistrationReady]
   )
 
-  protected override lazy val controller: RegistrationChangeAddressController =
+  protected override val controller: RegistrationChangeAddressController =
     instanceOf[RegistrationChangeAddressController]
 
   private lazy implicit val messagesApi: MessagesApi = controller.messagesApi
@@ -78,7 +78,7 @@ class RegistrationChangeAddressControllerSpec
     "handling requests to submit the is UK page" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.isUkSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -108,7 +108,7 @@ class RegistrationChangeAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -134,7 +134,7 @@ class RegistrationChangeAddressControllerSpec
     "handling requests to submit the enter non UK address page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterNonUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -161,7 +161,7 @@ class RegistrationChangeAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -197,7 +197,7 @@ class RegistrationChangeAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.selectAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/RegistrationEnterAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/RegistrationEnterAddressControllerSpec.scala
@@ -56,7 +56,7 @@ class RegistrationEnterAddressControllerSpec
       )
     )
 
-  protected override lazy val controller: RegistrationEnterAddressController =
+  protected override val controller: RegistrationEnterAddressController =
     instanceOf[RegistrationEnterAddressController]
 
   private lazy implicit val messagesApi: MessagesApi = controller.messagesApi
@@ -92,7 +92,7 @@ class RegistrationEnterAddressControllerSpec
     "handling requests to submit the is UK page" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.isUkSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -122,7 +122,7 @@ class RegistrationEnterAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -148,7 +148,7 @@ class RegistrationEnterAddressControllerSpec
     "handling requests to submit the enter non UK address page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterNonUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -175,7 +175,7 @@ class RegistrationEnterAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -213,7 +213,7 @@ class RegistrationEnterAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.selectAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/SubscriptionAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/SubscriptionAddressControllerSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscriptio
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, AddressSource}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, UserType}
@@ -51,7 +51,7 @@ class SubscriptionAddressControllerSpec
     SubscriptionReady(subscriptionDetails, sample[GGCredId])
   )
 
-  protected override lazy val controller: SubscriptionAddressController = instanceOf[SubscriptionAddressController]
+  protected override val controller: SubscriptionAddressController = instanceOf[SubscriptionAddressController]
 
   lazy implicit val messagesApi: MessagesApi = controller.messagesApi
 
@@ -88,7 +88,7 @@ class SubscriptionAddressControllerSpec
     "handling requests to submit the is UK page" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.isUkSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -118,7 +118,7 @@ class SubscriptionAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -144,7 +144,7 @@ class SubscriptionAddressControllerSpec
     "handling requests to submit the enter non UK address page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterNonUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -170,7 +170,7 @@ class SubscriptionAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -212,7 +212,7 @@ class SubscriptionAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.selectAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/SubscriptionEnterAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/address/SubscriptionEnterAddressControllerSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.AddressControllerSpe
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.RedirectToStartBehaviour
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
@@ -49,7 +49,7 @@ class SubscriptionEnterAddressControllerSpec
     None
   )
 
-  protected override lazy val controller: SubscriptionEnterAddressController =
+  protected override val controller: SubscriptionEnterAddressController =
     instanceOf[SubscriptionEnterAddressController]
 
   protected override val validJourneyStatus: SubscriptionEnterAddressJourney = SubscriptionEnterAddressJourney(
@@ -88,7 +88,7 @@ class SubscriptionEnterAddressControllerSpec
     "handling requests to submit the is UK page" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.isUkSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -118,7 +118,7 @@ class SubscriptionEnterAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -141,7 +141,7 @@ class SubscriptionEnterAddressControllerSpec
     "handling requests to submit the enter non UK address page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterNonUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -164,7 +164,7 @@ class SubscriptionEnterAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -206,7 +206,7 @@ class SubscriptionEnterAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.selectAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/RegistrationChangeEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/RegistrationChangeEmailControllerSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Registratio
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailJourneyType.Onboarding.ChangingRegistrationEmail
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.{Email, EmailSource}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.ContactName
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus}
 
@@ -68,10 +68,9 @@ class RegistrationChangeEmailControllerSpec
     : Option[(ChangingRegistrationEmail, ChangingRegistrationEmail, Either[Error, Unit]) => Unit] =
     None
 
-  override lazy val controller: RegistrationChangeEmailController =
-    instanceOf[RegistrationChangeEmailController]
+  override lazy val controller: RegistrationChangeEmailController = instanceOf[RegistrationChangeEmailController]
 
-  implicit lazy val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messagesApi: MessagesApi = controller.messagesApi
 
   def redirectToStartBehaviour(performAction: () => Future[Result]): Unit =
     redirectToStartWhenInvalidJourney(
@@ -98,7 +97,7 @@ class RegistrationChangeEmailControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.enterEmailSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/RegistrationEnterEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/RegistrationEnterEmailControllerSpec.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailJourneyType.On
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.{Email, EmailSource}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.ContactName
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.RegistrationDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus}
@@ -76,10 +77,9 @@ class RegistrationEnterEmailControllerSpec
     : Option[(EnteringRegistrationEmail, EnteringRegistrationEmail, Either[Error, Unit]) => Unit] =
     None
 
-  override lazy val controller: RegistrationEnterEmailController =
-    instanceOf[RegistrationEnterEmailController]
+  override lazy val controller: RegistrationEnterEmailController = instanceOf[RegistrationEnterEmailController]
 
-  implicit lazy val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messagesApi: MessagesApi = controller.messagesApi
 
   def redirectToStartBehaviour(performAction: () => Future[Result]): Unit =
     redirectToStartWhenInvalidJourney(
@@ -106,7 +106,7 @@ class RegistrationEnterEmailControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.enterEmailSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/SubscriptionChangeEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/SubscriptionChangeEmailControllerSpec.scala
@@ -29,8 +29,8 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.Subscriptio
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailJourneyType.Onboarding.ChangingSubscriptionEmail
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.{Email, EmailSource}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 
 import java.util.UUID
 import scala.concurrent.Future
@@ -69,10 +69,9 @@ class SubscriptionChangeEmailControllerSpec
     : Option[(ChangingSubscriptionEmail, ChangingSubscriptionEmail, Either[Error, Unit]) => Unit] =
     None
 
-  override lazy val controller: SubscriptionChangeEmailController =
-    instanceOf[SubscriptionChangeEmailController]
+  override lazy val controller: SubscriptionChangeEmailController = instanceOf[SubscriptionChangeEmailController]
 
-  implicit lazy val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messagesApi: MessagesApi = controller.messagesApi
 
   def redirectToStartBehaviour(performAction: () => Future[Result]): Unit =
     redirectToStartWhenInvalidJourney(
@@ -99,7 +98,7 @@ class SubscriptionChangeEmailControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.enterEmailSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/SubscriptionEnterEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/email/SubscriptionEnterEmailControllerSpec.scala
@@ -28,7 +28,6 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.email.{ro
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.SubscriptionMissingData
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.Email
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailJourneyType.Onboarding.EnteringSubscriptionEmail
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.EmailGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
@@ -36,6 +35,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.ContactName
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.BusinessPartnerRecord
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen.given
 
 import java.util.UUID
 import scala.concurrent.Future
@@ -84,10 +84,9 @@ class SubscriptionEnterEmailControllerSpec
   override val mockUpdateEmail
     : Option[(EnteringSubscriptionEmail, EnteringSubscriptionEmail, Either[Error, Unit]) => Unit] = None
 
-  override lazy val controller: SubscriptionEnterEmailController =
-    instanceOf[SubscriptionEnterEmailController]
+  override lazy val controller: SubscriptionEnterEmailController = instanceOf[SubscriptionEnterEmailController]
 
-  implicit lazy val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messagesApi: MessagesApi = controller.messagesApi
 
   def redirectToStartBehaviour(performAction: () => Future[Result]): Unit =
     redirectToStartWhenInvalidJourney(
@@ -113,7 +112,7 @@ class SubscriptionEnterEmailControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.enterEmailSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/IndividualNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/IndividualNameControllerSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.onboarding.Subscription
 import scala.concurrent.Future
 
 trait IndividualNameControllerSpec[J <: JourneyStatus] extends NameFormValidationTests with RedirectToStartBehaviour {
-  this: ControllerSpec with AuthSupport with SessionSupport with ScalaCheckDrivenPropertyChecks =>
+  this: ControllerSpec & AuthSupport & SessionSupport & ScalaCheckDrivenPropertyChecks =>
 
   val controller: IndividualNameController[J]
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/RegistrationChangeIndividualNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/RegistrationChangeIndividualNameControllerSpec.scala
@@ -24,9 +24,9 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.RegistrationStatus.RegistrationReady
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.IndividualName
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 
 class RegistrationChangeIndividualNameControllerSpec
     extends ControllerSpec
@@ -43,10 +43,10 @@ class RegistrationChangeIndividualNameControllerSpec
 
   override val mockUpdateName: Option[(RegistrationReady, RegistrationReady, Either[Error, Unit]) => Unit] = None
 
-  override lazy val controller: RegistrationChangeIndividualNameController =
+  override val controller: RegistrationChangeIndividualNameController =
     instanceOf[RegistrationChangeIndividualNameController]
 
-  override lazy val validJourney: RegistrationReady = sample[RegistrationReady]
+  override val validJourney: RegistrationReady = sample[RegistrationReady]
 
   override def updateName(
     name: IndividualName,
@@ -69,7 +69,7 @@ class RegistrationChangeIndividualNameControllerSpec
       behave like enterNameSubmit(
         data =>
           controller.enterIndividualNameSubmit()(
-            FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+            FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
           ),
         controllers.onboarding.routes.RegistrationController.checkYourAnswers()
       )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/RegistrationEnterIndividualNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/RegistrationEnterIndividualNameControllerSpec.scala
@@ -36,10 +36,10 @@ class RegistrationEnterIndividualNameControllerSpec
     with IndividualNameControllerSpec[IndividualSupplyingInformation]
     with ScalaCheckDrivenPropertyChecks {
 
-  override lazy val controller: RegistrationEnterIndividualNameController =
+  override val controller: RegistrationEnterIndividualNameController =
     instanceOf[RegistrationEnterIndividualNameController]
 
-  override lazy val validJourney: IndividualSupplyingInformation =
+  override val validJourney: IndividualSupplyingInformation =
     IndividualSupplyingInformation(None, None, None, None, sample[GGCredId])
 
   def isValidJourney(journey: JourneyStatus): Boolean =
@@ -72,7 +72,7 @@ class RegistrationEnterIndividualNameControllerSpec
       behave like enterNameSubmit(
         data =>
           controller.enterIndividualNameSubmit()(
-            FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+            FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
           ),
         controllers.onboarding.address.routes.RegistrationEnterAddressController
           .isUk()

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/SubscriptionChangeContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/onboarding/name/SubscriptionChangeContactNameControllerSpec.scala
@@ -20,12 +20,11 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.i18n.MessagesApi
 import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
-import shapeless.{Lens, lens}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ContactNameControllerSpec, ControllerSpec, SessionSupport}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.SubscriptionStatus.SubscriptionReady
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{ContactName, ContactNameSource}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.{controllers, models}
 
@@ -42,10 +41,10 @@ class SubscriptionChangeContactNameControllerSpec
   implicit lazy val messagesApi: MessagesApi = controller.messagesApi
 
   override val validJourney: SubscriptionReady = {
-    val contactNameSourceLens: Lens[SubscriptionReady, ContactNameSource] =
-      lens[SubscriptionReady].subscriptionDetails.contactNameSource
-    contactNameSourceLens.set(sample[SubscriptionReady])(
-      ContactNameSource.DerivedFromBusinessPartnerRecord
+    val subscriptionReady = sample[SubscriptionReady]
+
+    subscriptionReady.copy(subscriptionDetails =
+      subscriptionReady.subscriptionDetails.copy(contactNameSource = ContactNameSource.DerivedFromBusinessPartnerRecord)
     )
   }
 
@@ -80,7 +79,7 @@ class SubscriptionChangeContactNameControllerSpec
       behave like enterContactNameSubmit(
         data =>
           controller.enterContactNameSubmit()(
-            FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+            FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
           ),
         controllers.onboarding.routes.SubscriptionController.checkYourDetails()
       )

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/CheckAllAnswersAndSubmitControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/CheckAllAnswersAndSubmitControllerSpec.scala
@@ -47,25 +47,27 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOut
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Postcode
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.{AmountInPence, MoneyUtils, PaymentsJourney}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SingleMixedUseDetailsAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SingleMixedUseDetailsAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, CgtReference}
@@ -188,7 +190,7 @@ class CheckAllAnswersAndSubmitControllerSpec
           _: Call
         )(
           _: HeaderCarrier,
-          _: Request[_]
+          _: Request[?]
         )
       )
       .expects(cgtReference, chargeReference, amount, dueDate, returnUrl, backUrl, *, *)
@@ -1306,7 +1308,7 @@ class CheckAllAnswersAndSubmitControllerSpec
 
       lazy val submitReturnRequest = {
         val cyaPge                                                     = instanceOf[views.html.returns.check_all_answers]
-        implicit val requestWithSessionData: RequestWithSessionData[_] =
+        implicit val requestWithSessionData: RequestWithSessionData[?] =
           RequestWithSessionData(
             None,
             AuthenticatedRequest(
@@ -1341,7 +1343,7 @@ class CheckAllAnswersAndSubmitControllerSpec
         hideEstimatesQuestion: Boolean
       ): SubmitReturnRequest = {
         val cyaPge                                                     = instanceOf[views.html.returns.check_all_answers]
-        implicit val requestWithSessionData: RequestWithSessionData[_] =
+        implicit val requestWithSessionData: RequestWithSessionData[?] =
           RequestWithSessionData(
             None,
             AuthenticatedRequest(
@@ -1564,10 +1566,10 @@ class CheckAllAnswersAndSubmitControllerSpec
 
                 doc.select(".govuk-body").text shouldBe
                   s"""${messageFromMessageKey("submitReturnError.p1")} ${messageFromMessageKey(
-                    "submitReturnError.p2"
-                  )} ${messageFromMessageKey("submitReturnError.p3")} ${messageFromMessageKey(
-                    "submitReturnError.p4"
-                  )}"""
+                      "submitReturnError.p2"
+                    )} ${messageFromMessageKey("submitReturnError.p3")} ${messageFromMessageKey(
+                      "submitReturnError.p4"
+                    )}"""
 
                 doc
                   .select("#main-content ol.govuk-list--number > li:nth-child(1)")

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/DraftReturnSavedControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/DraftReturnSavedControllerSpec.scala
@@ -28,11 +28,11 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.RedirectT
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport, accounts, returns}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.FillingOutReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.AgentReferenceNumber
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
@@ -123,8 +123,8 @@ class DraftReturnSavedControllerSpec
               doc
                 .select(".govuk-warning-text__text")
                 .text()       shouldBe s"""${messageFromMessageKey(
-                "generic.warning"
-              )} ${messageFromMessageKey(expectedWarningMessageKey, formattedDate)}"""
+                  "generic.warning"
+                )} ${messageFromMessageKey(expectedWarningMessageKey, formattedDate)}"""
             }
           )
         }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/FurtherReturnCalculationEligibilityUtilSupport.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/FurtherReturnCalculationEligibilityUtilSupport.scala
@@ -38,7 +38,7 @@ trait FurtherReturnCalculationEligibilityUtilSupport { this: ControllerSpec =>
     fillingOutReturn: FillingOutReturn
   )(
     result: Either[Error, FurtherReturnCalculationEligibility]
-  ): CallHandler3[FillingOutReturn, HeaderCarrier, RequestWithSessionData[_], EitherT[
+  ): CallHandler3[FillingOutReturn, HeaderCarrier, RequestWithSessionData[?], EitherT[
     Future,
     Error,
     FurtherReturnCalculationEligibility
@@ -49,7 +49,7 @@ trait FurtherReturnCalculationEligibilityUtilSupport { this: ControllerSpec =>
           _: FillingOutReturn
         )(
           _: HeaderCarrier,
-          _: RequestWithSessionData[_]
+          _: RequestWithSessionData[?]
         )
       )
       .expects(fillingOutReturn, *, *)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ReturnsServiceSupport.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ReturnsServiceSupport.scala
@@ -39,13 +39,13 @@ trait ReturnsServiceSupport { this: MockFactory =>
     fillingOutReturn: FillingOutReturn
   )(
     result: Either[Error, Unit]
-  ): CallHandler3[FillingOutReturn, HeaderCarrier, Request[_], EitherT[Future, Error, Unit]] =
+  ): CallHandler3[FillingOutReturn, HeaderCarrier, Request[?], EitherT[Future, Error, Unit]] =
     (mockReturnsService
       .storeDraftReturn(
         _: FillingOutReturn
       )(
         _: HeaderCarrier,
-        _: Request[_]
+        _: Request[?]
       ))
       .expects(fillingOutReturn, *, *)
       .returning(EitherT.fromEither[Future](result))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/StartingToAmendToFillingOutReturnSpecBehaviour.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/StartingToAmendToFillingOutReturnSpecBehaviour.scala
@@ -24,10 +24,11 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.amend.routes.{AmendReturnController => amendRoutes}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingToAmendReturn}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.UUIDGenerator
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.{CompleteMultipleDisposalsReturn, CompleteMultipleIndirectDisposalReturn, CompleteSingleDisposalReturn, CompleteSingleIndirectDisposalReturn, CompleteSingleMixedUseDisposalReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
@@ -37,7 +38,7 @@ import java.time.{Clock, LocalDate}
 import java.util.UUID
 
 trait StartingToAmendToFillingOutReturnSpecBehaviour {
-  this: ControllerSpec with SessionSupport with AuthSupport with MockFactory =>
+  this: ControllerSpec & SessionSupport & AuthSupport & MockFactory =>
 
   def amendReturnToFillingOutReturnSpecBehaviour(
     performAction: Action[AnyContent],
@@ -77,7 +78,7 @@ trait StartingToAmendToFillingOutReturnSpecBehaviour {
         inSequence {
           mockAuthWithNoRetrievals()
           mockGetSession(SessionData.empty.copy(journeyStatus = Some(startingToAmend)))
-          (mockUUIDGenerator.nextId _).expects().returning(expectedDraftReturn.id)
+          (() => mockUUIDGenerator.nextId()).expects().returning(expectedDraftReturn.id)
           mockStoreSession(SessionData.empty.copy(journeyStatus = Some(fillingOutReturn)))(Right(()))
         }
 
@@ -219,7 +220,7 @@ trait StartingToAmendToFillingOutReturnSpecBehaviour {
         inSequence {
           mockAuthWithNoRetrievals()
           mockGetSession(SessionData.empty.copy(journeyStatus = Some(startingToAmend)))
-          (mockUUIDGenerator.nextId _).expects().returning(draftReturn.id)
+          (() => mockUUIDGenerator.nextId()).expects().returning(draftReturn.id)
           mockStoreSession(SessionData.empty.copy(journeyStatus = Some(fillingOutReturn)))(Left(Error("")))
         }
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/TaskListControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/TaskListControllerSpec.scala
@@ -33,21 +33,21 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.SessionData
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Country}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SingleMixedUseDetailsAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SingleMixedUseDetailsAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.{CompleteAcquisitionDetailsAnswers, IncompleteAcquisitionDetailsAnswers}
@@ -182,7 +182,7 @@ class TaskListControllerSpec
                       .select(s"li#$sectionLinkId > span")
                       .text shouldBe sectionLinkText
 
-                  case _                          =>
+                  case _ =>
                     doc
                       .select(s"li#$sectionLinkId > a")
                       .text         shouldBe sectionLinkText
@@ -193,7 +193,7 @@ class TaskListControllerSpec
 
                 doc
                   .select(s"li#$sectionLinkId > strong")
-                  .text shouldBe messageFromMessageKey(s"task-list.$sectionsStatus")
+                  .text shouldBe messageFromMessageKey(s"task-list.$sectionsStatus").toUpperCase
                 extraChecks(doc)
               } catch {
                 case t: Throwable =>

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/ViewReturnControllerSpec.scala
@@ -44,7 +44,8 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.PaymentMethod.Dir
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
@@ -52,7 +53,7 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.completeReliefDetailsAnswersGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, CgtReference}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
@@ -114,7 +115,7 @@ class ViewReturnControllerSpec
           _: Call
         )(
           _: HeaderCarrier,
-          _: Request[_]
+          _: Request[?]
         )
       )
       .expects(cgtReference, chargeReference, amount, dueDate, returnUrl, backUrl, *, *)
@@ -247,8 +248,8 @@ class ViewReturnControllerSpec
         paymentDetails(4)                                     shouldBe messageFromMessageKey("viewReturn.charge.status.paid")
 
         paymentDetails(5) shouldBe s"${formatAmountOfMoneyWithPoundSign(
-          fullPaymentForUkResidentReturnCharge.amount.inPounds()
-        )} direct debit payment received on ${govShortDisplayFormat(fullPaymentForUkResidentMainReturnChargeDueDate)}"
+            fullPaymentForUkResidentReturnCharge.amount.inPounds()
+          )} direct debit payment received on ${govShortDisplayFormat(fullPaymentForUkResidentMainReturnChargeDueDate)}"
 
         paymentDetails(6)    should startWith(messageFromMessageKey("viewReturn.chargeType.PenaltyInterest"))
         paymentDetails(7)  shouldBe govShortDisplayFormat(
@@ -290,8 +291,8 @@ class ViewReturnControllerSpec
         paymentDetails(4)                                     shouldBe messageFromMessageKey("viewReturn.charge.status.paid")
 
         paymentDetails(5) shouldBe s"${formatAmountOfMoneyWithPoundSign(
-          fullPaymentForUkResidentReturnCharge.amount.inPounds()
-        )} ${messageFromMessageKey("viewReturn.charge.paymentMethod.DirectDebit")} ${messageFromMessageKey("generic.on")} ${govShortDisplayFormat(fullPaymentForUkResidentMainReturnChargeDueDate)}"
+            fullPaymentForUkResidentReturnCharge.amount.inPounds()
+          )} ${messageFromMessageKey("viewReturn.charge.paymentMethod.DirectDebit")} ${messageFromMessageKey("generic.on")} ${govShortDisplayFormat(fullPaymentForUkResidentMainReturnChargeDueDate)}"
 
         paymentDetails(6)    should startWith(messageFromMessageKey("viewReturn.chargeType.DeltaCharge"))
         paymentDetails(7)  shouldBe govShortDisplayFormat(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/AcquisitionDetailsControllerSpec.scala
@@ -39,18 +39,18 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOut
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.MoneyUtils.formatAmountOfMoneyWithPoundSign
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.{AmountInPence, MoneyUtils}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.completeDisposalDetailsAnswersGen
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, UUIDGenerator}
@@ -119,7 +119,7 @@ class AcquisitionDetailsControllerSpec
     messageFromMessageKey(if (isAmend) "button.continue" else "button.saveAndContinue")
   def setAgentReferenceNumber(
     userType: UserType
-  ): Option[AgentReferenceNumber]                  =
+  ): Option[AgentReferenceNumber] =
     userType match {
       case UserType.Agent => Some(sample[AgentReferenceNumber])
       case _              => None
@@ -507,7 +507,7 @@ class AcquisitionDetailsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.acquisitionMethodSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -530,7 +530,7 @@ class AcquisitionDetailsControllerSpec
           assetType: AssetType,
           userKey: String
         ): Unit =
-          testFormError(data: _*)(userType, individualUserType, assetType)(
+          testFormError(data*)(userType, individualUserType, assetType)(
             expectedErrorMessageKey
           )(
             s"$key$userKey.title"
@@ -745,7 +745,7 @@ class AcquisitionDetailsControllerSpec
             }
 
             checkIsRedirect(
-              performAction(data: _*),
+              performAction(data*),
               routes.AcquisitionDetailsController.checkYourAnswers()
             )
           }
@@ -867,7 +867,7 @@ class AcquisitionDetailsControllerSpec
             }
 
             checkIsRedirect(
-              performAction(data: _*),
+              performAction(data*),
               routes.AcquisitionDetailsController.checkYourAnswers()
             )
           }
@@ -924,14 +924,14 @@ class AcquisitionDetailsControllerSpec
               val (incompleteAnswers, completeAnswers) =
                 sample[IncompleteAcquisitionDetailsAnswers] -> sample[CompleteAcquisitionDetailsAnswers]
               List(
-                Seq(key -> "0") -> incompleteAnswers.copy(acquisitionMethod = Some(AcquisitionMethod.Bought)),
-                Seq(key -> "1") -> incompleteAnswers.copy(acquisitionMethod = Some(AcquisitionMethod.Inherited)),
-                Seq(key -> "2") -> incompleteAnswers.copy(acquisitionMethod = Some(AcquisitionMethod.Gifted)),
+                Seq(key -> "0")                             -> incompleteAnswers.copy(acquisitionMethod = Some(AcquisitionMethod.Bought)),
+                Seq(key -> "1")                             -> incompleteAnswers.copy(acquisitionMethod = Some(AcquisitionMethod.Inherited)),
+                Seq(key -> "2")                             -> incompleteAnswers.copy(acquisitionMethod = Some(AcquisitionMethod.Gifted)),
                 Seq(key -> "3", otherKey -> "other things") -> incompleteAnswers
                   .copy(acquisitionMethod = Some(AcquisitionMethod.Other("other things"))),
-                Seq(key -> "0") -> completeAnswers.copy(acquisitionMethod = AcquisitionMethod.Bought),
-                Seq(key -> "1") -> completeAnswers.copy(acquisitionMethod = AcquisitionMethod.Inherited),
-                Seq(key -> "2") -> completeAnswers.copy(acquisitionMethod = AcquisitionMethod.Gifted),
+                Seq(key -> "0")                             -> completeAnswers.copy(acquisitionMethod = AcquisitionMethod.Bought),
+                Seq(key -> "1")                             -> completeAnswers.copy(acquisitionMethod = AcquisitionMethod.Inherited),
+                Seq(key -> "2")                             -> completeAnswers.copy(acquisitionMethod = AcquisitionMethod.Gifted),
                 Seq(key -> "3", otherKey -> "other things") -> completeAnswers
                   .copy(acquisitionMethod = AcquisitionMethod.Other("other things"))
               ).foreach { case (data, answers) =>
@@ -949,7 +949,7 @@ class AcquisitionDetailsControllerSpec
                 }
 
                 checkIsRedirect(
-                  performAction(data: _*),
+                  performAction(data*),
                   routes.AcquisitionDetailsController.checkYourAnswers()
                 )
               }
@@ -1130,7 +1130,7 @@ class AcquisitionDetailsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.acquisitionDateSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def formData(date: LocalDate): List[(String, String)] =
@@ -1191,7 +1191,7 @@ class AcquisitionDetailsControllerSpec
           assetType: AssetType,
           userKey: String
         )(expectedErrorKey: String): Unit =
-          testFormError(data: _*)(userType, individualUserType, assetType)(
+          testFormError(data*)(userType, individualUserType, assetType)(
             expectedErrorKey
           )(s"$key$userKey.title")(
             performAction,
@@ -1225,7 +1225,7 @@ class AcquisitionDetailsControllerSpec
                         "acquisitionDate-year"  -> yearString
                       ).collect { case (id, Some(input)) => id -> input }
 
-                    test(formData: _*)(userType, individualUserType, assetType, userKey + assetTypeKey)(
+                    test(formData*)(userType, individualUserType, assetType, userKey + assetTypeKey)(
                       expectedErrorKey
                     )
                   }
@@ -1239,7 +1239,7 @@ class AcquisitionDetailsControllerSpec
               val assetTypeKey = assetTypeMessageKey(assetType)
               val userKey      = userMessageKey(individualUserType, userType)
               val tomorrow     = disposalDate.value.plusDays(1L)
-              test(formData(tomorrow): _*)(
+              test(formData(tomorrow)*)(
                 userType,
                 individualUserType,
                 assetType,
@@ -1255,7 +1255,7 @@ class AcquisitionDetailsControllerSpec
               val userKey      = userMessageKey(individualUserType, userType)
               val before1900   = LocalDate.of(1800, 1, 1)
 
-              test(formData(before1900): _*)(
+              test(formData(before1900)*)(
                 userType,
                 individualUserType,
                 assetType,
@@ -1323,7 +1323,7 @@ class AcquisitionDetailsControllerSpec
               }
 
               checkIsTechnicalErrorPage(
-                performAction(formData(acquisitionDate.value): _*)
+                performAction(formData(acquisitionDate.value)*)
               )
           }
         }
@@ -1346,7 +1346,7 @@ class AcquisitionDetailsControllerSpec
               }
 
               checkIsTechnicalErrorPage(
-                performAction(formData(acquisitionDate.value): _*)
+                performAction(formData(acquisitionDate.value)*)
               )
           }
         }
@@ -1400,7 +1400,7 @@ class AcquisitionDetailsControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(submittedAcquisitionDate): _*),
+            performAction(formData(submittedAcquisitionDate)*),
             routes.AcquisitionDetailsController.checkYourAnswers()
           )
         }
@@ -1597,7 +1597,7 @@ class AcquisitionDetailsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.periodOfAdminMarketValueSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       val dateOfDeath = DateOfDeath(LocalDate.ofEpochDay(0L))
@@ -1665,7 +1665,7 @@ class AcquisitionDetailsControllerSpec
 
           val formattedDateOfDeath = TimeUtils.govDisplayFormat(dateOfDeath.value)
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             messageFromMessageKey(
               s"$key.title",
               formattedDateOfDeath
@@ -1756,7 +1756,7 @@ class AcquisitionDetailsControllerSpec
 
         val scenarios = List(
           List(key -> "£1,234") -> AmountInPence(123400L),
-          List(key -> "1") -> AmountInPence(100L)
+          List(key -> "1")      -> AmountInPence(100L)
         )
 
         "the price submitted is valid and the journey was incomplete" in {
@@ -1796,7 +1796,7 @@ class AcquisitionDetailsControllerSpec
               }
 
               checkIsRedirect(
-                performAction(formData: _*),
+                performAction(formData*),
                 routes.AcquisitionDetailsController.checkYourAnswers()
               )
             }
@@ -1839,7 +1839,7 @@ class AcquisitionDetailsControllerSpec
               }
 
               checkIsRedirect(
-                performAction(formData: _*),
+                performAction(formData*),
                 routes.AcquisitionDetailsController.checkYourAnswers()
               )
             }
@@ -1874,7 +1874,7 @@ class AcquisitionDetailsControllerSpec
           assetType: AssetType,
           userKey: String
         ): Unit =
-          forAll { acquisitionMethod: AcquisitionMethod =>
+          forAll { (acquisitionMethod: AcquisitionMethod) =>
             val isAmend         = sample[Boolean]
             val acquisitionDate = sample[AcquisitionDate]
             val answers         = sample[IncompleteAcquisitionDetailsAnswers].copy(
@@ -2002,7 +2002,7 @@ class AcquisitionDetailsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.acquisitionPriceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -2024,7 +2024,7 @@ class AcquisitionDetailsControllerSpec
           assetType: AssetType,
           userKey: String
         ): Unit =
-          forAll { answers: CompleteAcquisitionDetailsAnswers =>
+          forAll { (answers: CompleteAcquisitionDetailsAnswers) =>
             val scenarioSession = sessionWithState(
               answers,
               assetType,
@@ -2043,7 +2043,7 @@ class AcquisitionDetailsControllerSpec
               errorContext = Some(contextKey)
             ).foreach { scenario =>
               withClue(s"For $scenario: ") {
-                testFormError(scenario.formData: _*)(
+                testFormError(scenario.formData*)(
                   userType,
                   individualUserType,
                   assetType
@@ -2069,7 +2069,7 @@ class AcquisitionDetailsControllerSpec
           assetType: AssetType,
           userKey: String
         ): Unit =
-          forAll { answers: CompleteAcquisitionDetailsAnswers =>
+          forAll { (answers: CompleteAcquisitionDetailsAnswers) =>
             val scenarioSession = sessionWithState(
               answers,
               assetType,
@@ -2647,7 +2647,7 @@ class AcquisitionDetailsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.rebasedAcquisitionPriceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       val acquisitionDate = AcquisitionDate(allResidents.minusDays(1))
@@ -2722,7 +2722,7 @@ class AcquisitionDetailsControllerSpec
 
           val formattedRebaseDate = TimeUtils.govDisplayFormat(allResidents)
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             messageFromMessageKey(
               s"$key.title",
               formattedRebaseDate
@@ -2833,7 +2833,7 @@ class AcquisitionDetailsControllerSpec
 
         val scenarios = List(
           List("rebaseAcquisitionPrice" -> "£1,234") -> AmountInPence(123400L),
-          List("rebaseAcquisitionPrice" -> "1") -> AmountInPence(100L)
+          List("rebaseAcquisitionPrice" -> "1")      -> AmountInPence(100L)
         )
 
         "the price submitted is valid and the journey was incomplete" in {
@@ -2876,7 +2876,7 @@ class AcquisitionDetailsControllerSpec
                   }
 
                   checkIsRedirect(
-                    performAction(formData: _*),
+                    performAction(formData*),
                     routes.AcquisitionDetailsController.checkYourAnswers()
                   )
                 }
@@ -2925,7 +2925,7 @@ class AcquisitionDetailsControllerSpec
                   }
 
                   checkIsRedirect(
-                    performAction(formData: _*),
+                    performAction(formData*),
                     routes.AcquisitionDetailsController.checkYourAnswers()
                   )
                 }
@@ -3285,7 +3285,7 @@ class AcquisitionDetailsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.improvementCostsSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       val acquisitionDate = AcquisitionDate(LocalDate.ofEpochDay(0L))
@@ -3371,7 +3371,7 @@ class AcquisitionDetailsControllerSpec
           assetType: AssetType,
           userKey: String
         )(expectedErrorKey: String): Unit =
-          testFormError(data: _*)(userType, individualUserType, assetType)(
+          testFormError(data*)(userType, individualUserType, assetType)(
             expectedErrorKey
           )(s"$key$userKey.title")(performAction)
 
@@ -3403,7 +3403,7 @@ class AcquisitionDetailsControllerSpec
               amountOfMoneyErrorScenarios(valueKey).foreach { scenario =>
                 withClue(s"For $scenario: ") {
                   val data = (key -> "0") :: scenario.formData
-                  test(data: _*)(userType, individualUserType, assetType, userKey)(
+                  test(data*)(userType, individualUserType, assetType, userKey)(
                     scenario.expectedErrorMessageKey
                   )
                 }
@@ -3505,7 +3505,7 @@ class AcquisitionDetailsControllerSpec
       "redirect to the check you answers page" when {
         val scenarios = List(
           List(key -> "0", valueKey -> "£1,234") -> AmountInPence(123400L),
-          List(key -> "1") -> AmountInPence.zero
+          List(key -> "1")                       -> AmountInPence.zero
         )
 
         "the price submitted is valid and the journey was incomplete" in {
@@ -3544,7 +3544,7 @@ class AcquisitionDetailsControllerSpec
                   }
 
                   checkIsRedirect(
-                    performAction(formData: _*),
+                    performAction(formData*),
                     routes.AcquisitionDetailsController.checkYourAnswers()
                   )
                 }
@@ -3591,7 +3591,7 @@ class AcquisitionDetailsControllerSpec
                   }
 
                   checkIsRedirect(
-                    performAction(formData: _*),
+                    performAction(formData*),
                     routes.AcquisitionDetailsController.checkYourAnswers()
                   )
                 }
@@ -3976,7 +3976,7 @@ class AcquisitionDetailsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.acquisitionFeesSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -4027,7 +4027,7 @@ class AcquisitionDetailsControllerSpec
           userKey: String,
           wasUkResident: Boolean
         )(expectedErrorKey: String): Unit =
-          testFormError(data: _*)(userType, individualUserType, assetType, wasUkResident)(
+          testFormError(data*)(userType, individualUserType, assetType, wasUkResident)(
             expectedErrorKey,
             models.TimeUtils.govDisplayFormat(mockRebasingUtil.getRebasingCutOffDate(assetType, wasUkResident))
           )(s"$key$userKey.title")(performAction)
@@ -4064,7 +4064,7 @@ class AcquisitionDetailsControllerSpec
               amountOfMoneyErrorScenarios(valueKey).foreach { scenario =>
                 withClue(s"For $scenario: ") {
                   val data = (key -> "0") :: scenario.formData
-                  test(data: _*)(
+                  test(data*)(
                     userType,
                     individualUserType,
                     assetType,
@@ -4174,7 +4174,7 @@ class AcquisitionDetailsControllerSpec
 
         val scenarios = List(
           List(key -> "0", valueKey -> "£1,234") -> AmountInPence(123400L),
-          List(key -> "1") -> AmountInPence.zero
+          List(key -> "1")                       -> AmountInPence.zero
         )
 
         "the price submitted is valid and the journey was incomplete" in {
@@ -4215,7 +4215,7 @@ class AcquisitionDetailsControllerSpec
                   }
 
                   checkIsRedirect(
-                    performAction(formData: _*),
+                    performAction(formData*),
                     routes.AcquisitionDetailsController.checkYourAnswers()
                   )
                 }
@@ -4256,7 +4256,7 @@ class AcquisitionDetailsControllerSpec
                   }
 
                   checkIsRedirect(
-                    performAction(formData: _*),
+                    performAction(formData*),
                     routes.AcquisitionDetailsController.checkYourAnswers()
                   )
                 }
@@ -4390,7 +4390,7 @@ class AcquisitionDetailsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.shouldUseRebaseSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like amendReturnToFillingOutReturnSpecBehaviour(
@@ -4409,7 +4409,7 @@ class AcquisitionDetailsControllerSpec
         )(userType: UserType, individualUserType: IndividualUserType)(
           expectedErrorKey: String
         ): Unit =
-          testFormError(data: _*)(userType, individualUserType, NonResidential)(
+          testFormError(data*)(userType, individualUserType, NonResidential)(
             expectedErrorKey
           )("shouldUseRebase.title", date)(
             performAction,
@@ -4449,7 +4449,7 @@ class AcquisitionDetailsControllerSpec
         )(userType: UserType, individualUserType: IndividualUserType)(
           expectedErrorKey: String
         ): Unit =
-          testFormError(data: _*)(userType, individualUserType, Residential)(
+          testFormError(data*)(userType, individualUserType, Residential)(
             expectedErrorKey
           )("shouldUseRebase.title", date)(
             performAction,
@@ -5305,13 +5305,13 @@ class AcquisitionDetailsControllerSpec
 
     checkPageIsDisplayed(
       performAction(data),
-      messageFromMessageKey(pageTitleKey, titleArgs: _*),
+      messageFromMessageKey(pageTitleKey, titleArgs*),
       { doc =>
         doc
           .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
-          errorArgs: _*
+          errorArgs*
         )
         doc.title() should startWith("Error:")
       },

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/RebasingEligibilityUtilSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/acquisitiondetails/RebasingEligibilityUtilSpec.scala
@@ -20,8 +20,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.RebasingCutoffDates
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.CompleteAcquisitionDetailsAnswers

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/CompanyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/CompanyDetailsControllerSpec.scala
@@ -39,16 +39,16 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.{NonUkAdd
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Country, Postcode}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, UUIDGenerator}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
@@ -214,7 +214,7 @@ class CompanyDetailsControllerSpec
   val allIndividualUserTypeGen: Gen[IndividualUserType] =
     individualUserTypeGen.filter {
       case Self | Capacitor | PersonalRepresentative | PersonalRepresentativeInPeriodOfAdmin => true
-      case _                                                                                 => false
+      case null                                                                              => false
     }
 
   def userMessageKey(individualUserType: IndividualUserType): String =
@@ -413,7 +413,7 @@ class CompanyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.isUkSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -429,7 +429,7 @@ class CompanyDetailsControllerSpec
           formData: (String, String)*
         )(expectedErrorMessageKey: String, expectedTitleKey: String): Unit =
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
@@ -511,7 +511,7 @@ class CompanyDetailsControllerSpec
           formData: (String, String)*
         )(expectedErrorMessageKey: String, expectedTitleKey: String): Unit =
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
@@ -753,7 +753,7 @@ class CompanyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -769,7 +769,7 @@ class CompanyDetailsControllerSpec
           formData: (String, String)*
         )(expectedErrorMessageKey: String, expectedTitleKey: String): Unit =
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
@@ -965,7 +965,7 @@ class CompanyDetailsControllerSpec
           formData: (String, String)*
         )(expectedErrorMessageKey: String, expectedTitleKey: String): Unit =
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
@@ -1512,7 +1512,7 @@ class CompanyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterNonUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -1528,7 +1528,7 @@ class CompanyDetailsControllerSpec
           formData: (String, String)*
         )(expectedErrorMessageKey: String, expectedTitleKey: String): Unit =
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
@@ -1711,7 +1711,7 @@ class CompanyDetailsControllerSpec
           formData: (String, String)*
         )(expectedErrorMessageKey: String, expectedTitleKey: String): Unit =
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
@@ -2226,7 +2226,7 @@ class CompanyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.multipleIndirectDisposalsGuidance()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -2278,7 +2278,7 @@ class CompanyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.multipleIndirectDisposalsGuidanceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -2332,7 +2332,7 @@ class CompanyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.multipleIndirectDisposalPriceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -2402,7 +2402,7 @@ class CompanyDetailsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
@@ -2418,7 +2418,7 @@ class CompanyDetailsControllerSpec
           amountOfMoneyErrorScenarios(key).foreach { scenario =>
             withClue(s"For $scenario: ") {
               val data = scenario.formData
-              test(data: _*)(scenario.expectedErrorMessageKey)
+              test(data*)(scenario.expectedErrorMessageKey)
             }
           }
         }
@@ -2812,7 +2812,7 @@ class CompanyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.multipleIndirectAcquisitionPriceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -2882,7 +2882,7 @@ class CompanyDetailsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
@@ -2898,7 +2898,7 @@ class CompanyDetailsControllerSpec
           amountOfMoneyErrorScenarios(key).foreach { scenario =>
             withClue(s"For $scenario: ") {
               val data = scenario.formData
-              test(data: _*)(scenario.expectedErrorMessageKey)
+              test(data*)(scenario.expectedErrorMessageKey)
             }
           }
         }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MixedUsePropertyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MixedUsePropertyDetailsControllerSpec.scala
@@ -36,16 +36,16 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Postcode
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SingleMixedUseDetailsAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SingleMixedUseDetailsAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, UUIDGenerator}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
@@ -326,8 +326,7 @@ class MixedUsePropertyDetailsControllerSpec
 
     "handling requests to display the enter address page" must {
 
-      def performAction(): Future[Result] =
-        controller.enterUkAddress()(FakeRequest())
+      def performAction(): Future[Result] = controller.enterUkAddress()(FakeRequest())
 
       behave like redirectToStartBehaviour(() => performAction())
 
@@ -363,9 +362,7 @@ class MixedUsePropertyDetailsControllerSpec
 
               doc
                 .select("#content form, #main-content form")
-                .attr("action") shouldBe routes.MixedUsePropertyDetailsController
-                .enterUkAddressSubmit()
-                .url
+                .attr("action") shouldBe routes.MixedUsePropertyDetailsController.enterUkAddressSubmit().url
             }
           )
 
@@ -423,7 +420,7 @@ class MixedUsePropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -439,7 +436,7 @@ class MixedUsePropertyDetailsControllerSpec
           formData: (String, String)*
         )(expectedErrorMessageKey: String, expectedTitleKey: String): Unit =
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(expectedTitleKey),
             doc =>
               doc
@@ -696,7 +693,7 @@ class MixedUsePropertyDetailsControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData: _*),
+            performAction(formData*),
             routes.MixedUsePropertyDetailsController.checkYourAnswers()
           )
         }
@@ -959,7 +956,7 @@ class MixedUsePropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterDisposalValueSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -1033,7 +1030,7 @@ class MixedUsePropertyDetailsControllerSpec
             userMessageKey(draftReturn.triageAnswers.fold(_.individualUserType, _.individualUserType), Individual)
 
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             messageFromMessageKey(s"$key$userKey.title"),
             doc =>
               doc
@@ -1049,7 +1046,7 @@ class MixedUsePropertyDetailsControllerSpec
           amountOfMoneyErrorScenarios(key).foreach { scenario =>
             withClue(s"For $scenario: ") {
               val data = scenario.formData
-              test(data: _*)(scenario.expectedErrorMessageKey)
+              test(data*)(scenario.expectedErrorMessageKey)
             }
           }
         }
@@ -1202,7 +1199,7 @@ class MixedUsePropertyDetailsControllerSpec
           val userKey = userMessageKey(individualUserType, userType)
           checkPageIsDisplayed(
             performAction(),
-            messageFromMessageKey(s"$key$userKey.title", titleArgs: _*),
+            messageFromMessageKey(s"$key$userKey.title", titleArgs*),
             { doc =>
               doc.select(".govuk-back-link").attr("href") shouldBe expectedBackLink.url
               doc
@@ -1369,7 +1366,7 @@ class MixedUsePropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterAcquisitionValueSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -1445,7 +1442,7 @@ class MixedUsePropertyDetailsControllerSpec
           val dateOfDeath = draftReturn.representeeAnswers.flatMap(_.fold(_.dateOfDeath, _.dateOfDeath))
           val titleArg    = dateOfDeath.map(e => TimeUtils.govDisplayFormat(e.value)).getOrElse("")
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             messageFromMessageKey(s"$key$userKey.title", titleArg),
             doc =>
               doc
@@ -1458,12 +1455,12 @@ class MixedUsePropertyDetailsControllerSpec
         }
 
         "the data is invalid" in {
-          forAll { individualUserType: Option[IndividualUserType] =>
+          forAll { (individualUserType: Option[IndividualUserType]) =>
             whenever(!individualUserType.contains(PersonalRepresentativeInPeriodOfAdmin)) {
               amountOfMoneyErrorScenarios(key).foreach { scenario =>
                 withClue(s"For $individualUserType and $scenario: ") {
                   val data = scenario.formData
-                  test(data: _*)(
+                  test(data*)(
                     sample[DraftSingleMixedUseDisposalReturn].copy(
                       triageAnswers =
                         sample[CompleteSingleDisposalTriageAnswers].copy(individualUserType = individualUserType),
@@ -1485,7 +1482,7 @@ class MixedUsePropertyDetailsControllerSpec
             scenario =>
               withClue(s"For $scenario: ") {
                 val data = scenario.formData
-                test(data: _*)(
+                test(data*)(
                   sample[DraftSingleMixedUseDisposalReturn].copy(
                     triageAnswers = sample[CompleteSingleDisposalTriageAnswers]
                       .copy(individualUserType = Some(PersonalRepresentativeInPeriodOfAdmin)),

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MultipleDisposalsPropertyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/MultipleDisposalsPropertyDetailsControllerSpec.scala
@@ -38,18 +38,18 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.{NonUkAdd
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Postcode}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, GGCredId, UUIDGenerator}
@@ -114,7 +114,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
       bind[UUIDGenerator].toInstance(mockUUIDGenerator)
     ) ::: super.overrideBindings
 
-  protected override lazy val controller: PropertyDetailsController = instanceOf[PropertyDetailsController]
+  protected override val controller: PropertyDetailsController = instanceOf[PropertyDetailsController]
 
   private lazy implicit val messagesApi: MessagesApi = controller.messagesApi
 
@@ -453,7 +453,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
       "redirect to the enter postcode page" when {
         "the user did not dispose of a non-residential property and" when {
           "the user has not started this section before" in {
-            forAll { assetTypes: List[AssetType] =>
+            forAll { (assetTypes: List[AssetType]) =>
               whenever(
                 assetTypes.contains(AssetType.Residential) ||
                   assetTypes.toSet === Set(
@@ -478,7 +478,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           }
 
           "the user has started but not completed this section" in {
-            forAll { assetTypes: List[AssetType] =>
+            forAll { (assetTypes: List[AssetType]) =>
               whenever(
                 assetTypes.contains(AssetType.Residential) ||
                   assetTypes.toSet === Set(
@@ -605,7 +605,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
     "handling submits on the has a uk postcode page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.multipleDisposalsHasUkPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like amendReturnToFillingOutReturnSpecBehaviour(
@@ -705,7 +705,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.checkUPRNSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like amendReturnToFillingOutReturnSpecBehaviour(
@@ -826,7 +826,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
     "handling submits on the enter UPRN page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.multipleDisposalsEnterLandUprnSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def formData(ukAddress: UkAddress): List[(String, String)] =
@@ -874,7 +874,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey("enterUPRN.title"),
             { doc =>
               val errors = doc.select("[data-spec='errorSummaryDisplay'] ul").first()
@@ -965,7 +965,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(newAddress): _*),
+            performAction(formData(newAddress)*),
             routes.PropertyDetailsController.checkYourAnswers()
           )
         }
@@ -1006,7 +1006,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             mockStoreDraftReturn(newJourney)(Left(Error("")))
           }
 
-          checkIsTechnicalErrorPage(performAction(formData(newAddress): _*))
+          checkIsTechnicalErrorPage(performAction(formData(newAddress)*))
         }
 
         "there is an error updating the session" in {
@@ -1023,7 +1023,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             )(Left(Error("")))
           }
 
-          checkIsTechnicalErrorPage(performAction(formData(newAddress): _*))
+          checkIsTechnicalErrorPage(performAction(formData(newAddress)*))
         }
       }
     }
@@ -1045,7 +1045,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
     "handling submitted addresses from enter UK address page" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -1079,7 +1079,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
     "handling submitted postcodes and filters" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -1133,7 +1133,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
     "handling submitted selected addresses" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.selectAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -1479,7 +1479,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.disposalDateSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       def formData(d: LocalDate): List[(String, String)] =
@@ -1582,7 +1582,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(disposalDate.value): _*),
+            performAction(formData(disposalDate.value)*),
             routes.PropertyDetailsController.checkYourAnswers()
           )
         }
@@ -1632,14 +1632,14 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
                 .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey,
-                args: _*
+                args*
               ),
             BAD_REQUEST,
             messageRegexPrefix
@@ -1781,7 +1781,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             )
 
             test(
-              performAction(formData(updatedDisposalDate.value): _*),
+              performAction(formData(updatedDisposalDate.value)*),
               oldDraftReturn,
               updatedDraftReturn,
               isAmend = false
@@ -1816,7 +1816,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             )
 
             test(
-              performAction(formData(updatedDisposalDate.value): _*),
+              performAction(formData(updatedDisposalDate.value)*),
               oldDraftReturn,
               updatedDraftReturn,
               isAmend = false
@@ -1857,7 +1857,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
               )
 
               test(
-                performAction(formData(disposalDate.value): _*),
+                performAction(formData(disposalDate.value)*),
                 oldDraftReturn,
                 updatedDraftReturn,
                 isAmend = true
@@ -2131,7 +2131,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.disposalPriceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -2200,7 +2200,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             messageFromMessageKey(s"$key.title"),
             doc =>
               doc
@@ -2216,7 +2216,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           amountOfMoneyErrorScenarios(key).foreach { scenario =>
             withClue(s"For $scenario: ") {
               val data = scenario.formData
-              test(data: _*)(scenario.expectedErrorMessageKey)
+              test(data*)(scenario.expectedErrorMessageKey)
             }
           }
         }
@@ -2731,7 +2731,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.acquisitionPriceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -2796,7 +2796,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             expectedTitle,
             doc =>
               doc
@@ -2807,11 +2807,11 @@ class MultipleDisposalsPropertyDetailsControllerSpec
         }
 
         "the data is invalid" in {
-          forAll { individualUserType: Option[IndividualUserType] =>
+          forAll { (individualUserType: Option[IndividualUserType]) =>
             whenever(!individualUserType.contains(PersonalRepresentativeInPeriodOfAdmin)) {
               amountOfMoneyErrorScenarios(key).foreach { scenario =>
                 withClue(s"For $scenario: ") {
-                  test(scenario.formData: _*)(
+                  test(scenario.formData*)(
                     sample[DraftMultipleDisposalsReturn].copy(
                       triageAnswers = sample[CompleteMultipleDisposalsTriageAnswers].copy(individualUserType = None),
                       examplePropertyDetailsAnswers = Some(
@@ -2834,7 +2834,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
             scenario =>
               withClue(s"For $scenario: ") {
                 val data = scenario.formData
-                test(data: _*)(
+                test(data*)(
                   sample[DraftMultipleDisposalsReturn].copy(
                     triageAnswers = sample[CompleteMultipleDisposalsTriageAnswers]
                       .copy(individualUserType = Some(PersonalRepresentativeInPeriodOfAdmin)),
@@ -3303,7 +3303,7 @@ class MultipleDisposalsPropertyDetailsControllerSpec
   ): Unit =
     "redirect to the check your answers page" when {
       "the asset types being disposed of do not require us to ask if a postcode exists" in {
-        forAll { assetTypes: List[AssetType] =>
+        forAll { (assetTypes: List[AssetType]) =>
           whenever(
             assetTypes.contains(AssetType.Residential) ||
               assetTypes.toSet === Set(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/SingleDisposalPropertyDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/address/SingleDisposalPropertyDetailsControllerSpec.scala
@@ -35,14 +35,14 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.{ReturnsServ
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, PreviousReturnData, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.{NonUkAddress, UkAddress}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Postcode}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{GGCredId, UUIDGenerator}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.Self
@@ -90,7 +90,7 @@ class SingleDisposalPropertyDetailsControllerSpec
       bind[UUIDGenerator].toInstance(mockUUIDGenerator)
     ) ::: super.overrideBindings
 
-  protected override lazy val controller: PropertyDetailsController = instanceOf[PropertyDetailsController]
+  protected override val controller: PropertyDetailsController = instanceOf[PropertyDetailsController]
 
   lazy implicit val messagesApi: MessagesApi = controller.messagesApi
 
@@ -164,7 +164,7 @@ class SingleDisposalPropertyDetailsControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -202,7 +202,7 @@ class SingleDisposalPropertyDetailsControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -258,7 +258,7 @@ class SingleDisposalPropertyDetailsControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.selectAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -490,7 +490,7 @@ class SingleDisposalPropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.singleDisposalHasUkPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like amendReturnToFillingOutReturnSpecBehaviour(
@@ -596,7 +596,7 @@ class SingleDisposalPropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.checkUPRNSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like amendReturnToFillingOutReturnSpecBehaviour(
@@ -719,7 +719,7 @@ class SingleDisposalPropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.singleDisposalEnterLandUprnSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def formData(ukAddress: UkAddress): List[(String, String)] =
@@ -779,7 +779,7 @@ class SingleDisposalPropertyDetailsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey("enterUPRN.title"),
             { doc =>
               val errors = doc.select("[data-spec='errorSummaryDisplay'] ul").first()
@@ -869,7 +869,7 @@ class SingleDisposalPropertyDetailsControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(newAddress): _*),
+            performAction(formData(newAddress)*),
             routes.PropertyDetailsController.checkYourAnswers()
           )
         }
@@ -911,7 +911,7 @@ class SingleDisposalPropertyDetailsControllerSpec
             mockStoreDraftReturn(newJourney)(Left(Error("")))
           }
 
-          checkIsTechnicalErrorPage(performAction(formData(newAddress): _*))
+          checkIsTechnicalErrorPage(performAction(formData(newAddress)*))
         }
 
         "there is an error updating the session" in {
@@ -929,7 +929,7 @@ class SingleDisposalPropertyDetailsControllerSpec
             )(Left(Error("")))
           }
 
-          checkIsTechnicalErrorPage(performAction(formData(newAddress): _*))
+          checkIsTechnicalErrorPage(performAction(formData(newAddress)*))
         }
 
       }
@@ -1008,7 +1008,7 @@ class SingleDisposalPropertyDetailsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.noUPRNEnterAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def formData(ukAddress: UkAddress): List[(String, String)] =
@@ -1071,7 +1071,7 @@ class SingleDisposalPropertyDetailsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey("noUPRN.title"),
             { doc =>
               val errors = doc.select("[data-spec='errorSummaryDisplay'] ul").first()
@@ -1160,7 +1160,7 @@ class SingleDisposalPropertyDetailsControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(newAddress): _*),
+            performAction(formData(newAddress)*),
             routes.PropertyDetailsController.checkYourAnswers()
           )
         }
@@ -1202,7 +1202,7 @@ class SingleDisposalPropertyDetailsControllerSpec
             mockStoreDraftReturn(newJourney)(Left(Error("")))
           }
 
-          checkIsTechnicalErrorPage(performAction(formData(newAddress): _*))
+          checkIsTechnicalErrorPage(performAction(formData(newAddress)*))
         }
 
         "there is an error updating the session" in {
@@ -1220,7 +1220,7 @@ class SingleDisposalPropertyDetailsControllerSpec
             )(Left(Error("")))
           }
 
-          checkIsTechnicalErrorPage(performAction(formData(newAddress): _*))
+          checkIsTechnicalErrorPage(performAction(formData(newAddress)*))
         }
 
       }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/amend/AmendReturnControllerSpec.scala
@@ -35,9 +35,9 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, Contro
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.completeSingleDisposalReturnGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, CgtReference, UUIDGenerator}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
@@ -82,7 +82,7 @@ class AmendReturnControllerSpec
         _: ExecutionContext,
         _: HeaderCarrier,
         _: Writes[CancelAmendReturn],
-        _: Request[_]
+        _: Request[?]
       ))
       .expects("CancelAmendReturn", auditEvent, "cancel-amend-return", *, *, *, *)
       .returning(())
@@ -187,7 +187,7 @@ class AmendReturnControllerSpec
     "handling submits on the confirm cancellation page" must {
 
       def performAction(formData: (String, String)*)(back: String): Future[Result] =
-        controller.confirmCancelSubmit(back)(FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST"))
+        controller.confirmCancelSubmit(back)(FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST"))
 
       behave like redirectToStartWhenInvalidJourney(
         () => performAction()(AmendReturnController.ConfirmCancelBackLocations.checkAnswers),
@@ -228,7 +228,7 @@ class AmendReturnControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(data: _*)(AmendReturnController.ConfirmCancelBackLocations.checkAnswers),
+            performAction(data*)(AmendReturnController.ConfirmCancelBackLocations.checkAnswers),
             messageFromMessageKey("confirmCancelAmendReturn.title"),
             { doc =>
               doc.select("#back, .govuk-back-link").attr("href") shouldBe routes.AmendReturnController

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/disposaldetails/DisposalDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/disposaldetails/DisposalDetailsControllerSpec.scala
@@ -36,18 +36,18 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOut
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Country
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.MoneyUtils.formatAmountOfMoneyWithPoundSign
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalMethodGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, UUIDGenerator}
@@ -282,7 +282,7 @@ class DisposalDetailsControllerSpec
   val acceptedIndividualUserType: Gen[IndividualUserType] =
     individualUserTypeGen.filter {
       case Self | Capacitor | PersonalRepresentative | PersonalRepresentativeInPeriodOfAdmin => true
-      case _                                                                                 => false
+      case null                                                                              => false
     }
 
   "DisposalDetailsController" when {
@@ -407,7 +407,7 @@ class DisposalDetailsControllerSpec
 
       def performAction(data: Seq[(String, String)]): Future[Result] =
         controller.howMuchDidYouOwnSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -826,7 +826,7 @@ class DisposalDetailsControllerSpec
                 disposalMethod: DisposalMethod,
                 individualUserType: IndividualUserType
               ) =>
-                forAll { c: CompleteDisposalDetailsAnswers =>
+                forAll { (c: CompleteDisposalDetailsAnswers) =>
                   val currentAnswers                  =
                     c.copy(shareOfProperty = ShareOfProperty.Full)
                   val percentage                      = 40.23
@@ -1028,7 +1028,7 @@ class DisposalDetailsControllerSpec
         individualUserType: IndividualUserType,
         userType: UserType
       ): Seq[(DisposalMethod, ShareOfProperty, String)] = {
-        val userMsgKey = userMessageKey(individualUserType, userType)
+        val userMsgKey                                                            = userMessageKey(individualUserType, userType)
         def row(disposalMethod: DisposalMethod, shareOfProperty: ShareOfProperty) = {
           val expectedMessage = (disposalMethod, individualUserType, userType) match {
             case (_, Capacitor | PersonalRepresentative, _)                             => "disposalPrice.1.title"
@@ -1195,7 +1195,7 @@ class DisposalDetailsControllerSpec
 
       def performAction(data: Seq[(String, String)]): Future[Result] =
         controller.whatWasDisposalPriceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -1300,7 +1300,7 @@ class DisposalDetailsControllerSpec
                 errorContext = Some(s"$key$userKey$disposalMethodKey")
               ).foreach { scenario =>
                 withClue(s"For $scenario: ") {
-                  test(scenario.formData: _*)(scenario.expectedErrorMessageKey)(
+                  test(scenario.formData*)(scenario.expectedErrorMessageKey)(
                     disposalMethod,
                     userType,
                     individualUserType
@@ -1834,7 +1834,7 @@ class DisposalDetailsControllerSpec
 
       def performAction(data: Seq[(String, String)]): Future[Result] =
         controller.whatWasDisposalPriceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -1933,7 +1933,7 @@ class DisposalDetailsControllerSpec
                 errorContext = Some(s"$key$userKey.indirect$disposalMethodKey")
               ).foreach { scenario =>
                 withClue(s"For $scenario: ") {
-                  test(scenario.formData: _*)(scenario.expectedErrorMessageKey)(
+                  test(scenario.formData*)(scenario.expectedErrorMessageKey)(
                     disposalMethod,
                     userType,
                     individualUserType
@@ -2334,7 +2334,7 @@ class DisposalDetailsControllerSpec
           }
           (disposalMethod, shareOfProperty, expectedMessage)
         }
-        val userKey = userMessageKey(individualUserType, userType)
+        val userKey                                                               = userMessageKey(individualUserType, userType)
         List(
           (DisposalMethod.Sold, ShareOfProperty.Full, s"disposalFees$userKey.title"),
           (DisposalMethod.Gifted, ShareOfProperty.Full, s"disposalFees$userKey.title"),
@@ -2517,7 +2517,7 @@ class DisposalDetailsControllerSpec
 
       def performAction(data: Seq[(String, String)]): Future[Result] =
         controller.whatWereDisposalFeesSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -2643,7 +2643,7 @@ class DisposalDetailsControllerSpec
                 errorContext = Some(s"disposalFees$userKey")
               ).foreach { scenario =>
                 withClue(s"For $scenario: ") {
-                  test(scenario.formData: _*)(scenario.expectedErrorMessageKey)(
+                  test(scenario.formData*)(scenario.expectedErrorMessageKey)(
                     disposalMethod,
                     userType,
                     individualUserType
@@ -3317,7 +3317,7 @@ class DisposalDetailsControllerSpec
                 userMessageKey(
                   individualUserType,
                   userType
-                ) //TODO - change when the CYA changes go in
+                ) // TODO - change when the CYA changes go in
               doc
                 .select("#propertyShare-question")
                 .text() shouldBe messageFromMessageKey(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/exemptionandlosses/ExemptionAndLossesControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/exemptionandlosses/ExemptionAndLossesControllerSpec.scala
@@ -38,18 +38,19 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Country
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.MoneyUtils.formatAmountOfMoneyWithPoundSign
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.{AmountInPence, MoneyUtils}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.AgentReferenceNumber
@@ -362,7 +363,7 @@ class ExemptionAndLossesControllerSpec
   val acceptedIndividualUserTypeGen: Gen[IndividualUserType] =
     individualUserTypeGen.filter {
       case Self | Capacitor | PersonalRepresentative | PersonalRepresentativeInPeriodOfAdmin => true
-      case _                                                                                 => false
+      case null                                                                              => false
     }
 
   "ExemptionAndLossesController" when {
@@ -640,7 +641,7 @@ class ExemptionAndLossesControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.inYearLossesSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -692,7 +693,7 @@ class ExemptionAndLossesControllerSpec
             Some(individualUserType)
           )._1
 
-          testFormError(data: _*)(key, expectedErrorKey)(
+          testFormError(data*)(key, expectedErrorKey)(
             s"$key$userKey.title",
             disposalDate.taxYear.startDateInclusive.getYear.toString,
             disposalDate.taxYear.endDateExclusive.getYear.toString
@@ -730,7 +731,7 @@ class ExemptionAndLossesControllerSpec
                 withClue(s"For $scenario: ") {
                   val data    = (key -> "0") :: scenario.formData
                   val userKey = userMessageKey(individualUserType, userType)
-                  test(data: _*)(scenario.expectedErrorMessageKey)(
+                  test(data*)(scenario.expectedErrorMessageKey)(
                     userType,
                     individualUserType,
                     userKey
@@ -1217,7 +1218,7 @@ class ExemptionAndLossesControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.previousYearsLossesSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -1267,7 +1268,7 @@ class ExemptionAndLossesControllerSpec
             Some(individualUserType)
           )._1
 
-          testFormError(data: _*)(key, expectedErrorKey)(s"$key$userKey.title")(
+          testFormError(data*)(key, expectedErrorKey)(s"$key$userKey.title")(
             performAction,
             session
           )
@@ -1304,7 +1305,7 @@ class ExemptionAndLossesControllerSpec
                 withClue(s"For $scenario: ") {
                   val data    = (key -> "0") :: scenario.formData
                   val userKey = userMessageKey(individualUserType, userType)
-                  test(data: _*)(scenario.expectedErrorMessageKey)(
+                  test(data*)(scenario.expectedErrorMessageKey)(
                     userType,
                     individualUserType,
                     userKey
@@ -1910,7 +1911,7 @@ class ExemptionAndLossesControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.annualExemptAmountSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       val maximumAnnualExemptAmount = AmountInPence(10000L)
@@ -1996,7 +1997,7 @@ class ExemptionAndLossesControllerSpec
             Some(individualUserType)
           )._1
 
-          testFormError(data: _*)(
+          testFormError(data*)(
             key,
             expectedErrorKey,
             MoneyUtils.formatAmountOfMoneyWithoutPoundSign(
@@ -2014,7 +2015,7 @@ class ExemptionAndLossesControllerSpec
                 errorContext = Some(s"$key$userKey")
               ).foreach { scenario =>
                 withClue(s"For $scenario: ") {
-                  test(scenario.formData: _*)(scenario.expectedErrorMessageKey)(
+                  test(scenario.formData*)(scenario.expectedErrorMessageKey)(
                     userType,
                     individualUserType,
                     userKey
@@ -2561,13 +2562,13 @@ class ExemptionAndLossesControllerSpec
 
     checkPageIsDisplayed(
       performAction(data),
-      messageFromMessageKey(pageTitleKey, titleArgs: _*),
+      messageFromMessageKey(pageTitleKey, titleArgs*),
       { doc =>
         doc
           .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
-          errorArgs: _*
+          errorArgs*
         )
 
         doc.title() should startWith("Error:")

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/gainorlossafterreliefs/FurtherReturnCalculationEligibilityUtilSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/gainorlossafterreliefs/FurtherReturnCalculationEligibilityUtilSpec.scala
@@ -32,20 +32,20 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.ReturnsServi
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, PreviousReturnData}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.ukAddressGen
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.{CompleteAcquisitionDetailsAnswers, IncompleteAcquisitionDetailsAnswers}
@@ -200,7 +200,7 @@ class FurtherReturnCalculationEligibilityUtilSpec
         sessionData: SessionData,
         expected: FurtherReturnCalculationEligibility
       )(service: FurtherReturnCalculationEligibilityUtil): Assertion = {
-        implicit val request: RequestWithSessionData[_] = requestWithSessionData(sessionData)
+        implicit val request: RequestWithSessionData[?] = requestWithSessionData(sessionData)
         await(service.isEligibleForFurtherReturnOrAmendCalculation(fillingOutReturn).value) shouldBe Right(expected)
       }
 
@@ -621,10 +621,10 @@ class FurtherReturnCalculationEligibilityUtilSpec
           service: FurtherReturnCalculationEligibilityUtilImpl
         ): Unit = {
           val sessionData                                 = SessionData.empty.copy(journeyStatus = Some(fillingOutReturn))
-          implicit val request: RequestWithSessionData[_] = requestWithSessionData(sessionData)
+          implicit val request: RequestWithSessionData[?] = requestWithSessionData(sessionData)
 
           val result = service.isEligibleForFurtherReturnOrAmendCalculation(fillingOutReturn)
-          await(result.value) shouldBe a[Left[_, _]]
+          await(result.value) shouldBe a[Left[?, ?]]
         }
 
         "the triage section isn't complete in a DraftSingleDisposalReturn" in new TestEnvironment() {
@@ -701,7 +701,7 @@ class FurtherReturnCalculationEligibilityUtilSpec
           }
 
           private val result = service.isEligibleForFurtherReturnOrAmendCalculation(fillingOutReturn)
-          await(result.value) shouldBe a[Left[_, _]]
+          await(result.value) shouldBe a[Left[?, ?]]
         }
 
         "there is an error updating the session" in new TestEnvironment() {
@@ -734,7 +734,7 @@ class FurtherReturnCalculationEligibilityUtilSpec
             )(Left(Error("")))
 
             val result = service.isEligibleForFurtherReturnOrAmendCalculation(fillingOutReturn)
-            await(result.value) shouldBe a[Left[_, _]]
+            await(result.value) shouldBe a[Left[?, ?]]
           }
 
         }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/gainorlossafterreliefs/GainOrLossAfterReliefsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/gainorlossafterreliefs/GainOrLossAfterReliefsControllerSpec.scala
@@ -37,17 +37,17 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.RetrievedUserType.Trust
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UserType.{Agent, Individual, Organisation}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Postcode}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.{AmountInPence, MoneyUtils}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.UUIDGenerator
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
@@ -63,7 +63,6 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, SessionData, User
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.SessionStore
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.FurtherReturnCalculationEligibility.{Eligible, Ineligible}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.{FurtherReturnCalculationEligibilityUtil, ReturnsService}
-import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 
@@ -93,7 +92,7 @@ class GainOrLossAfterReliefsControllerSpec
 
   implicit lazy val messagesApi: MessagesApi = controller.messagesApi
 
-  implicit val hc: HeaderCarrier = mock[HeaderCarrier]
+//  implicit val hc: HeaderCarrier = mock[HeaderCarrier]
 
   protected override val overrideBindings: List[GuiceableModule] = List[GuiceableModule](
     bind[AuthConnector].toInstance(mockAuthConnector),
@@ -1005,7 +1004,7 @@ class GainOrLossAfterReliefsControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.enterGainOrLossAfterReliefsSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -1038,7 +1037,7 @@ class GainOrLossAfterReliefsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(data: _*),
+            performAction(data*),
             messageFromMessageKey(pageTitleKey),
             doc =>
               doc
@@ -1071,7 +1070,7 @@ class GainOrLossAfterReliefsControllerSpec
                 withClue(s"For test case '$userKey' and scenario $scenario: ") {
                   val data = ("gainOrLossAfterReliefs" -> "0") :: scenario.formData
 
-                  testFormError(session._1, session._2, data: _*)(
+                  testFormError(session._1, session._2, data*)(
                     s"gainOrLossAfterReliefs$userKey.title",
                     scenario.expectedErrorMessageKey
                   )
@@ -1087,7 +1086,7 @@ class GainOrLossAfterReliefsControllerSpec
                 withClue(s"For test case '$userKey' and scenario $scenario: ") {
                   val data = ("gainOrLossAfterReliefs" -> "1") :: scenario.formData
 
-                  testFormError(session._1, session._2, data: _*)(
+                  testFormError(session._1, session._2, data*)(
                     s"gainOrLossAfterReliefs$userKey.title",
                     scenario.expectedErrorMessageKey
                   )
@@ -1185,7 +1184,7 @@ class GainOrLossAfterReliefsControllerSpec
             )(Right(()))
           }
           checkIsRedirect(
-            performAction(formData: _*),
+            performAction(formData*),
             routes.GainOrLossAfterReliefsController.checkYourAnswers()
           )
         }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/initialgainorloss/InitialGainOrLossControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/initialgainorloss/InitialGainOrLossControllerSpec.scala
@@ -34,12 +34,12 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.{ReturnsServ
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport, returns}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DraftSingleDisposalReturn
@@ -267,7 +267,7 @@ class InitialGainOrLossControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.submitInitialGainOrLoss()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -402,7 +402,7 @@ class InitialGainOrLossControllerSpec
                 .select("[data-spec='errorSummaryDisplay'] a")
                 .text() shouldBe messageFromMessageKey(
                 expectedErrorMessageKey,
-                errorArgs: _*
+                errorArgs*
               ),
             BAD_REQUEST
           )
@@ -416,7 +416,7 @@ class InitialGainOrLossControllerSpec
         )(
           expectedErrorKey: String
         ): Unit =
-          testFormError(fillingOutReturn, isAgent, data: _*)(
+          testFormError(fillingOutReturn, isAgent, data*)(
             expectedErrorKey
           )(s"initialGainOrLoss$userKey.title")(performAction)
 
@@ -442,7 +442,7 @@ class InitialGainOrLossControllerSpec
                   keyWithReturn._1,
                   keyWithReturn._2,
                   keyWithReturn._3,
-                  data: _*
+                  data*
                 )(scenario.expectedErrorMessageKey)
               }
             }
@@ -458,7 +458,7 @@ class InitialGainOrLossControllerSpec
                   keyWithReturn._1,
                   keyWithReturn._2,
                   keyWithReturn._3,
-                  data: _*
+                  data*
                 )(scenario.expectedErrorMessageKey)
               }
             }
@@ -483,7 +483,7 @@ class InitialGainOrLossControllerSpec
       "redirect to check your answers" when {
 
         "initial gain or loss has been entered correctly" in {
-          forAll(Gen.choose(10L, 100L).map(AmountInPence(_))) { amountInPence: AmountInPence =>
+          forAll(Gen.choose(10L, 100L).map(AmountInPence(_))) { (amountInPence: AmountInPence) =>
             val (session, journey, draftReturn) =
               sessionWithState(Some(AmountInPence(amountInPence.value - 1L)))
             val newDraftReturn                  = updateDraftReturn(draftReturn, amountInPence)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/reliefdetails/ReliefDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/reliefdetails/ReliefDetailsControllerSpec.scala
@@ -36,19 +36,19 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, Contro
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.MoneyUtils.formatAmountOfMoneyWithPoundSign
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
@@ -199,7 +199,7 @@ class ReliefDetailsControllerSpec
   val acceptedIndividualUserTypeGen: Gen[IndividualUserType] =
     individualUserTypeGen.filter {
       case Self | Capacitor | PersonalRepresentative | PersonalRepresentativeInPeriodOfAdmin => true
-      case _                                                                                 => false
+      case null                                                                              => false
     }
 
   val acceptedIndividualUserTypeForLettingsRelief: Gen[IndividualUserType] =
@@ -322,7 +322,7 @@ class ReliefDetailsControllerSpec
 
       def performAction(data: Seq[(String, String)]): Future[Result] =
         controller.privateResidentsReliefSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -391,7 +391,7 @@ class ReliefDetailsControllerSpec
               ).foreach { scenario =>
                 withClue(s"For $scenario: ") {
                   val data = (key -> "0") :: scenario.formData
-                  test(data: _*)(scenario.expectedErrorMessageKey)(
+                  test(data*)(scenario.expectedErrorMessageKey)(
                     userType,
                     individualUserType,
                     userKey
@@ -596,7 +596,7 @@ class ReliefDetailsControllerSpec
 
           "the private residence relief value changes" in {
 
-            forAll { ic: IncompleteReliefDetailsAnswers =>
+            forAll { (ic: IncompleteReliefDetailsAnswers) =>
               forAll(acceptedUserTypeGen, acceptedIndividualUserTypeGen) {
                 (userType: UserType, individualUserType: IndividualUserType) =>
                   val lettingRelief =
@@ -798,7 +798,7 @@ class ReliefDetailsControllerSpec
 
       def performAction(data: Seq[(String, String)]): Future[Result] =
         controller.lettingsReliefSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -849,7 +849,7 @@ class ReliefDetailsControllerSpec
               doc.select("legend").text()                              shouldBe messageFromMessageKey(s"$key$userKey.title")
               doc.select("[data-spec='errorSummaryDisplay'] a").text() shouldBe Messages(
                 expectedErrorMessageKey,
-                args: _*
+                args*
               )
             },
             BAD_REQUEST
@@ -863,7 +863,7 @@ class ReliefDetailsControllerSpec
               amountOfMoneyErrorScenarios(valueKey).foreach { scenario =>
                 withClue(s"For $scenario: ") {
                   val data = (key -> "0") :: scenario.formData
-                  test(data: _*)(scenario.expectedErrorMessageKey, Nil)(
+                  test(data*)(scenario.expectedErrorMessageKey, Nil)(
                     userType,
                     individualUserType,
                     userKey
@@ -1058,7 +1058,7 @@ class ReliefDetailsControllerSpec
 
         "the user has answered all of the relief details questions " +
           "and the draft return and session data has been successfully updated" in {
-            forAll { c: CompleteReliefDetailsAnswers =>
+            forAll { (c: CompleteReliefDetailsAnswers) =>
               val currentAnswers    =
                 c.copy(
                   privateResidentsRelief = AmountInPence(Long.MaxValue),
@@ -1338,7 +1338,7 @@ class ReliefDetailsControllerSpec
 
       def performAction(data: Seq[(String, String)]): Future[Result] =
         controller.otherReliefsSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -1396,7 +1396,7 @@ class ReliefDetailsControllerSpec
                 withClue(s"For $scenario: ") {
                   val data =
                     (key -> "0") :: (nameKey -> "ReliefsName") :: scenario.formData
-                  test(data: _*)(scenario.expectedErrorMessageKey)(
+                  test(data*)(scenario.expectedErrorMessageKey)(
                     userType,
                     individualUserType,
                     userKey
@@ -1684,7 +1684,7 @@ class ReliefDetailsControllerSpec
 
         "the user has answered all of the relief details questions " +
           "and the draft return and session data has been successfully updated" in {
-            forAll { c: CompleteReliefDetailsAnswers =>
+            forAll { (c: CompleteReliefDetailsAnswers) =>
               val otherReliefs    =
                 OtherReliefs("ReliefName1", AmountInPence.fromPounds(1d))
               val newOtherReliefs =
@@ -2103,7 +2103,7 @@ class ReliefDetailsControllerSpec
         }
 
         "the user has already answered all the questions" in {
-          forAll { completeAnswers: CompleteReliefDetailsAnswers =>
+          forAll { (completeAnswers: CompleteReliefDetailsAnswers) =>
             forAll(acceptedUserTypeGen, acceptedIndividualUserTypeGen) {
               (userType: UserType, individualUserType: IndividualUserType) =>
                 inSequence {

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/ChangeRepresenteeContactAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/ChangeRepresenteeContactAddressControllerSpec.scala
@@ -28,10 +28,10 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.RedirectT
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.ReturnsServiceSupport
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingNewDraftReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.{CompleteRepresenteeAnswers, IncompleteRepresenteeAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, JourneyStatus, UserType}
@@ -53,7 +53,7 @@ trait ChangeRepresenteeContactAddressControllerSpec
       bind[ReturnsService].toInstance(mockReturnsService)
     ) ::: super.overrideBindings
 
-  protected override lazy val controller: ChangeRepresenteeContactAddressController =
+  protected override val controller: ChangeRepresenteeContactAddressController =
     instanceOf[ChangeRepresenteeContactAddressController]
 
   lazy implicit val messagesApi: MessagesApi = controller.messagesApi
@@ -176,7 +176,7 @@ trait ChangeRepresenteeContactAddressControllerSpec
     "handling requests to submit the is UK page" must {
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.isUkSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -206,7 +206,7 @@ trait ChangeRepresenteeContactAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -229,7 +229,7 @@ trait ChangeRepresenteeContactAddressControllerSpec
     "handling requests to submit the enter non UK address page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.enterNonUkAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -252,7 +252,7 @@ trait ChangeRepresenteeContactAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.enterPostcodeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))
@@ -281,7 +281,7 @@ trait ChangeRepresenteeContactAddressControllerSpec
 
       def performAction(formData: Seq[(String, String)]): Future[Result] =
         controller.selectAddressSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction(Seq.empty))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/ChangeRepresenteeEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/representee/ChangeRepresenteeEmailControllerSpec.scala
@@ -31,10 +31,10 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.ReturnsServi
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingNewDraftReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.Email
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailJourneyType.Returns.ChangingRepresenteeEmail
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.UUIDGenerator
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.{CompleteRepresenteeAnswers, IncompleteRepresenteeAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
@@ -63,8 +63,7 @@ trait ChangeRepresenteeEmailControllerSpec
 
   val mockUpdateEmail: Option[(ChangingRepresenteeEmail, ChangingRepresenteeEmail, Either[Error, Unit]) => Unit]
 
-  override lazy val controller: ChangeRepresenteeEmailController =
-    instanceOf[ChangeRepresenteeEmailController]
+  override lazy val controller: ChangeRepresenteeEmailController = instanceOf[ChangeRepresenteeEmailController]
 
   protected override val overrideBindings: List[GuiceableModule] =
     List[GuiceableModule](
@@ -96,7 +95,7 @@ trait ChangeRepresenteeEmailControllerSpec
     )
   }
 
-  implicit lazy val messagesApi: MessagesApi = controller.messagesApi
+  implicit val messagesApi: MessagesApi = controller.messagesApi
 
   protected def updateAnswers(
     answers: RepresenteeAnswers,
@@ -185,7 +184,7 @@ trait ChangeRepresenteeEmailControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.enterEmailSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withCSRFToken.withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withCSRFToken.withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/supportingevidence/SupportingEvidenceControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/supportingevidence/SupportingEvidenceControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.supportingevidence
 import cats.data.EitherT
-import cats.instances.future._
+import cats.instances.future.*
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.http.Status.BAD_REQUEST
 import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
@@ -24,17 +24,17 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
 import play.api.mvc.{Call, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.RedirectToStartBehaviour
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.{ReturnsServiceSupport, StartingToAmendToFillingOutReturnSpecBehaviour}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport, returns}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, StartingToAmendReturn}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.UUIDGenerator
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SupportingEvidenceAnswers.{CompleteSupportingEvidenceAnswers, IncompleteSupportingEvidenceAnswers, SupportingEvidence}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{DraftMultipleDisposalsReturn, DraftSingleDisposalReturn, SupportingEvidenceAnswers}
@@ -169,13 +169,13 @@ class SupportingEvidenceControllerSpec
     }
     checkPageIsDisplayed(
       performAction(data),
-      messageFromMessageKey(pageTitleKey, titleArgs: _*),
+      messageFromMessageKey(pageTitleKey, titleArgs*),
       { doc =>
         doc
           .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
-          errorArgs: _*
+          errorArgs*
         )
         doc.title() should startWith("Error:")
       },
@@ -269,7 +269,7 @@ class SupportingEvidenceControllerSpec
 
       def performAction(data: (String, String)*): Future[Result] =
         controller.doYouWantToUploadSupportingEvidenceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like amendReturnToFillingOutReturnSpecBehaviour(
@@ -336,7 +336,7 @@ class SupportingEvidenceControllerSpec
         )._1
 
         def test(data: (String, String)*)(expectedErrorMessageKey: String): Unit =
-          testFormError(data: _*)(expectedErrorMessageKey)(
+          testFormError(data*)(expectedErrorMessageKey)(
             "supporting-evidence.do-you-want-to-upload.title"
           )(
             performAction,
@@ -1250,7 +1250,7 @@ class SupportingEvidenceControllerSpec
           val updatedUpscanSuccess =
             upscanSuccess.copy(uploadDetails = Map("fileName" -> supportingEvidence.fileName))
 
-          val upscanUpload         =
+          val upscanUpload =
             sample[UpscanUpload].copy(
               uploadReference = uploadReference,
               upscanCallBack = Some(updatedUpscanSuccess)
@@ -1392,7 +1392,7 @@ class SupportingEvidenceControllerSpec
           val updatedUpscanSuccess =
             upscanSuccess.copy(uploadDetails = Map("fileName" -> supportingEvidence.fileName))
 
-          val upscanUpload         =
+          val upscanUpload =
             sample[UpscanUpload].copy(
               uploadReference = uploadReference,
               upscanCallBack = Some(updatedUpscanSuccess)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/CommonTriageQuestionsControllerSpec.scala
@@ -31,18 +31,18 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.{ReturnsServ
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport, returns}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, PreviousReturnData, StartingNewDraftReturn, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Country
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, UUIDGenerator}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
@@ -525,7 +525,7 @@ class CommonTriageQuestionsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.whoIsIndividualRepresentingSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -579,7 +579,7 @@ class CommonTriageQuestionsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey("who-are-you-reporting-for.title"),
             { doc =>
               doc
@@ -1183,7 +1183,7 @@ class CommonTriageQuestionsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.howManyPropertiesSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -1256,7 +1256,7 @@ class CommonTriageQuestionsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey("numberOfProperties.title"),
             { doc =>
               doc
@@ -1448,7 +1448,7 @@ class CommonTriageQuestionsControllerSpec
         "the user is filling in a return and" when {
 
           "they are on a multiple disposals journey and change the answer to one property" in {
-            forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+            forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
               val answers = c.copy(
                 individualUserType = Some(IndividualUserType.Self)
               )
@@ -1592,7 +1592,7 @@ class CommonTriageQuestionsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.howManyPropertiesFurtherReturnSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -1657,7 +1657,7 @@ class CommonTriageQuestionsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey("numberOfProperties.title"),
             { doc =>
               doc
@@ -1688,7 +1688,7 @@ class CommonTriageQuestionsControllerSpec
       "handle valid data" when {
 
         "the user is on an amend return journey" in {
-          forAll { c: SingleDisposalTriageAnswers =>
+          forAll { (c: SingleDisposalTriageAnswers) =>
             val answers = c.fold(
               _.copy(individualUserType = Some(IndividualUserType.Self)),
               _.copy(
@@ -2266,8 +2266,8 @@ class CommonTriageQuestionsControllerSpec
               { doc =>
                 doc.select("#back, .govuk-back-link").attr("href") shouldBe expectedBackLink.url
                 doc.select(".govuk-warning-text__text").text()     shouldBe s"""${messageFromMessageKey(
-                  "generic.warning"
-                )} ${messageFromMessageKey(expectedWarningKey)}"""
+                    "generic.warning"
+                  )} ${messageFromMessageKey(expectedWarningKey)}"""
               }
             )
 
@@ -2996,7 +2996,7 @@ class CommonTriageQuestionsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.amendsHaveYouAlreadySentSelfAssessmentSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -3048,7 +3048,7 @@ class CommonTriageQuestionsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(
               s"$key.title",
               startDateInclusive.getYear.toString,
@@ -3268,7 +3268,7 @@ class CommonTriageQuestionsControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.haveYouAlreadySentSelfAssessmentSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartWhenInvalidJourney(
@@ -3310,7 +3310,7 @@ class CommonTriageQuestionsControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey(
               s"$key.title",
               startDateInclusive.getYear.toString,

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/FurtherReturnGuidanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/FurtherReturnGuidanceControllerSpec.scala
@@ -27,13 +27,13 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.onboarding.RedirectToStartBehaviour
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport, returns}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, PreviousReturnData, StartingNewDraftReturn, StartingToAmendReturn}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.AgentReferenceNumber
@@ -208,7 +208,7 @@ class FurtherReturnGuidanceControllerSpec
   val acceptedIndividualUserTypeGen: Gen[IndividualUserType] =
     individualUserTypeGen.filter {
       case Self | Capacitor | PersonalRepresentative | PersonalRepresentativeInPeriodOfAdmin => true
-      case _                                                                                 => false
+      case null                                                                              => false
     }
 
   val acceptedUserTypeGen: Gen[UserType] = userTypeGen.filter {

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/MultipleDisposalsTriageControllerSpec.scala
@@ -36,19 +36,19 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.{ReturnsServ
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, DateErrorScenarios, SessionSupport}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, PreviousReturnData, StartingNewDraftReturn, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Country
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.{arb, sample}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, UUIDGenerator}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
@@ -256,7 +256,7 @@ class MultipleDisposalsTriageControllerSpec
           .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
-          errorArgs: _*
+          errorArgs*
         )
         doc.title() should startWith("Error:")
       },
@@ -265,7 +265,7 @@ class MultipleDisposalsTriageControllerSpec
   }
 
   private def mockGenerateUUID(uuid: UUID): Unit =
-    (mockUUIDGenerator.nextId _)
+    (() => mockUUIDGenerator.nextId())
       .expects()
       .returning(uuid)
 
@@ -330,7 +330,7 @@ class MultipleDisposalsTriageControllerSpec
               personalRepDisplay,
               capacitorDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user name ${displayType.name.fold(_ => "Trust name", _ => "Individual name")} ${displayType.getSubKey()} "
               ) {
@@ -374,7 +374,7 @@ class MultipleDisposalsTriageControllerSpec
               personalRepDisplay,
               capacitorDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user type ${displayType.getSubKey()} "
               ) {
@@ -535,7 +535,7 @@ class MultipleDisposalsTriageControllerSpec
     "handling submits on the how many disposals page" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.howManyDisposalsSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       val key = "multipleDisposalsNumberOfProperties"
@@ -717,7 +717,7 @@ class MultipleDisposalsTriageControllerSpec
 
       "display form error" when {
         def test(data: (String, String)*)(expectedErrorMessageKey: String): Unit =
-          testFormError(data: _*)(expectedErrorMessageKey)(s"$key.title")(
+          testFormError(data*)(expectedErrorMessageKey)(s"$key.title")(
             performAction
           )
 
@@ -846,7 +846,7 @@ class MultipleDisposalsTriageControllerSpec
               personalRepDisplay,
               capacitorDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
               ) {
@@ -875,7 +875,7 @@ class MultipleDisposalsTriageControllerSpec
               personalRepDisplay,
               capacitorDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
               ) {
@@ -918,7 +918,7 @@ class MultipleDisposalsTriageControllerSpec
               personalRepDisplay,
               capacitorDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
               ) {
@@ -945,7 +945,7 @@ class MultipleDisposalsTriageControllerSpec
     "handling submits on the were uk resident page" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.wereYouAUKResidentSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -1072,7 +1072,7 @@ class MultipleDisposalsTriageControllerSpec
         "the user has started a draft return and" when {
           "have completed the section and they enter a figure which is " +
             "different than one they have already entered" in {
-              forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+              forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
                 val answers                         = c.copy(
                   countryOfResidence = sample[Country],
                   taxYearExchanged = getTaxYearExchanged(Some(taxYear)),
@@ -1126,7 +1126,7 @@ class MultipleDisposalsTriageControllerSpec
             capacitorDisplay,
             personalRepDisplay,
             periodOfAdminDisplay
-          ).foreach { displayType: UserTypeDisplay =>
+          ).foreach { (displayType: UserTypeDisplay) =>
             withClue(
               s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
             ) {
@@ -1297,7 +1297,7 @@ class MultipleDisposalsTriageControllerSpec
     "handling submits on the were all properties residential page" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.wereAllPropertiesResidentialSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       val key = "multipleDisposalsWereAllPropertiesResidential"
@@ -1706,7 +1706,7 @@ class MultipleDisposalsTriageControllerSpec
     "handling submits on the tax year exchanged page" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.whenWereContractsExchangedSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       val cutoffTaxYearDate    = LocalDate.of(cutoffTaxYear, 4, 6)
@@ -2070,7 +2070,7 @@ class MultipleDisposalsTriageControllerSpec
                 startDateInclusive = LocalDate.of(currentTaxYear - 3, 4, 6),
                 endDateExclusive = LocalDate.of(currentTaxYear - 2, 4, 6)
               )
-              forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+              forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
                 val amendReturnData                 = sample[AmendReturnData]
                 val answers                         = c.copy(
                   individualUserType = Some(Self),
@@ -2376,7 +2376,7 @@ class MultipleDisposalsTriageControllerSpec
               capacitorDisplay,
               personalRepDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
               ) {
@@ -2412,7 +2412,7 @@ class MultipleDisposalsTriageControllerSpec
               personalRepDisplay,
               capacitorDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
               ) {
@@ -2489,7 +2489,7 @@ class MultipleDisposalsTriageControllerSpec
     "handling submits on the country of residence page" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.countryOfResidenceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -2590,7 +2590,7 @@ class MultipleDisposalsTriageControllerSpec
         "the user has started a draft return and" when {
           "have completed the section and they enter a country which is " +
             "different than one they have already entered" in {
-              forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+              forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
                 val answers = c.copy(countryOfResidence = Country("FI"))
 
                 val (session, journey, draftReturn) =
@@ -2621,7 +2621,7 @@ class MultipleDisposalsTriageControllerSpec
             }
 
           "the user is on an amend journey where the estimates answer should be preserved" in {
-            forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+            forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
               val answers = c.copy(countryOfResidence = Country("FI"))
 
               val (session, journey, draftReturn) =
@@ -2833,8 +2833,8 @@ class MultipleDisposalsTriageControllerSpec
                 "for",
                 "multipleDisposalsAssetTypeForNonUkResidents-3",
                 s"Residential Non-residential Mixed use ${messageFromMessageKey(
-                  s"multipleDisposalsAssetTypeForNonUkResidents${displayType.getSubKey(separatePeriodOfAdminKey = true)}.IndirectDisposal"
-                )}"
+                    s"multipleDisposalsAssetTypeForNonUkResidents${displayType.getSubKey(separatePeriodOfAdminKey = true)}.IndirectDisposal"
+                  )}"
               )
             )
           )
@@ -2848,7 +2848,7 @@ class MultipleDisposalsTriageControllerSpec
               capacitorDisplay,
               personalRepDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
               ) {
@@ -2877,7 +2877,7 @@ class MultipleDisposalsTriageControllerSpec
               personalRepDisplay,
               capacitorDisplay,
               periodOfAdminDisplay
-            ).foreach { displayType: UserTypeDisplay =>
+            ).foreach { (displayType: UserTypeDisplay) =>
               withClue(
                 s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
               ) {
@@ -2934,7 +2934,7 @@ class MultipleDisposalsTriageControllerSpec
     "handling submits on the asset type for non-uk residents page" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.assetTypeForNonUkResidentsSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -3098,7 +3098,7 @@ class MultipleDisposalsTriageControllerSpec
         "the user has started a draft return and" when {
           "have completed the section and they enter a figure which is " +
             "different than one they have already entered" in {
-              forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+              forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
                 val amendReturnData                 = sample[AmendReturnData]
                 val answers                         = c.copy(
                   countryOfResidence = sample[Country],
@@ -3184,7 +3184,7 @@ class MultipleDisposalsTriageControllerSpec
             capacitorDisplay,
             personalRepDisplay,
             periodOfAdminDisplay
-          ).foreach { displayType: UserTypeDisplay =>
+          ).foreach { (displayType: UserTypeDisplay) =>
             withClue(
               s"For user type ${displayType.getSubKey(separatePeriodOfAdminKey = true)}"
             ) {
@@ -3390,7 +3390,7 @@ class MultipleDisposalsTriageControllerSpec
     "handling submitted completion dates" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.completionDateSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def formData(d: LocalDate): List[(String, String)] =
@@ -3450,7 +3450,7 @@ class MultipleDisposalsTriageControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey("multipleDisposalsCompletionDate.title"),
             doc =>
               doc
@@ -3528,7 +3528,7 @@ class MultipleDisposalsTriageControllerSpec
           }
 
           checkIsTechnicalErrorPage(
-            performAction(formData(today): _*)
+            performAction(formData(today)*)
           )
         }
 
@@ -3569,7 +3569,7 @@ class MultipleDisposalsTriageControllerSpec
           }
 
           checkIsTechnicalErrorPage(
-            performAction(formData(newCompletionDate.value): _*)
+            performAction(formData(newCompletionDate.value)*)
           )
         }
       }
@@ -3636,13 +3636,13 @@ class MultipleDisposalsTriageControllerSpec
             }
 
             checkIsRedirect(
-              performAction(formData(newCompletionDate.value): _*),
+              performAction(formData(newCompletionDate.value)*),
               routes.MultipleDisposalsTriageController.checkYourAnswers()
             )
           }
 
           "the user has already answered the question" in {
-            forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+            forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
               val answers            = c.copy(
                 individualUserType = Some(Self),
                 completionDate = CompletionDate(today),
@@ -3671,7 +3671,7 @@ class MultipleDisposalsTriageControllerSpec
               }
 
               checkIsRedirect(
-                performAction(formData(newCompletionDate.value): _*),
+                performAction(formData(newCompletionDate.value)*),
                 routes.MultipleDisposalsTriageController.checkYourAnswers()
               )
             }
@@ -3717,7 +3717,7 @@ class MultipleDisposalsTriageControllerSpec
 
               checkIsRedirect(
                 performAction(
-                  formData(submittedDate): _*
+                  formData(submittedDate)*
                 ),
                 routes.MultipleDisposalsTriageController.checkYourAnswers()
               )
@@ -3747,7 +3747,7 @@ class MultipleDisposalsTriageControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(answers.completionDate.value): _*),
+            performAction(formData(answers.completionDate.value)*),
             routes.MultipleDisposalsTriageController.checkYourAnswers()
           )
         }
@@ -3810,7 +3810,7 @@ class MultipleDisposalsTriageControllerSpec
     "handling submitted disposal of shares date" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.disposalDateOfSharesSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def formData(d: LocalDate): List[(String, String)] =
@@ -3865,7 +3865,7 @@ class MultipleDisposalsTriageControllerSpec
           }
 
           checkPageIsDisplayed(
-            performAction(formData: _*),
+            performAction(formData*),
             messageFromMessageKey("sharesDisposalDate.title"),
             doc =>
               doc
@@ -3966,7 +3966,7 @@ class MultipleDisposalsTriageControllerSpec
           }
 
           checkIsTechnicalErrorPage(
-            performAction(formData(newCompletionDate.value): _*)
+            performAction(formData(newCompletionDate.value)*)
           )
         }
       }
@@ -4021,7 +4021,7 @@ class MultipleDisposalsTriageControllerSpec
 
           checkIsRedirect(
             performAction(
-              formData(submittedDate): _*
+              formData(submittedDate)*
             ),
             routes.MultipleDisposalsTriageController.checkYourAnswers()
           )
@@ -4124,7 +4124,7 @@ class MultipleDisposalsTriageControllerSpec
 
           checkIsRedirect(
             performAction(
-              formData(submittedDate): _*
+              formData(submittedDate)*
             ),
             routes.CommonTriageQuestionsController.amendReturnDisposalDateDifferentTaxYear()
           )
@@ -4187,7 +4187,7 @@ class MultipleDisposalsTriageControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(answers.completionDate.value): _*),
+            performAction(formData(answers.completionDate.value)*),
             routes.MultipleDisposalsTriageController.checkYourAnswers()
           )
         }
@@ -4355,7 +4355,7 @@ class MultipleDisposalsTriageControllerSpec
             List(AssetType.MixedUse, AssetType.IndirectDisposal)
           )
 
-          forAll { assetTypes: List[AssetType] =>
+          forAll { (assetTypes: List[AssetType]) =>
             whenever(
               !invalidAssetTypes
                 .contains(assetTypes.distinct) && assetTypes.nonEmpty
@@ -4908,7 +4908,7 @@ class MultipleDisposalsTriageControllerSpec
 
     checkPageIsDisplayed(
       performAction(),
-      messageFromMessageKey(expectedPageTitleMessageKey, titleMessageArgs: _*),
+      messageFromMessageKey(expectedPageTitleMessageKey, titleMessageArgs*),
       { doc =>
         doc.select("#back, .govuk-back-link").attr("href") shouldBe expectedBackLink.url
         doc
@@ -4951,7 +4951,7 @@ class MultipleDisposalsTriageControllerSpec
 
     checkPageIsDisplayed(
       performAction(),
-      messageFromMessageKey(expectedPageTitleMessageKey, titleMessageArgs: _*),
+      messageFromMessageKey(expectedPageTitleMessageKey, titleMessageArgs*),
       { doc =>
         doc.select("#back, .govuk-back-link").attr("href") shouldBe expectedBackLink.url
         val selector = doc.body().select(".govuk-label.govuk-radios__label").asScala.map(_.text()).toList

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageControllerSpec.scala
@@ -36,19 +36,19 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.{ReturnsServ
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.{AuthSupport, ControllerSpec, SessionSupport}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, PreviousReturnData, StartingNewDraftReturn, StartingToAmendReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Country
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.{arb, booleanGen, sample}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{AgentReferenceNumber, UUIDGenerator}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
@@ -173,7 +173,7 @@ class SingleDisposalsTriageControllerSpec
   }
 
   private def mockGetNextUUID(uuid: UUID) =
-    (mockUUIDGenerator.nextId _).expects().returning(uuid)
+    (() => mockUUIDGenerator.nextId()).expects().returning(uuid)
 
   private def mockGetTaxYear(
     date: LocalDate
@@ -360,7 +360,7 @@ class SingleDisposalsTriageControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.howDidYouDisposeOfPropertySubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -535,7 +535,7 @@ class SingleDisposalsTriageControllerSpec
             )
 
           "the section is complete" in {
-            forAll { completeAnswers: CompleteSingleDisposalTriageAnswers =>
+            forAll { (completeAnswers: CompleteSingleDisposalTriageAnswers) =>
               testSuccessfulUpdateFillingOutReturn(
                 performAction,
                 completeAnswers.copy(disposalMethod = DisposalMethod.Sold),
@@ -797,7 +797,7 @@ class SingleDisposalsTriageControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.wereYouAUKResidentSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -1029,7 +1029,7 @@ class SingleDisposalsTriageControllerSpec
         "the user is filling out a draft return and" when {
 
           "the section is complete" in {
-            forAll { completeAnswers: CompleteSingleDisposalTriageAnswers =>
+            forAll { (completeAnswers: CompleteSingleDisposalTriageAnswers) =>
               val newAnswers =
                 IncompleteSingleDisposalTriageAnswers(
                   completeAnswers.individualUserType,
@@ -1298,7 +1298,7 @@ class SingleDisposalsTriageControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.didYouDisposeOfAResidentialPropertySubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       val requiredPreviousAnswers =
@@ -1493,7 +1493,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           "the user has complete the section and has changed their answer from not in the uk to was in the uk" in {
-            forAll { completeAnswers: CompleteSingleDisposalTriageAnswers =>
+            forAll { (completeAnswers: CompleteSingleDisposalTriageAnswers) =>
               testSuccessfulUpdateFillingOutReturn(
                 performAction,
                 completeAnswers.copy(
@@ -1956,7 +1956,7 @@ class SingleDisposalsTriageControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.whenWasDisposalDateSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def formData(date: LocalDate): Seq[(String, String)] =
@@ -2039,7 +2039,7 @@ class SingleDisposalsTriageControllerSpec
             mockGetTaxYear(today)(Left(Error("")))
           }
 
-          checkIsTechnicalErrorPage(performAction(formData(today): _*))
+          checkIsTechnicalErrorPage(performAction(formData(today)*))
         }
 
       }
@@ -2291,7 +2291,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           "the section is complete" in {
-            forAll { c: CompleteSingleDisposalTriageAnswers =>
+            forAll { (c: CompleteSingleDisposalTriageAnswers) =>
               val completeJourney = c.copy(
                 individualUserType = Some(Self),
                 disposalDate = DisposalDate(today, taxYear),
@@ -2436,7 +2436,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(today): _*),
+            performAction(formData(today)*),
             routes.CommonTriageQuestionsController.amendReturnDisposalDateDifferentTaxYear()
           )
         }
@@ -2639,7 +2639,7 @@ class SingleDisposalsTriageControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.whenWasCompletionDateSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def formData(date: LocalDate) =
@@ -2989,7 +2989,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           "the section is complete" in {
-            forAll { c: CompleteSingleDisposalTriageAnswers =>
+            forAll { (c: CompleteSingleDisposalTriageAnswers) =>
               val completionDate  =
                 CompletionDate(disposalDate.value.plusDays(1L))
               val completeAnswers = c.copy(
@@ -3041,7 +3041,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(disposalDate.value): _*),
+            performAction(formData(disposalDate.value)*),
             routes.SingleDisposalsTriageController.checkYourAnswers()
           )
         }
@@ -3222,7 +3222,7 @@ class SingleDisposalsTriageControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.countryOfResidenceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -3421,7 +3421,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           "the user has complete the section and has changed their answer from not in the uk to was in the uk" in {
-            forAll { c: CompleteSingleDisposalTriageAnswers =>
+            forAll { (c: CompleteSingleDisposalTriageAnswers) =>
               val completeAnswers = c.copy(
                 countryOfResidence = Country("CC"),
                 disposalMethod = DisposalMethod.Sold
@@ -3446,7 +3446,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           "the user is on an amend journey where the estimates answer should be preserved" in {
-            forAll { c: CompleteSingleDisposalTriageAnswers =>
+            forAll { (c: CompleteSingleDisposalTriageAnswers) =>
               val completeAnswers = c.copy(
                 countryOfResidence = Country("CC"),
                 disposalMethod = DisposalMethod.Sold
@@ -3694,7 +3694,7 @@ class SingleDisposalsTriageControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.assetTypeForNonUkResidentsSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def updateDraftReturn(
@@ -4009,7 +4009,7 @@ class SingleDisposalsTriageControllerSpec
         "the user is filling out a draft return and" when {
 
           "the section is complete" in {
-            forAll { completeAnswers: CompleteSingleDisposalTriageAnswers =>
+            forAll { (completeAnswers: CompleteSingleDisposalTriageAnswers) =>
               testSuccessfulUpdateFillingOutReturn(
                 performAction,
                 completeAnswers.copy(
@@ -4341,7 +4341,7 @@ class SingleDisposalsTriageControllerSpec
 
       def performAction(formData: (String, String)*): Future[Result] =
         controller.disposalDateOfSharesSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       def formData(date: LocalDate): Seq[(String, String)] =
@@ -4424,7 +4424,7 @@ class SingleDisposalsTriageControllerSpec
             mockGetTaxYear(today)(Left(Error("")))
           }
 
-          checkIsTechnicalErrorPage(performAction(formData(today): _*))
+          checkIsTechnicalErrorPage(performAction(formData(today)*))
         }
 
       }
@@ -4614,7 +4614,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           "the section is complete" in {
-            forAll { c: CompleteSingleDisposalTriageAnswers =>
+            forAll { (c: CompleteSingleDisposalTriageAnswers) =>
               val completeJourney = c.copy(
                 individualUserType = Some(Self),
                 disposalDate = DisposalDate(today, taxYear),
@@ -4794,7 +4794,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           "the section is complete" in {
-            forAll { c: CompleteSingleDisposalTriageAnswers =>
+            forAll { (c: CompleteSingleDisposalTriageAnswers) =>
               val completeJourney = c.copy(
                 individualUserType = Some(Self),
                 disposalDate = DisposalDate(today, taxYear),
@@ -4856,7 +4856,7 @@ class SingleDisposalsTriageControllerSpec
           }
 
           checkIsRedirect(
-            performAction(formData(today): _*),
+            performAction(formData(today)*),
             routes.SingleDisposalsTriageController.checkYourAnswers()
           )
         }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/yeartodatelliability/YearToDateLiabilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/yeartodatelliability/YearToDateLiabilityControllerSpec.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.controllers.returns.yeartodatelliability
 
 import cats.data.EitherT
-import cats.instances.future._
-import cats.syntax.order._
+import cats.instances.future.*
+import cats.syntax.order.*
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -39,31 +39,32 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Country}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.MoneyUtils.formatAmountOfMoneyWithPoundSign
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.{AmountInPence, MoneyUtils}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalMethodGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalMethodGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExemptionsAndLossesAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.UserTypeGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.AgentReferenceNumber
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.{CompleteAcquisitionDetailsAnswers, IncompleteAcquisitionDetailsAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CalculatedTaxDue.GainCalculatedTaxDue
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.{CompleteMultipleDisposalsReturn, CompleteSingleDisposalReturn, CompleteSingleIndirectDisposalReturn, CompleteSingleMixedUseDisposalReturn}
@@ -75,10 +76,9 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ReliefDetailsAnsw
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.CompleteRepresenteeAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.{CompleteSingleDisposalTriageAnswers, IncompleteSingleDisposalTriageAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SupportingEvidenceAnswers.CompleteSupportingEvidenceAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.CalculatedYTDAnswers._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.CalculatedYTDAnswers.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.{CompleteNonCalculatedYTDAnswers, IncompleteNonCalculatedYTDAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.{CalculatedYTDAnswers, NonCalculatedYTDAnswers}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.UpscanCallBack.{UpscanFailure, UpscanSuccess}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.{UploadReference, UpscanUpload}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{CompleteReturnWithSummary, Error, SessionData, TaxYear, TimeUtils, UserType}
@@ -848,7 +848,7 @@ class YearToDateLiabilityControllerSpec
     "handling submitted answers to the estimated income page" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.estimatedIncomeSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -872,7 +872,7 @@ class YearToDateLiabilityControllerSpec
           AmountOfMoneyErrorScenarios
             .amountOfMoneyErrorScenarios("estimatedIncome")
             .foreach { scenario =>
-              testFormError(scenario.formData: _*)(
+              testFormError(scenario.formData*)(
                 scenario.expectedErrorMessageKey
               )("estimatedIncome.title")(
                 performAction
@@ -1257,7 +1257,7 @@ class YearToDateLiabilityControllerSpec
     "handling submitted answers to the personal allowance page" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.personalAllowanceSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -1348,7 +1348,7 @@ class YearToDateLiabilityControllerSpec
             )
             .foreach { scenario =>
               withClue(s"For $scenario: ") {
-                testFormError(scenario.formData: _*)(
+                testFormError(scenario.formData*)(
                   scenario.expectedErrorMessageKey,
                   args.getOrElse(scenario.expectedErrorMessageKey, Nil)
                 )(
@@ -1998,7 +1998,7 @@ class YearToDateLiabilityControllerSpec
     "handling submitted answers to the has estimated details page" when {
       def performAction(data: (String, String)*): Future[Result] =
         controller.hasEstimatedDetailsSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like markUnmetDependencyBehaviour(controller.hasEstimatedDetailsSubmit())
@@ -2059,7 +2059,7 @@ class YearToDateLiabilityControllerSpec
           )._1
 
           def test(data: (String, String)*)(expectedErrorMessageKey: String): Unit =
-            testFormError(data: _*)(expectedErrorMessageKey)(
+            testFormError(data*)(expectedErrorMessageKey)(
               "hasEstimatedDetails.title"
             )(performAction, currentSession)
 
@@ -2220,7 +2220,7 @@ class YearToDateLiabilityControllerSpec
           )._1
 
           def test(data: (String, String)*)(expectedErrorMessageKey: String): Unit =
-            testFormError(data: _*)(expectedErrorMessageKey)(
+            testFormError(data*)(expectedErrorMessageKey)(
               "hasEstimatedDetails.title"
             )(performAction, currentSession)
 
@@ -2810,7 +2810,7 @@ class YearToDateLiabilityControllerSpec
     "handling submitted answers to the tax due page for a calculated journey" must {
       def performAction(data: (String, String)*): Future[Result] =
         controller.taxDueSubmit()(
-          FakeRequest().withFormUrlEncodedBody(data: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(data*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -2963,7 +2963,7 @@ class YearToDateLiabilityControllerSpec
             .foreach { scenario =>
               withClue(s"For $scenario: ") {
                 val formData = ("agreeWithCalculation" -> "1") :: scenario.formData
-                testFormError(formData: _*)(
+                testFormError(formData*)(
                   scenario.expectedErrorMessageKey
                 )("taxDue.title")(
                   performAction,
@@ -3339,7 +3339,7 @@ class YearToDateLiabilityControllerSpec
 
         "show the page" when {
           "the section is complete" in {
-            forAll { completeAnswers: CompleteCalculatedYTDAnswers =>
+            forAll { (completeAnswers: CompleteCalculatedYTDAnswers) =>
               inSequence {
                 mockAuthWithNoRetrievals()
                 mockGetSession(
@@ -3367,7 +3367,7 @@ class YearToDateLiabilityControllerSpec
           }
 
           "the user is on an amend journey where the estimates question should be hidden" in {
-            forAll { completeAnswers: CompleteCalculatedYTDAnswers =>
+            forAll { (completeAnswers: CompleteCalculatedYTDAnswers) =>
               inSequence {
                 mockAuthWithNoRetrievals()
                 mockGetSession(
@@ -3410,7 +3410,7 @@ class YearToDateLiabilityControllerSpec
           }
 
           "the user is period of admin on an amend journey where the income and allowance question should be hidden" in {
-            forAll { completeAnswers: CompleteCalculatedYTDAnswers =>
+            forAll { (completeAnswers: CompleteCalculatedYTDAnswers) =>
               inSequence {
                 mockAuthWithNoRetrievals()
                 mockGetSession(
@@ -3814,7 +3814,7 @@ class YearToDateLiabilityControllerSpec
           }
 
           "the user is on an amend journey where the estimates question should be hidden" in {
-            forAll { completeAnswers: CompleteNonCalculatedYTDAnswers =>
+            forAll { (completeAnswers: CompleteNonCalculatedYTDAnswers) =>
               val (session, fillingOutReturn, _) =
                 sessionWithSingleDisposalState(
                   Some(completeAnswers),
@@ -4886,7 +4886,7 @@ class YearToDateLiabilityControllerSpec
     "handling submits on the taxable gain or net loss page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.taxableGainOrLossSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -4930,7 +4930,7 @@ class YearToDateLiabilityControllerSpec
           )._1
 
           def test(data: (String, String)*)(expectedErrorKey: String): Unit =
-            testFormError(data: _*)(
+            testFormError(data*)(
               expectedErrorKey
             )("taxableGainOrLoss.pageTitle")(performAction, currentSession)
 
@@ -4944,7 +4944,7 @@ class YearToDateLiabilityControllerSpec
               .foreach { scenario =>
                 withClue(s"For $scenario: ") {
                   val data = ("taxableGainOrLoss" -> "0") :: scenario.formData
-                  test(data: _*)(scenario.expectedErrorMessageKey)
+                  test(data*)(scenario.expectedErrorMessageKey)
                 }
               }
           }
@@ -4962,7 +4962,7 @@ class YearToDateLiabilityControllerSpec
               .foreach { scenario =>
                 withClue(s"For $scenario: ") {
                   val data = ("taxableGainOrLoss" -> "1") :: scenario.formData
-                  test(data: _*)(scenario.expectedErrorMessageKey)
+                  test(data*)(scenario.expectedErrorMessageKey)
                 }
               }
           }
@@ -4979,7 +4979,7 @@ class YearToDateLiabilityControllerSpec
           def test(
             state: (SessionData, FillingOutReturn)
           )(data: (String, String)*)(expectedTitleKey: String, expectedErrorKey: String): Unit =
-            testFormError(data: _*)(
+            testFormError(data*)(
               expectedErrorKey
             )(expectedTitleKey)(
               performAction,
@@ -5039,7 +5039,7 @@ class YearToDateLiabilityControllerSpec
                 .foreach { scenario =>
                   withClue(s"For user key '$userKey' and $scenario: ") {
                     val data = ("taxableGainOrLoss" -> "0") :: scenario.formData
-                    test(session)(data: _*)(
+                    test(session)(data*)(
                       s"taxableGainOrLoss$userKey.furtherReturn.title",
                       scenario.expectedErrorMessageKey
                     )
@@ -5069,7 +5069,7 @@ class YearToDateLiabilityControllerSpec
                 .foreach { scenario =>
                   withClue(s"For user key '$userKey' and $scenario: ") {
                     val data = ("taxableGainOrLoss" -> "1") :: scenario.formData
-                    test(session)(data: _*)(
+                    test(session)(data*)(
                       s"taxableGainOrLoss$userKey.furtherReturn.title",
                       scenario.expectedErrorMessageKey
                     )
@@ -5564,7 +5564,7 @@ class YearToDateLiabilityControllerSpec
                 doc
                   .select("#main-content dl.govuk-summary-list > div:nth-child(2) > dd")
                   .text() shouldBe s"- ${MoneyUtils
-                  .formatAmountOfMoneyWithPoundSign(previousYearToDateLiability.inPounds())}"
+                    .formatAmountOfMoneyWithPoundSign(previousYearToDateLiability.inPounds())}"
 
                 doc
                   .select("#main-content dl.govuk-summary-list > div.sum-total > dd")
@@ -5673,7 +5673,7 @@ class YearToDateLiabilityControllerSpec
               performAction(),
               messageFromMessageKey(s"nonCalculatedTaxDue.furtherReturn.enterTaxDue.title"),
               { doc =>
-                doc.select("#nonCalculatedTaxDue-hint") contains expectedP1Key
+                doc.select("#nonCalculatedTaxDue-hint").contains(expectedP1Key)
                 doc
                   .select("#main-content form")
                   .attr("action") shouldBe routes.YearToDateLiabilityController
@@ -5800,7 +5800,7 @@ class YearToDateLiabilityControllerSpec
                   .formatAmountOfMoneyWithPoundSign(yearToDateLiability.inPounds())
 
                 doc.select("#main-content dl.govuk-summary-list > div:nth-child(2) > dd").text() shouldBe s"${MoneyUtils
-                  .formatAmountOfMoneyWithPoundSign(previousYearToDateLiability.inPounds())}"
+                    .formatAmountOfMoneyWithPoundSign(previousYearToDateLiability.inPounds())}"
 
                 doc.select("#main-content dl.govuk-summary-list > div.sum-total > dd").text() shouldBe formattedTaxDue
 
@@ -5883,7 +5883,7 @@ class YearToDateLiabilityControllerSpec
               messageFromMessageKey(s"nonCalculatedTaxDue.amendReturn.enterTaxDue$userKey.title"),
               { doc =>
                 doc.select("#back, .govuk-back-link").attr("href") shouldBe expectedBackLink.url
-                doc.select("#nonCalculatedTaxDue-form-hint") contains expectedP1Key
+                doc.select("#nonCalculatedTaxDue-form-hint").contains(expectedP1Key)
                 doc
                   .select("#content > article > form, #main-content form")
                   .attr("action")                                  shouldBe routes.YearToDateLiabilityController
@@ -5987,7 +5987,7 @@ class YearToDateLiabilityControllerSpec
     "handling submits on the non calculated enter tax due page" must {
       def performAction(formData: (String, String)*): Future[Result] =
         controller.nonCalculatedEnterTaxDueSubmit()(
-          FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST")
+          FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST")
         )
 
       behave like redirectToStartBehaviour(() => performAction())
@@ -6039,7 +6039,7 @@ class YearToDateLiabilityControllerSpec
         )._1
 
         def test(data: (String, String)*)(expectedErrorKey: String): Unit =
-          testFormError(data: _*)(
+          testFormError(data*)(
             expectedErrorKey
           )("nonCalculatedTaxDue.title")(performAction, currentSession)
 
@@ -6048,7 +6048,7 @@ class YearToDateLiabilityControllerSpec
             .amountOfMoneyErrorScenarios("nonCalculatedTaxDue")
             .foreach { scenario =>
               withClue(s"For $scenario: ") {
-                test(scenario.formData: _*)(scenario.expectedErrorMessageKey)
+                test(scenario.formData*)(scenario.expectedErrorMessageKey)
               }
             }
         }
@@ -6512,8 +6512,8 @@ class YearToDateLiabilityControllerSpec
             wasUkResident = sample[Boolean]
           )
 
-        val fileName       = "file"
-        val callback       = sample[UpscanSuccess]
+        val fileName = "file"
+        val callback = sample[UpscanSuccess]
           .copy(uploadDetails = Map("fileName" -> fileName))
 
         val newAnswers     = answers.copy(
@@ -7752,7 +7752,7 @@ class YearToDateLiabilityControllerSpec
 
     "handling submits on the year to date liability page" must {
       def performAction(formData: (String, String)*): Future[Result] =
-        controller.yearToDateLiabilitySubmit()(FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST"))
+        controller.yearToDateLiabilitySubmit()(FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST"))
 
       behave like redirectToStartBehaviour(() => performAction())
 
@@ -7831,10 +7831,10 @@ class YearToDateLiabilityControllerSpec
           expectedTitleKey: String,
           expectedTitleArgs: String*
         )(expectedErrorKey: String, expectedErrorArgs: String*): Unit =
-          testFormError(data: _*)(
+          testFormError(data*)(
             expectedErrorKey,
             expectedErrorArgs
-          )(expectedTitleKey, expectedTitleArgs: _*)(
+          )(expectedTitleKey, expectedTitleArgs*)(
             performAction,
             sessionData,
             _ => mockFurtherReturnCalculationEligibilityCheck(fillingOutReturn)(Right(sample[Ineligible]))
@@ -7892,7 +7892,7 @@ class YearToDateLiabilityControllerSpec
               .filter(s => s.input.exists(_.nonEmpty))
               .foreach { scenario =>
                 withClue(s"For user key '$userKey' and $scenario: ") {
-                  test(session._1, session._2)(scenario.formData: _*)(
+                  test(session._1, session._2)(scenario.formData*)(
                     s"yearToDateLiability$userKey.title",
                     taxYearStart,
                     taxYearEnd
@@ -8282,7 +8282,7 @@ class YearToDateLiabilityControllerSpec
 
     "handling submits on the repayment page" must {
       def performAction(formData: (String, String)*): Future[Result] =
-        controller.repaymentSubmit()(FakeRequest().withFormUrlEncodedBody(formData: _*).withMethod("POST"))
+        controller.repaymentSubmit()(FakeRequest().withFormUrlEncodedBody(formData*).withMethod("POST"))
 
       behave like redirectToStartBehaviour(() => performAction())
 
@@ -8340,7 +8340,7 @@ class YearToDateLiabilityControllerSpec
         )(
           data: (String, String)*
         )(expectedTitleKey: String, expectedErrorKey: String): Unit =
-          testFormError(data: _*)(
+          testFormError(data*)(
             expectedErrorKey
           )(expectedTitleKey)(performAction, sessionData)
 
@@ -8891,13 +8891,13 @@ class YearToDateLiabilityControllerSpec
     }
     checkPageIsDisplayed(
       performAction(data),
-      messageFromMessageKey(pageTitleKey, titleArgs: _*),
+      messageFromMessageKey(pageTitleKey, titleArgs*),
       { doc =>
         doc
           .select("[data-spec='errorSummaryDisplay'] a")
           .text() shouldBe messageFromMessageKey(
           expectedErrorMessageKey,
-          errorArgs: _*
+          errorArgs*
         )
         doc.title() should startWith("Error:")
       },

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/metrics/TestMetrics.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/metrics/TestMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics
 
-import org.scalamock.scalatest.MockFactory
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import com.codahale.metrics.MetricRegistry
 
-object MockMetrics extends MockFactory with GuiceOneServerPerSuite {
-  val metrics: Metrics = app.injector.instanceOf[Metrics]
-}
+class TestMetrics extends Metrics(new MetricRegistry) {}

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/JourneyStatusSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/JourneyStatusSpec.scala
@@ -19,16 +19,16 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.{FillingOutReturn, PreviousReturnData}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.taxYearGen
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/AcquisitionDetailsGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/AcquisitionDetailsGen.scala
@@ -17,20 +17,20 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.{CompleteAcquisitionDetailsAnswers, IncompleteAcquisitionDetailsAnswers}
+import io.github.martinhh.derived.scalacheck.given
+
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{AcquisitionDate, AcquisitionMethod}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.{CompleteAcquisitionDetailsAnswers, IncompleteAcquisitionDetailsAnswers}
 
 object AcquisitionDetailsGen extends GenUtils {
 
-  implicit val completeAcquisitionDetailsAnswersGen: Gen[CompleteAcquisitionDetailsAnswers] =
+  given completeAcquisitionDetailsAnswersGen: Gen[CompleteAcquisitionDetailsAnswers] =
     gen[CompleteAcquisitionDetailsAnswers]
 
-  implicit val incompleteAcquisitionDetailsAnswersGen: Gen[IncompleteAcquisitionDetailsAnswers] =
+  given incompleteAcquisitionDetailsAnswersGen: Gen[IncompleteAcquisitionDetailsAnswers] =
     gen[IncompleteAcquisitionDetailsAnswers]
 
-  implicit val acquisitionMethodGen: Gen[AcquisitionMethod] =
-    gen[AcquisitionMethod]
+  given acquisitionMethodGen: Gen[AcquisitionMethod] = gen[AcquisitionMethod]
 
-  implicit val acquisitionDateGen: Gen[AcquisitionDate] = gen[AcquisitionDate]
-
+  given acquisitionDateGen: Gen[AcquisitionDate] = gen[AcquisitionDate]
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/AddressGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/AddressGen.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.{NonUkAddress, UkAddress}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Country, Postcode}
 
@@ -47,4 +47,10 @@ object AddressGen extends AddressHigherPriorityGen {
   } yield NonUkAddress(line1, line2, line3, line4, postcode, country)
 
   implicit val addressGen: Gen[Address] = Gen.oneOf(ukAddressGen, nonUkAddressGen)
+
+  given addressArb: Arbitrary[Address]           = Arbitrary(AddressGen.addressGen)
+  given postcodeArb: Arbitrary[Postcode]         = Arbitrary(AddressGen.postcodeGen)
+  given countryArb: Arbitrary[Country]           = Arbitrary(AddressGen.countryGen)
+  given ukAddressArb: Arbitrary[UkAddress]       = Arbitrary(AddressGen.ukAddressGen)
+  given nonUkAddressArb: Arbitrary[NonUkAddress] = Arbitrary(AddressGen.nonUkAddressGen)
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/BusinessPartnerRecordGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/BusinessPartnerRecordGen.scala
@@ -17,13 +17,14 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import org.scalacheck.Arbitrary
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.EmailGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.{BusinessPartnerRecord, BusinessPartnerRecordRequest}
 
-object BusinessPartnerRecordGen extends GenUtils {
+object BusinessPartnerRecordGen extends GenUtils:
 
-  implicit val bprArb: Gen[BusinessPartnerRecord] = gen[BusinessPartnerRecord]
+  given Gen[BusinessPartnerRecord] = gen[BusinessPartnerRecord]
 
-  implicit val bprRequestArb: Gen[BusinessPartnerRecordRequest] =
-    gen[BusinessPartnerRecordRequest]
-
-}
+  given Gen[BusinessPartnerRecordRequest] = gen[BusinessPartnerRecordRequest]

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/CompleteReturnGen.scala
@@ -21,21 +21,21 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.{C
 
 object CompleteReturnGen extends LowerPriorityCompleteReturnGen {
 
-  implicit val completeSingleDisposalReturnGen: Gen[CompleteSingleDisposalReturn] =
+  given completeSingleDisposalReturnGen: Gen[CompleteSingleDisposalReturn] =
     for {
-      triageAnswers              <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
-      propertyAddress            <- AddressGen.ukAddressGen
-      disposalDetails            <- disposalDetails
-      acquisitionDetails         <- acquisitionDetails
-      reliefDetails              <- ReliefDetailsGen.completeReliefDetailsAnswersGen
-      exemptionsAndLossesDetails <- ExemptionsAndLossesAnswersGen.completeExemptionAndLossesAnswersGen
-      yearToDateLiabilityAnswers <-
+      triageAnswers                    <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
+      propertyAddress                  <- AddressGen.ukAddressGen
+      disposalDetails                  <- disposalDetails
+      acquisitionDetails               <- acquisitionDetails
+      reliefDetails                    <- ReliefDetailsGen.completeReliefDetailsAnswersGen
+      exemptionsAndLossesDetails       <- ExemptionsAndLossesAnswersGen.completeExemptionAndLossesAnswersGen
+      chosenYearToDateLiabilityAnswers <-
         Gen.either(yearToDateLiabilityAnswers, YearToDateLiabilityAnswersGen.completeCalculatedYTDLiabilityAnswersGen)
-      supportingDocumentAnswers  <- supportingDocumentAnswers
-      initialGainOrLoss          <- Gen.option(MoneyGen.amountInPenceGen)
-      representeeAnswers         <- Gen.option(RepresenteeAnswersGen.completeRepresenteeAnswersGen)
-      gainOrLossAfterReliefs     <- Gen.option(MoneyGen.amountInPenceGen)
-      hasAttachments             <- Generators.booleanGen
+      supportingDocumentAnswers        <- supportingDocumentAnswers
+      initialGainOrLoss                <- Gen.option(MoneyGen.amountInPenceGen)
+      representeeAnswers               <- Gen.option(RepresenteeAnswersGen.completeRepresenteeAnswersGen)
+      gainOrLossAfterReliefs           <- Gen.option(MoneyGen.amountInPenceGen)
+      hasAttachments                   <- Generators.booleanGen
     } yield CompleteSingleDisposalReturn(
       triageAnswers,
       propertyAddress,
@@ -43,7 +43,7 @@ object CompleteReturnGen extends LowerPriorityCompleteReturnGen {
       acquisitionDetails,
       reliefDetails,
       exemptionsAndLossesDetails,
-      yearToDateLiabilityAnswers,
+      chosenYearToDateLiabilityAnswers,
       supportingDocumentAnswers,
       initialGainOrLoss,
       representeeAnswers,
@@ -75,7 +75,7 @@ trait LowerPriorityCompleteReturnGen extends Common {
     hasAttachments
   )
 
-  implicit val completeSingleIndirectDisposalReturnGen: Gen[CompleteSingleIndirectDisposalReturn] = {
+  implicit val completeSingleIndirectDisposalReturnGen: Gen[CompleteSingleIndirectDisposalReturn] =
     for {
       triageAnswers              <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
       companyAddress             <- AddressGen.addressGen
@@ -99,7 +99,6 @@ trait LowerPriorityCompleteReturnGen extends Common {
       gainOrLossAfterReliefs,
       hasAttachments
     )
-  }
 
   implicit val completeMultipleIndirectDisposalReturnGen: Gen[CompleteMultipleIndirectDisposalReturn] = for {
     triageAnswers                <- TriageQuestionsGen.completeMultipleDisposalsTriageAnswersGen
@@ -121,10 +120,10 @@ trait LowerPriorityCompleteReturnGen extends Common {
     hasAttachments
   )
 
-  implicit val completeSingleMixedUseDisposalReturnGen: Gen[CompleteSingleMixedUseDisposalReturn] = {
+  implicit val completeSingleMixedUseDisposalReturnGen: Gen[CompleteSingleMixedUseDisposalReturn] =
     for {
       triageAnswers              <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
-      propertyDetailsAnswers     <- SingleMixedUseDetailsAnswersGen.completeMixedUsePropertyDetailsAnswers
+      propertyDetailsAnswers     <- SingleMixedUseDetailsAnswersGen.given_Gen_CompleteMixedUsePropertyDetailsAnswers
       exemptionsAndLossesDetails <- exemptionAndLossesAnswers
       yearToDateLiabilityAnswers <- yearToDateLiabilityAnswers
       supportingDocumentAnswers  <- supportingDocumentAnswers
@@ -141,6 +140,5 @@ trait LowerPriorityCompleteReturnGen extends Common {
       gainOrLossAfterReliefs,
       hasAttachments
     )
-  }
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DisposalDetailsGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DisposalDetailsGen.scala
@@ -16,23 +16,23 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import org.scalacheck.Gen
+import org.scalacheck._
+import io.github.martinhh.derived.scalacheck.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalDetailsAnswers.{CompleteDisposalDetailsAnswers, IncompleteDisposalDetailsAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ShareOfProperty
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ShareOfProperty.{Full, Half}
 
 object DisposalDetailsGen extends GenUtils {
 
-  implicit val completeDisposalDetailsAnswersGen: Gen[CompleteDisposalDetailsAnswers] =
+  given completeDisposalDetailsAnswersGen: Gen[CompleteDisposalDetailsAnswers] =
     gen[CompleteDisposalDetailsAnswers]
 
-  implicit val incompleteDisposalDetailsAnswersGen: Gen[IncompleteDisposalDetailsAnswers] =
+  given incompleteDisposalDetailsAnswersGen: Gen[IncompleteDisposalDetailsAnswers] =
     gen[IncompleteDisposalDetailsAnswers]
 
-  implicit val shareOfPropertyGen: Gen[ShareOfProperty] =
-    gen[ShareOfProperty].map {
-      case a: ShareOfProperty.Other if a.percentageValue > 100 =>
-        ShareOfProperty.Full
-      case other: ShareOfProperty                              => other
-    }
-
+  given shareOfPropertyGen: Gen[ShareOfProperty] = gen[ShareOfProperty].map {
+    case a: ShareOfProperty.Other if a.percentageValue > 100 =>
+      ShareOfProperty.Full
+    case other: ShareOfProperty                              => other
+  }
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DraftReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/DraftReturnGen.scala
@@ -17,16 +17,19 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.{Arbitrary, Gen}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
+import io.github.martinhh.derived.scalacheck.{*, given}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
 
 import java.time.LocalDate
 
 object DraftReturnGen extends HigherPriorityDraftReturnGen with GenUtils
 
 trait HigherPriorityDraftReturnGen extends LowerPriorityDraftReturnGen {
-  implicit val singleDisposalDraftReturnGen: Gen[DraftSingleDisposalReturn] = singleDisposalDraftReturnGen2
+  given singleDisposalDraftReturnGen: Gen[DraftSingleDisposalReturn] = singleDisposalDraftReturnGen2
 
-  implicit val draftReturnGen: Gen[DraftReturn] = Gen.oneOf(
+  given draftReturnGen: Gen[DraftReturn] = Gen.oneOf(
     singleDisposalDraftReturnGen,
     singleIndirectDisposalDraftReturnGen,
     singleMixedUseDraftReturnGen,
@@ -37,7 +40,8 @@ trait HigherPriorityDraftReturnGen extends LowerPriorityDraftReturnGen {
 
 trait LowerPriorityDraftReturnGen extends GenUtils {
 
-  private val supportingEvidenceGen: Gen[SupportingEvidenceAnswers]  = gen[SupportingEvidenceAnswers]
+  given supportingEvidenceGen: Gen[SupportingEvidenceAnswers] = gen[SupportingEvidenceAnswers]
+
   private val exemptionsAndLossesAnswersGen                          = Gen.oneOf(
     ExemptionsAndLossesAnswersGen.completeExemptionAndLossesAnswersGen,
     ExemptionsAndLossesAnswersGen.incompleteExemptionAndLossesAnswersGen
@@ -47,9 +51,10 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
       DisposalDetailsGen.completeDisposalDetailsAnswersGen,
       DisposalDetailsGen.incompleteDisposalDetailsAnswersGen
     )
-  private val acquisitionDetailsAnswersGen                           = gen[AcquisitionDetailsAnswers]
 
-  val singleDisposalDraftReturnGen2: Gen[DraftSingleDisposalReturn] =
+  given acquisitionDetailsAnswersGen: Gen[AcquisitionDetailsAnswers] = gen[AcquisitionDetailsAnswers]
+
+  given singleDisposalDraftReturnGen2: Gen[DraftSingleDisposalReturn] =
     for {
       id                         <- Gen.uuid
       triageAnswers              <- TriageQuestionsGen.singleDisposalTraiageAnswersGen
@@ -80,11 +85,16 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
       lastUpdatedDate
     )
 
-  implicit val multipleDisposalDraftReturnGen: Gen[DraftMultipleDisposalsReturn] = {
+  given multipleDisposalDraftReturnGen: Gen[DraftMultipleDisposalsReturn] =
     for {
       id                            <- Gen.uuid
       triageAnswers                 <- TriageQuestionsGen.multipleDisposalsTriageAnswersGen
-      examplePropertyDetailsAnswers <- Gen.option(gen[ExamplePropertyDetailsAnswers])
+      examplePropertyDetailsAnswers <- Gen.option(
+                                         Gen.oneOf(
+                                           ExamplePropertyDetailsAnswersGen.completeExamplePropertyDetailsAnswersGen,
+                                           ExamplePropertyDetailsAnswersGen.incompleteExamplePropertyDetailsAnswersGen
+                                         )
+                                       )
       exemptionAndLossesAnswers     <- Gen.option(exemptionsAndLossesAnswersGen)
       yearToDateLiabilityAnswers    <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
       supportingEvidenceAnswers     <- Gen.option(supportingEvidenceGen)
@@ -102,13 +112,17 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
       gainOrLossAfterReliefs,
       lastUpdatedDate
     )
-  }
 
-  implicit val multipleIndirectDisposalDraftReturnGen: Gen[DraftMultipleIndirectDisposalsReturn] = {
+  given multipleIndirectDisposalDraftReturnGen: Gen[DraftMultipleIndirectDisposalsReturn] =
     for {
       id                           <- Gen.uuid
       triageAnswers                <- TriageQuestionsGen.multipleDisposalsTriageAnswersGen
-      exampleCompanyDetailsAnswers <- Gen.option(gen[ExampleCompanyDetailsAnswers])
+      exampleCompanyDetailsAnswers <- Gen.option(
+                                        Gen.oneOf(
+                                          ExampleCompanyDetailsAnswersGen.completeExampleCompanyDetailsAnswersGen,
+                                          ExampleCompanyDetailsAnswersGen.incompleteExampleCompanyDetailsAnswersGen
+                                        )
+                                      )
       exemptionAndLossesAnswers    <- Gen.option(exemptionsAndLossesAnswersGen)
       yearToDateLiabilityAnswers   <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
       supportingEvidenceAnswers    <- Gen.option(supportingEvidenceGen)
@@ -126,9 +140,8 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
       gainOrLossAfterReliefs,
       lastUpdatedDate
     )
-  }
 
-  implicit val singleIndirectDisposalDraftReturnGen: Gen[DraftSingleIndirectDisposalReturn] =
+  given singleIndirectDisposalDraftReturnGen: Gen[DraftSingleIndirectDisposalReturn] =
     for {
       id                         <- Gen.uuid
       triageAnswers              <- TriageQuestionsGen.singleDisposalTraiageAnswersGen
@@ -155,11 +168,16 @@ trait LowerPriorityDraftReturnGen extends GenUtils {
       lastUpdatedDate
     )
 
-  implicit val singleMixedUseDraftReturnGen: Gen[DraftSingleMixedUseDisposalReturn] =
+  given singleMixedUseDraftReturnGen: Gen[DraftSingleMixedUseDisposalReturn] =
     for {
       id                             <- Gen.uuid
       triageAnswers                  <- TriageQuestionsGen.singleDisposalTraiageAnswersGen
-      mixedUsePropertyDetailsAnswers <- Gen.option(gen[MixedUsePropertyDetailsAnswers])
+      mixedUsePropertyDetailsAnswers <- Gen.option(
+                                          Gen.oneOf(
+                                            SingleMixedUseDetailsAnswersGen.given_Gen_CompleteMixedUsePropertyDetailsAnswers,
+                                            SingleMixedUseDetailsAnswersGen.given_Gen_IncompleteMixedUsePropertyDetailsAnswers
+                                          )
+                                        )
       exemptionAndLossesAnswers      <- Gen.option(exemptionsAndLossesAnswersGen)
       yearToDateLiabilityAnswers     <- Gen.option(YearToDateLiabilityAnswersGen.ytdLiabilityAnswersGen)
       supportingEvidenceAnswers      <- Gen.option(supportingEvidenceGen)

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/EmailGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/EmailGen.scala
@@ -16,11 +16,14 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.{Email, EmailSource}
 
 object EmailGen extends GenUtils {
-  implicit val emailGen: Gen[Email]             = Generators.stringGen.map(Email(_))
+  implicit val emailGen: Gen[Email] = Generators.stringGen.map(Email(_))
+
+  given emailArb: Arbitrary[Email] = Arbitrary(EmailGen.emailGen)
+
   implicit val emailSourceGen: Gen[EmailSource] =
     Gen.oneOf(EmailSource.GovernmentGateway, EmailSource.BusinessPartnerRecord, EmailSource.ManuallyEntered)
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ExampleCompanyDetailsAnswersGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ExampleCompanyDetailsAnswersGen.scala
@@ -17,14 +17,17 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import org.scalacheck.Arbitrary
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExampleCompanyDetailsAnswers.{CompleteExampleCompanyDetailsAnswers, IncompleteExampleCompanyDetailsAnswers}
 
 object ExampleCompanyDetailsAnswersGen extends GenUtils {
 
-  implicit val incompleteExampleCompanyDetailsAnswersGen: Gen[IncompleteExampleCompanyDetailsAnswers] =
+  given incompleteExampleCompanyDetailsAnswersGen: Gen[IncompleteExampleCompanyDetailsAnswers] =
     gen[IncompleteExampleCompanyDetailsAnswers]
 
-  implicit val completeExampleCompanyDetailsAnswersGen: Gen[CompleteExampleCompanyDetailsAnswers] =
+  given completeExampleCompanyDetailsAnswersGen: Gen[CompleteExampleCompanyDetailsAnswers] =
     gen[CompleteExampleCompanyDetailsAnswers]
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ExamplePropertyDetailsAnswersGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ExamplePropertyDetailsAnswersGen.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,16 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExamplePropertyDetailsAnswers.{CompleteExamplePropertyDetailsAnswers, IncompleteExamplePropertyDetailsAnswers}
 
 object ExamplePropertyDetailsAnswersGen extends GenUtils {
 
-  implicit val incompleteExamplePropertyDetailsAnswersGen: Gen[IncompleteExamplePropertyDetailsAnswers] =
+  given incompleteExamplePropertyDetailsAnswersGen: Gen[IncompleteExamplePropertyDetailsAnswers] =
     gen[IncompleteExamplePropertyDetailsAnswers]
 
-  implicit val completeExamplePropertyDetailsAnswersGen: Gen[CompleteExamplePropertyDetailsAnswers] =
+  given completeExamplePropertyDetailsAnswersGen: Gen[CompleteExamplePropertyDetailsAnswers] =
     gen[CompleteExamplePropertyDetailsAnswers]
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ExemptionsAndLossesAnswersGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ExemptionsAndLossesAnswersGen.scala
@@ -21,13 +21,12 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExemptionAndLosse
 
 object ExemptionsAndLossesAnswersGen extends GenUtils {
 
-  implicit val completeExemptionAndLossesAnswersGen: Gen[CompleteExemptionAndLossesAnswers] = {
+  implicit val completeExemptionAndLossesAnswersGen: Gen[CompleteExemptionAndLossesAnswers] =
     for {
       inYearLosses        <- MoneyGen.amountInPenceGen
       previousYearsLosses <- MoneyGen.amountInPenceGen
       annualExemptAmount  <- MoneyGen.amountInPenceGen
     } yield CompleteExemptionAndLossesAnswers(inYearLosses, previousYearsLosses, annualExemptAmount)
-  }
 
   implicit val incompleteExemptionAndLossesAnswersGen: Gen[IncompleteExemptionAndLossesAnswers] =
     for {

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/FileUploadGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/FileUploadGen.scala
@@ -16,28 +16,31 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.uploadReferenceGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SupportingEvidenceAnswers.{CompleteSupportingEvidenceAnswers, IncompleteSupportingEvidenceAnswers, SupportingEvidence}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.UpscanCallBack.{UpscanFailure, UpscanSuccess}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.{UploadRequest, UpscanUpload}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.{UploadReference, UploadRequest, UpscanCallBack, UpscanUpload}
 
 object FileUploadGen extends GenUtils {
 
-  implicit val completeUploadSupportingEvidenceAnswersGen: Gen[CompleteSupportingEvidenceAnswers] =
+  given completeUploadSupportingEvidenceAnswersGen: Gen[CompleteSupportingEvidenceAnswers] =
     gen[CompleteSupportingEvidenceAnswers]
 
-  implicit val incompleteUploadSupportingEvidenceAnswersGen: Gen[IncompleteSupportingEvidenceAnswers] =
+  given incompleteUploadSupportingEvidenceAnswersGen: Gen[IncompleteSupportingEvidenceAnswers] =
     gen[IncompleteSupportingEvidenceAnswers]
 
-  implicit val supportingEvidenceGen: Gen[SupportingEvidence] =
-    gen[SupportingEvidence]
+  given uploadReferenceArb: Arbitrary[UploadReference] = Arbitrary(uploadReferenceGen)
+  given supportingEvidenceGen: Gen[SupportingEvidence] = gen[SupportingEvidence]
 
-  implicit val uploadRequestGen: Gen[UploadRequest] = gen[UploadRequest]
+  given uploadRequestGen: Gen[UploadRequest] = gen[UploadRequest]
 
-  implicit val upscanUploadGen: Gen[UpscanUpload] = gen[UpscanUpload]
+  given upscanUploadGen: Gen[UpscanUpload] = gen[UpscanUpload]
 
-  implicit val upscanSuccessGen: Gen[UpscanSuccess] = gen[UpscanSuccess]
+  given upscanSuccessGen: Gen[UpscanSuccess] = gen[UpscanSuccess]
 
-  implicit val upscanFailureGen: Gen[UpscanFailure] = gen[UpscanFailure]
+  given upscanFailureGen: Gen[UpscanFailure] = gen[UpscanFailure]
 
+  given Gen[UpscanCallBack] = Gen.oneOf(upscanSuccessGen, upscanFailureGen)
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/FurtherReturnCalculationGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/FurtherReturnCalculationGen.scala
@@ -17,28 +17,29 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import io.github.martinhh.derived.scalacheck.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.FurtherReturnCalculationEligibility.{Eligible, Ineligible}
 
-object FurtherReturnCalculationGen extends GenUtils {
+object FurtherReturnCalculationGen extends GenUtils:
 
-  implicit val calculatedGlarBreakdownGen: Gen[CalculatedGlarBreakdown] =
-    gen[CalculatedGlarBreakdown]
+  given calculatedGlarBreakdownGen: Gen[CalculatedGlarBreakdown] = gen[CalculatedGlarBreakdown]
 
-  implicit val eligibleGen: Gen[Eligible] = gen[Eligible]
+  given Gen[FurtherReturnCalculationData] = gen[FurtherReturnCalculationData]
 
-  implicit val ineligibleGen: Gen[Ineligible] = gen[Ineligible]
+  given eligibleGen: Gen[Eligible] = gen[Eligible]
 
-  implicit val taxableGainOrLossCalculationRequestGen: Gen[TaxableGainOrLossCalculationRequest] =
+  given ineligibleGen: Gen[Ineligible] = gen[Ineligible]
+
+  given taxableGainOrLossCalculationRequestGen: Gen[TaxableGainOrLossCalculationRequest] =
     gen[TaxableGainOrLossCalculationRequest]
 
-  implicit val taxableGainOrLossCalculationGen: Gen[TaxableGainOrLossCalculation] =
+  given taxableGainOrLossCalculationGen: Gen[TaxableGainOrLossCalculation] =
     gen[TaxableGainOrLossCalculation]
 
-  implicit val yearToDateLiabilityCalculationRequestGen: Gen[YearToDateLiabilityCalculationRequest] =
+  given yearToDateLiabilityCalculationRequestGen: Gen[YearToDateLiabilityCalculationRequest] =
     gen[YearToDateLiabilityCalculationRequest]
 
-  implicit val yearToDateLiabilityCalculationGen: Gen[YearToDateLiabilityCalculation] =
+  given yearToDateLiabilityCalculationGen: Gen[YearToDateLiabilityCalculation] =
     gen[YearToDateLiabilityCalculation]
-
-}

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/GenUtils.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/GenUtils.scala
@@ -16,12 +16,12 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import org.scalacheck.{Arbitrary, Gen, ScalacheckShapeless}
+import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.stringGen
 
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
 
-trait GenUtils extends ScalacheckShapeless {
+trait GenUtils {
   def gen[A](implicit arb: Arbitrary[A]): Gen[A] = arb.arbitrary
 
   // define our own Arbitrary instance for String to generate more legible strings

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/MoneyGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/MoneyGen.scala
@@ -114,11 +114,10 @@ object MoneyGen extends GenUtils {
     snd <- Generators.stringGen
   } yield PaymentsJourney(fst, snd)
 
-  implicit val amountInPenceWithSourceGen: Gen[AmountInPenceWithSource] = {
+  implicit val amountInPenceWithSourceGen: Gen[AmountInPenceWithSource] =
     for {
       amount <- amountInPenceGen
       source <- Gen.oneOf(Source.Calculated, Source.UserSupplied)
     } yield AmountInPenceWithSource(amount, source)
-  }
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/NameGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/NameGen.scala
@@ -16,19 +16,21 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{ContactName, IndividualName, TrustName}
 
 object NameGen extends GenUtils {
 
   implicit val contactNameGen: Gen[ContactName] = Generators.stringGen.map(ContactName(_))
+  given contactNameArb: Arbitrary[ContactName]  = Arbitrary(contactNameGen)
 
   implicit val individualNameGen: Gen[IndividualName] =
     for {
       firstName <- Generators.stringGen
       lastName  <- Generators.stringGen
     } yield IndividualName(firstName, lastName)
+  given individualNameArb: Arbitrary[IndividualName]  = Arbitrary(individualNameGen)
 
   implicit val trustNameGen: Gen[TrustName] = Generators.stringGen.map(TrustName(_))
-
+  given trustNameArb: Arbitrary[TrustName]  = Arbitrary(trustNameGen)
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/NameMatchGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/NameMatchGen.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,21 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import io.github.martinhh.derived.scalacheck.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UnsuccessfulNameMatchAttempts
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UnsuccessfulNameMatchAttempts.NameMatchDetails.{IndividualRepresenteeNameMatchDetails, IndividualSautrNameMatchDetails, TrustNameMatchDetails}
 
-object NameMatchGen extends GenUtils {
+object NameMatchGen extends GenUtils:
 
-  implicit val trustNameMatchDetailsGen: Gen[TrustNameMatchDetails] =
+  given trustNameMatchDetailsGen: Gen[TrustNameMatchDetails] =
     gen[TrustNameMatchDetails]
 
-  implicit val individualSautrNameMatchDetailsGen: Gen[IndividualSautrNameMatchDetails] =
+  given individualSautrNameMatchDetailsGen: Gen[IndividualSautrNameMatchDetails] =
     gen[IndividualSautrNameMatchDetails]
 
-  implicit val individualUnsuccessfulNameMatchAttemptsGen
+  given individualUnsuccessfulNameMatchAttemptsGen
     : Gen[UnsuccessfulNameMatchAttempts[IndividualSautrNameMatchDetails]] =
     gen[UnsuccessfulNameMatchAttempts[IndividualSautrNameMatchDetails]]
 
-  implicit val individualRepresenteeNameMatchDetailsGen: Gen[IndividualRepresenteeNameMatchDetails] =
+  given individualRepresenteeNameMatchDetailsGen: Gen[IndividualRepresenteeNameMatchDetails] =
     gen[IndividualRepresenteeNameMatchDetails]
-
-}

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/OnboardingDetailsGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/OnboardingDetailsGen.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,21 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import org.scalacheck.Arbitrary
+import io.github.martinhh.derived.scalacheck.*
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.EmailGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.{RegistrationDetails, SubscribedUpdateDetails, SubscriptionDetails}
 
 object OnboardingDetailsGen extends GenUtils {
 
-  implicit val registrationDetailsArb: Gen[RegistrationDetails] =
-    gen[RegistrationDetails]
+  given registrationDetailsGen: Gen[RegistrationDetails] = gen[RegistrationDetails]
 
-  implicit val subscriptionDetailsArb: Gen[SubscriptionDetails] =
-    gen[SubscriptionDetails]
+  given subscriptionDetailsGen: Gen[SubscriptionDetails] = gen[SubscriptionDetails]
 
-  implicit val subscribedUpdateDetailsGen: Gen[SubscribedUpdateDetails] =
-    gen[SubscribedUpdateDetails]
+  given subscribedUpdateDetailsGen: Gen[SubscribedUpdateDetails] = gen[SubscribedUpdateDetails]
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReliefDetailsGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReliefDetailsGen.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.{Arbitrary, Gen}
+import io.github.martinhh.derived.scalacheck.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen.amountInPenceGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.OtherReliefsOption.{NoOtherReliefs, OtherReliefs}
@@ -32,23 +33,21 @@ object ReliefDetailsGen extends HigherPriorityReliefDetailGen with GenUtils {
 
 trait HigherPriorityReliefDetailGen extends LowerPriorityReliefDetailGen { this: GenUtils =>
 
-  implicit val reliefDetailsAnswersGen: Gen[ReliefDetailsAnswers] =
-    gen[ReliefDetailsAnswers]
+  given reliefDetailsAnswersGen: Gen[ReliefDetailsAnswers] = gen[ReliefDetailsAnswers]
 
-  implicit val completeReliefDetailsAnswersGen: Gen[CompleteReliefDetailsAnswers] =
+  given completeReliefDetailsAnswersGen: Gen[CompleteReliefDetailsAnswers] =
     gen[CompleteReliefDetailsAnswers].map {
       case a: CompleteReliefDetailsAnswers if a.otherReliefs.isEmpty =>
         a.copy(otherReliefs = Some(NoOtherReliefs))
       case other                                                     => other
     }
 
-  implicit val otherReliefsGen: Gen[OtherReliefs] = gen[OtherReliefs]
-
+  given otherReliefsGen: Gen[OtherReliefs] = gen[OtherReliefs]
 }
 
 trait LowerPriorityReliefDetailGen { this: GenUtils =>
 
-  implicit val incompleteReliefDetailsAnswersGen: Gen[IncompleteReliefDetailsAnswers] =
+  given incompleteReliefDetailsAnswersGen: Gen[IncompleteReliefDetailsAnswers] =
     gen[IncompleteReliefDetailsAnswers].map {
       case a: IncompleteReliefDetailsAnswers if a.otherReliefs.isEmpty =>
         a.copy(otherReliefs = Some(NoOtherReliefs))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/RepresenteeAnswersGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/RepresenteeAnswersGen.scala
@@ -17,6 +17,11 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import org.scalacheck.Arbitrary
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.EmailGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.{CompleteRepresenteeAnswers, IncompleteRepresenteeAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeReferenceId.{RepresenteeCgtReference, RepresenteeNino, RepresenteeSautr}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{DateOfDeath, RepresenteeAnswers, RepresenteeContactDetails, RepresenteeReferenceId}
@@ -25,31 +30,25 @@ object RepresenteeAnswersGen extends HigherPriorityRepresenteeAnswersGen with Ge
 
 trait HigherPriorityRepresenteeAnswersGen extends LowerPriorityRepresenteeAnswersGen { this: GenUtils =>
 
-  implicit val representeeAnswersGen: Gen[RepresenteeAnswers] =
-    gen[RepresenteeAnswers]
+  given representeeAnswersGen: Gen[RepresenteeAnswers] = gen[RepresenteeAnswers]
 
-  implicit val incompleteRepresenteeAnswersGen: Gen[IncompleteRepresenteeAnswers] = gen[IncompleteRepresenteeAnswers]
+  given incompleteRepresenteeAnswersGen: Gen[IncompleteRepresenteeAnswers] = gen[IncompleteRepresenteeAnswers]
 
-  implicit val representeeReferenceIdGen: Gen[RepresenteeReferenceId] =
-    gen[RepresenteeReferenceId]
+  given representeeReferenceIdGen: Gen[RepresenteeReferenceId] = gen[RepresenteeReferenceId]
 
-  implicit val representeeCgtReferenceGen: Gen[RepresenteeCgtReference] =
-    gen[RepresenteeCgtReference]
+  given representeeCgtReferenceGen: Gen[RepresenteeCgtReference] = gen[RepresenteeCgtReference]
 
-  implicit val representeeContactDetailsGen: Gen[RepresenteeContactDetails] =
-    gen[RepresenteeContactDetails]
+  given representeeContactDetailsGen: Gen[RepresenteeContactDetails] = gen[RepresenteeContactDetails]
 
 }
 
 trait LowerPriorityRepresenteeAnswersGen { this: GenUtils =>
 
-  implicit val completeRepresenteeAnswersGen: Gen[CompleteRepresenteeAnswers] =
-    gen[CompleteRepresenteeAnswers]
+  given completeRepresenteeAnswersGen: Gen[CompleteRepresenteeAnswers] = gen[CompleteRepresenteeAnswers]
 
-  implicit val representeeSautrGen: Gen[RepresenteeSautr] =
-    gen[RepresenteeSautr]
+  given representeeSautrGen: Gen[RepresenteeSautr] = gen[RepresenteeSautr]
 
-  implicit val representeeNinoGen: Gen[RepresenteeNino] = gen[RepresenteeNino]
+  given representeeNinoGen: Gen[RepresenteeNino] = gen[RepresenteeNino]
 
-  implicit val dateOfDeathGen: Gen[DateOfDeath] = gen[DateOfDeath]
+  given dateOfDeathGen: Gen[DateOfDeath] = gen[DateOfDeath]
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnAPIGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnAPIGen.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,17 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import org.scalacheck.Arbitrary
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.B64Html
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{CalculateCgtTaxDueRequest, SubmitReturnRequest, SubmitReturnResponse}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsServiceImpl.ListReturnsResponse
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.{CalculateCgtTaxDueRequest, SubmitReturnRequest, SubmitReturnResponse}
 
 object ReturnAPIGen extends Common {
 
-  implicit val submitReturnRequestGen: Gen[SubmitReturnRequest] = for {
+  given submitReturnRequestGen: Gen[SubmitReturnRequest] = for {
     completeReturn          <- ReturnGen.completeReturnGen
     id                      <- Gen.uuid
     subscribedDetails       <- SubscribedDetailsGen.subscribedDetailsGen
@@ -41,14 +45,14 @@ object ReturnAPIGen extends Common {
     amendReturnData
   )
 
-  implicit val submitReturnResponseGen: Gen[SubmitReturnResponse] =
+  given submitReturnResponseGen: Gen[SubmitReturnResponse] =
     gen[SubmitReturnResponse]
 
-  implicit val listReturnsResponseGen: Gen[ListReturnsResponse] = for {
+  given listReturnsResponseGen: Gen[ListReturnsResponse] = for {
     returns <- Gen.listOf(ReturnGen.returnSummaryGen)
   } yield ListReturnsResponse(returns)
 
-  implicit val calculateCgtTaxDueRequestGen: Gen[CalculateCgtTaxDueRequest] =
+  given calculateCgtTaxDueRequestGen: Gen[CalculateCgtTaxDueRequest] =
     for {
       triageAnswers      <- TriageQuestionsGen.completeSingleDisposalTriageAnswersGen
       address            <- AddressGen.ukAddressGen

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/ReturnGen.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.CompleteReturnWithSummary
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.PreviousReturnData
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.*
 
 import java.time.LocalDate
 
@@ -34,7 +34,9 @@ object ReturnGen extends GenUtils {
       CompleteReturnGen.completeMultipleIndirectDisposalReturnGen
     )
 
-  implicit val returnSummaryGen: Gen[ReturnSummary] = {
+  given completeReturnArb: Arbitrary[CompleteReturn] = Arbitrary(completeReturnGen)
+
+  implicit val returnSummaryGen: Gen[ReturnSummary] =
     for {
       submissionId              <- Generators.stringGen
       submissionDate            <- Arbitrary.arbitrary[LocalDate]
@@ -60,14 +62,13 @@ object ReturnGen extends GenUtils {
       isRecentlyAmended,
       expired
     )
-  }
 
   private val furtherReturnCalculationData = for {
     address                <- AddressGen.ukAddressGen
     gainOrLossAfterReliefs <- MoneyGen.amountInPenceGen
   } yield FurtherReturnCalculationData(address, gainOrLossAfterReliefs)
 
-  implicit val previousReturnDataGen: Gen[PreviousReturnData] = {
+  implicit val previousReturnDataGen: Gen[PreviousReturnData] =
     for {
       summaries                                     <- Gen.listOf(returnSummaryGen)
       previousYearToDate                            <- Gen.option(MoneyGen.amountInPenceGen)
@@ -79,7 +80,6 @@ object ReturnGen extends GenUtils {
       previousReturnsImplyEligibilityForCalculation,
       calculationData
     )
-  }
 
   implicit val returnTypeGen: Gen[ReturnType] =
     Gen.oneOf(ReturnType.FirstReturn, ReturnType.FurtherReturn, ReturnType.AmendedReturn)
@@ -94,4 +94,6 @@ object ReturnGen extends GenUtils {
     originalReturn                      <- completeReturnWithSummaryGen
     shouldDisplayGainOrLossAfterReliefs <- Generators.booleanGen
   } yield AmendReturnData(originalReturn, shouldDisplayGainOrLossAfterReliefs)
+
+  given Arbitrary[AmendReturnData] = Arbitrary(amendReturnDataGen)
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SingleMixedUseDetailsAnswersGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SingleMixedUseDetailsAnswersGen.scala
@@ -17,14 +17,12 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MixedUsePropertyDetailsAnswers.{CompleteMixedUsePropertyDetailsAnswers, IncompleteMixedUsePropertyDetailsAnswers}
 
-object SingleMixedUseDetailsAnswersGen extends GenUtils {
+object SingleMixedUseDetailsAnswersGen extends GenUtils:
 
-  implicit val incompleteMixedUsePropertyDetailsAnswers: Gen[IncompleteMixedUsePropertyDetailsAnswers] =
-    gen[IncompleteMixedUsePropertyDetailsAnswers]
-
-  implicit val completeMixedUsePropertyDetailsAnswers: Gen[CompleteMixedUsePropertyDetailsAnswers] =
-    gen[CompleteMixedUsePropertyDetailsAnswers]
-
-}
+  given Gen[IncompleteMixedUsePropertyDetailsAnswers] = gen[IncompleteMixedUsePropertyDetailsAnswers]
+  given Gen[CompleteMixedUsePropertyDetailsAnswers]   = gen[CompleteMixedUsePropertyDetailsAnswers]

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SubscribedDetailsGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/SubscribedDetailsGen.scala
@@ -16,14 +16,14 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TelephoneNumber
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 
 object SubscribedDetailsGen extends GenUtils {
 
-  implicit val subscribedDetailsGen: Gen[SubscribedDetails] = for {
+  given subscribedDetailsGen: Gen[SubscribedDetails] = for {
     name: Either[TrustName, IndividualName] <-
       Gen.oneOf(NameGen.trustNameGen.map(Left(_)), NameGen.individualNameGen.map(Right(_)))
     emailAddress                            <- EmailGen.emailGen
@@ -33,5 +33,7 @@ object SubscribedDetailsGen extends GenUtils {
     telephoneNumber                         <- Gen.option(Generators.stringGen.map(TelephoneNumber(_)))
     registeredWithId                        <- Generators.booleanGen
   } yield SubscribedDetails(name, emailAddress, address, contactName, cgtReference, telephoneNumber, registeredWithId)
+
+  given Arbitrary[SubscribedDetails] = Arbitrary(subscribedDetailsGen)
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/TaxYearGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/TaxYearGen.scala
@@ -17,10 +17,9 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import io.github.martinhh.derived.scalacheck.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.TaxYear
 
-object TaxYearGen extends GenUtils {
+object TaxYearGen extends GenUtils:
 
-  implicit val taxYearGen: Gen[TaxYear] = gen[TaxYear]
-
-}
+  given taxYearGen: Gen[TaxYear] = gen[TaxYear]

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/TriageQuestionsGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/TriageQuestionsGen.scala
@@ -17,15 +17,16 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import io.github.martinhh.derived.scalacheck.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MultipleDisposalsTriageAnswers.{CompleteMultipleDisposalsTriageAnswers, IncompleteMultipleDisposalsTriageAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.{CompleteSingleDisposalTriageAnswers, IncompleteSingleDisposalTriageAnswers}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.*
 
 object TriageQuestionsGen extends HigherPriorityTriageQuestionsGen with GenUtils
 
 trait HigherPriorityTriageQuestionsGen extends LowerPriorityTriageQuestionsGen { this: GenUtils =>
 
-  implicit val completeSingleDisposalTriageAnswersGen: Gen[CompleteSingleDisposalTriageAnswers] = {
+  implicit val completeSingleDisposalTriageAnswersGen: Gen[CompleteSingleDisposalTriageAnswers] =
     for {
       individualUserType        <- Gen.option(individualUserTypeGen)
       disposalMethod            <- DisposalMethodGen.disposalMethodGen
@@ -43,7 +44,6 @@ trait HigherPriorityTriageQuestionsGen extends LowerPriorityTriageQuestionsGen {
       alreadySentSelfAssessment,
       completionDate
     )
-  }
 
   implicit val individualTriageAnswersGen: Gen[SingleDisposalTriageAnswers] = Gen.oneOf(
     completeSingleDisposalTriageAnswersGen,
@@ -53,9 +53,9 @@ trait HigherPriorityTriageQuestionsGen extends LowerPriorityTriageQuestionsGen {
   val singleDisposalTraiageAnswersGen: Gen[SingleDisposalTriageAnswers] =
     Gen.oneOf(completeSingleDisposalTriageAnswersGen, incompleteSingleDisposalTriageAnswersGen)
 
-  private val taxYearExchangedGen = gen[TaxYearExchanged]
+  given taxYearExchangedGen: Gen[TaxYearExchanged] = gen[TaxYearExchanged]
 
-  implicit val completeMultipleDisposalsTriageAnswersGen: Gen[CompleteMultipleDisposalsTriageAnswers] = {
+  implicit val completeMultipleDisposalsTriageAnswersGen: Gen[CompleteMultipleDisposalsTriageAnswers] =
     for {
       individualUserType        <- Gen.option(individualUserTypeGen)
       numberOfProperties        <- Gen.size
@@ -75,9 +75,8 @@ trait HigherPriorityTriageQuestionsGen extends LowerPriorityTriageQuestionsGen {
       alreadySentSelfAssessment,
       completionDate
     )
-  }
 
-  implicit val incompleteMultipleDisposalsTriageAnswersGen: Gen[IncompleteMultipleDisposalsTriageAnswers] = {
+  implicit val incompleteMultipleDisposalsTriageAnswersGen: Gen[IncompleteMultipleDisposalsTriageAnswers] =
     for {
       individualUserType           <- Gen.option(individualUserTypeGen)
       numberOfProperties           <- Gen.option(Gen.size)
@@ -101,12 +100,11 @@ trait HigherPriorityTriageQuestionsGen extends LowerPriorityTriageQuestionsGen {
       alreadySentSelfAssessment,
       completionDate
     )
-  }
 
   val multipleDisposalsTriageAnswersGen: Gen[MultipleDisposalsTriageAnswers] =
     Gen.oneOf(completeMultipleDisposalsTriageAnswersGen, incompleteMultipleDisposalsTriageAnswersGen)
 
-  implicit val numberOfPropertiesGen: Gen[NumberOfProperties] =
+  given numberOfPropertiesGen: Gen[NumberOfProperties] =
     Gen.oneOf(NumberOfProperties.One, NumberOfProperties.MoreThanOne)
 }
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/VerifierMatchGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/VerifierMatchGen.scala
@@ -17,11 +17,12 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
 import org.scalacheck.Gen
+import io.github.martinhh.derived.scalacheck.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.agents.UnsuccessfulVerifierAttempts
 
-object VerifierMatchGen extends GenUtils {
+object VerifierMatchGen extends GenUtils:
 
-  implicit val unsuccessfulVerifierMatchAttemptsGen: Gen[UnsuccessfulVerifierAttempts] =
+  given unsuccessfulVerifierMatchAttemptsGen: Gen[UnsuccessfulVerifierAttempts] =
     gen[UnsuccessfulVerifierAttempts]
-
-}

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/YearToDateLiabilityAnswersGen.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/generators/YearToDateLiabilityAnswersGen.scala
@@ -16,10 +16,12 @@
 
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators
 
-import cats.syntax.order._
+import cats.syntax.order.*
 import org.scalacheck.Gen
+import io.github.martinhh.derived.scalacheck.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CalculatedTaxDue.GainCalculatedTaxDue
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.CalculatedYTDAnswers.{CompleteCalculatedYTDAnswers, IncompleteCalculatedYTDAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.{CompleteNonCalculatedYTDAnswers, IncompleteNonCalculatedYTDAnswers}
@@ -51,10 +53,7 @@ trait HigherPriorityYearToDateLiabilityAnswersGen extends LowerPriorityYearToDat
       case other                                                                                                    => other
     }
 
-  implicit val calculatedTaxDue: Gen[CalculatedTaxDue] = calculatedTaxDueGen
-
-  implicit val gainCalculatedTaxDueGen: Gen[GainCalculatedTaxDue] =
-    gen[GainCalculatedTaxDue]
+  given gainCalculatedTaxDueGen: Gen[GainCalculatedTaxDue] = gen[GainCalculatedTaxDue]
 
   implicit val ytdLiabilityAnswersGen: Gen[YearToDateLiabilityAnswers] =
     Gen.oneOf(
@@ -68,8 +67,7 @@ trait HigherPriorityYearToDateLiabilityAnswersGen extends LowerPriorityYearToDat
 trait LowerPriorityYearToDateLiabilityAnswersGen extends EvenLowerPriorityYearToDateLiabilityAnswersGen {
   this: GenUtils =>
 
-  val calculatedTaxDueGen: Gen[CalculatedTaxDue] =
-    gen[CalculatedTaxDue]
+  given calculatedTaxDueGen: Gen[CalculatedTaxDue] = gen[CalculatedTaxDue]
 
   private val incompleteCalculatedYTDLiabilityAnswersRaw = for {
     estimatedIncome     <- Gen.option(MoneyGen.amountInPenceGen)
@@ -101,7 +99,7 @@ trait LowerPriorityYearToDateLiabilityAnswersGen extends EvenLowerPriorityYearTo
       case other => other
     }
 
-  implicit val completeNonCalculatedYTDLiabilityAnswersGen: Gen[CompleteNonCalculatedYTDAnswers] = {
+  implicit val completeNonCalculatedYTDLiabilityAnswersGen: Gen[CompleteNonCalculatedYTDAnswers] =
     for {
       taxableGainOrLoss              <- MoneyGen.amountInPenceGen
       hasEstimatedDetails            <- Generators.booleanGen
@@ -125,16 +123,13 @@ trait LowerPriorityYearToDateLiabilityAnswersGen extends EvenLowerPriorityYearTo
       taxableGainOrLossCalculation,
       yearToDateLiabilityCalculation
     )
-  }
 
 }
 
 trait EvenLowerPriorityYearToDateLiabilityAnswersGen { this: GenUtils =>
+  given mandatoryEvidenceGen: Gen[MandatoryEvidence] = gen[MandatoryEvidence]
 
-  implicit val mandatoryEvidenceGen: Gen[MandatoryEvidence] =
-    gen[MandatoryEvidence]
-
-  implicit val incompleteNonCalculatedYTDLiabilityAnswersGen: Gen[IncompleteNonCalculatedYTDAnswers] = {
+  implicit val incompleteNonCalculatedYTDLiabilityAnswersGen: Gen[IncompleteNonCalculatedYTDAnswers] =
     for {
       taxableGainOrLoss              <- Gen.option(MoneyGen.amountInPenceGen)
       hasEstimatedDetails            <- Gen.option(Generators.booleanGen)
@@ -162,6 +157,5 @@ trait EvenLowerPriorityYearToDateLiabilityAnswersGen { this: GenUtils =>
       taxableGainOrLossCalculation,
       yearToDateLiabilityCalculation
     )
-  }
 
 }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/AcquisitionDetailsAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/AcquisitionDetailsAnswersSpec.scala
@@ -20,10 +20,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AcquisitionDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.{arb, sample}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AcquisitionDetailsAnswers.{CompleteAcquisitionDetailsAnswers, IncompleteAcquisitionDetailsAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.AssetType.{IndirectDisposal, Residential}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.IndividualUserType.{PersonalRepresentativeInPeriodOfAdmin, Self}
@@ -34,7 +34,7 @@ class AcquisitionDetailsAnswersSpec extends AnyWordSpec with Matchers with Scala
   "IncompleteAcquisitionDetailsAnswers" must {
 
     "have a method which converts incomplete answers to complete answers" in {
-      forAll { completeAnswers: CompleteAcquisitionDetailsAnswers =>
+      forAll { (completeAnswers: CompleteAcquisitionDetailsAnswers) =>
         IncompleteAcquisitionDetailsAnswers.fromCompleteAnswers(
           completeAnswers
         ) shouldBe IncompleteAcquisitionDetailsAnswers(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/CalculatedGlarBreakdownSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/CalculatedGlarBreakdownSpec.scala
@@ -182,7 +182,7 @@ class CalculatedGlarBreakdownSpec extends AnyWordSpec with Matchers {
         rebasedAcquisitionPrice = None
       )
       "Throw an exception" in {
-        assertThrows[Exception](breakdown.acquisitionOrRebased) //edge case - shouldn't happen
+        assertThrows[Exception](breakdown.acquisitionOrRebased) // edge case - shouldn't happen
       }
     }
   }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/DisposalDetailsAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/DisposalDetailsAnswersSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DisposalDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.{arb, sample}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.DisposalDetailsAnswers.{CompleteDisposalDetailsAnswers, IncompleteDisposalDetailsAnswers}
 
@@ -28,7 +28,7 @@ class DisposalDetailsAnswersSpec extends AnyWordSpec with Matchers with ScalaChe
   "IncompleteDisposalDetailsAnswers" must {
 
     "have a method which converts incomplete answers to complete answers" in {
-      forAll { completeAnswers: CompleteDisposalDetailsAnswers =>
+      forAll { (completeAnswers: CompleteDisposalDetailsAnswers) =>
         IncompleteDisposalDetailsAnswers
           .fromCompleteAnswers(
             completeAnswers

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ExamplePropertyDetailsAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ExamplePropertyDetailsAnswersSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.{arb, sample}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExamplePropertyDetailsAnswers.{CompleteExamplePropertyDetailsAnswers, IncompleteExamplePropertyDetailsAnswers}
 
@@ -28,7 +28,7 @@ class ExamplePropertyDetailsAnswersSpec extends AnyWordSpec with Matchers with S
   "IncompleteExamplePropertyDetailsAnswers" must {
 
     "have a method which converts incomplete answers to complete answers" in {
-      forAll { completeAnswers: CompleteExamplePropertyDetailsAnswers =>
+      forAll { (completeAnswers: CompleteExamplePropertyDetailsAnswers) =>
         IncompleteExamplePropertyDetailsAnswers.fromCompleteAnswers(
           completeAnswers
         ) shouldBe IncompleteExamplePropertyDetailsAnswers(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ExemptionAndLossesAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ExemptionAndLossesAnswersSpec.scala
@@ -28,7 +28,7 @@ class ExemptionAndLossesAnswersSpec extends AnyWordSpec with Matchers with Scala
   "IncompleteExemptionAndLossesAnswers" must {
 
     "have a method which converts incomplete answers to complete answers" in {
-      forAll { completeAnswers: CompleteExemptionAndLossesAnswers =>
+      forAll { (completeAnswers: CompleteExemptionAndLossesAnswers) =>
         IncompleteExemptionAndLossesAnswers.fromCompleteAnswers(
           completeAnswers
         ) shouldBe IncompleteExemptionAndLossesAnswers(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/MultipleDisposalsTriageAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/MultipleDisposalsTriageAnswersSpec.scala
@@ -32,7 +32,7 @@ class MultipleDisposalsTriageAnswersSpec extends AnyWordSpec with Matchers with 
     "have a method which converts incomplete answers to complete answers" when {
 
       "the country of residence is uk" in {
-        forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+        forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
           val completeAnswers = c.copy(
             countryOfResidence = Country.uk,
             assetTypes = List(AssetType.Residential)
@@ -56,7 +56,7 @@ class MultipleDisposalsTriageAnswersSpec extends AnyWordSpec with Matchers with 
       }
 
       "the country of residence is not uk" in {
-        forAll { c: CompleteMultipleDisposalsTriageAnswers =>
+        forAll { (c: CompleteMultipleDisposalsTriageAnswers) =>
           val completeAnswers = c.copy(countryOfResidence = sample[Country])
 
           IncompleteMultipleDisposalsTriageAnswers.fromCompleteAnswers(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ReliefDetailsAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/ReliefDetailsAnswersSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.{arb, sample}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReliefDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ReliefDetailsAnswers.{CompleteReliefDetailsAnswers, IncompleteReliefDetailsAnswers}
 
 class ReliefDetailsAnswersSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
@@ -29,7 +29,7 @@ class ReliefDetailsAnswersSpec extends AnyWordSpec with Matchers with ScalaCheck
   "IncompleteReliefDetailsAnswers" must {
 
     "have a method which converts incomplete answers to complete answers" in {
-      forAll { completeAnswers: CompleteReliefDetailsAnswers =>
+      forAll { (completeAnswers: CompleteReliefDetailsAnswers) =>
         IncompleteReliefDetailsAnswers.fromCompleteAnswers(
           completeAnswers
         ) shouldBe IncompleteReliefDetailsAnswers(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/SingleDisposalTriageAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/SingleDisposalTriageAnswersSpec.scala
@@ -32,7 +32,7 @@ class SingleDisposalTriageAnswersSpec extends AnyWordSpec with Matchers with Sca
   "IncompleteSingleDisposalTriageAnswers" must {
 
     "have a method which converts incomplete answers to complete answers for uk resident" in {
-      forAll { c: CompleteSingleDisposalTriageAnswers =>
+      forAll { (c: CompleteSingleDisposalTriageAnswers) =>
         val completeAnswers = c.copy(countryOfResidence = Country.uk)
 
         IncompleteSingleDisposalTriageAnswers.fromCompleteAnswers(
@@ -53,7 +53,7 @@ class SingleDisposalTriageAnswersSpec extends AnyWordSpec with Matchers with Sca
     }
 
     "have a method which converts incomplete answers to complete answers for non-uk residents" in {
-      forAll { c: CompleteSingleDisposalTriageAnswers =>
+      forAll { (c: CompleteSingleDisposalTriageAnswers) =>
         val completeAnswers = c.copy(countryOfResidence = sample[Country])
 
         IncompleteSingleDisposalTriageAnswers.fromCompleteAnswers(

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/YearToDateLiabilityAnswersSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/YearToDateLiabilityAnswersSpec.scala
@@ -21,8 +21,8 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.AmountInPence
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.{arb, sample}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.MoneyGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.CalculatedYTDAnswers.{CompleteCalculatedYTDAnswers, IncompleteCalculatedYTDAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.YearToDateLiabilityAnswers.NonCalculatedYTDAnswers.{CompleteNonCalculatedYTDAnswers, IncompleteNonCalculatedYTDAnswers}
 
@@ -31,7 +31,7 @@ class YearToDateLiabilityAnswersSpec extends AnyWordSpec with Matchers with Scal
   "IncompleteNonCalculatedYTDAnswers" must {
 
     "have a method which converts incomplete answers to complete answers" in {
-      forAll { completeAnswers: CompleteNonCalculatedYTDAnswers =>
+      forAll { (completeAnswers: CompleteNonCalculatedYTDAnswers) =>
         IncompleteNonCalculatedYTDAnswers.fromCompleteAnswers(
           completeAnswers
         ) shouldBe IncompleteNonCalculatedYTDAnswers(
@@ -75,26 +75,18 @@ class YearToDateLiabilityAnswersSpec extends AnyWordSpec with Matchers with Scal
     "have a method which unsets fields" when {
 
       "given incomplete answers" in {
-        incompleteAnswers.unset(_.taxableGainOrLoss)   shouldBe incompleteAnswers
-          .copy(taxableGainOrLoss = None)
-        incompleteAnswers.unset(
-          _.hasEstimatedDetails
-        )                                              shouldBe incompleteAnswers.copy(hasEstimatedDetails = None)
-        incompleteAnswers.unset(_.taxDue)              shouldBe incompleteAnswers
-          .copy(taxDue = None)
-        incompleteAnswers.unset(_.mandatoryEvidence)   shouldBe incompleteAnswers
-          .copy(mandatoryEvidence = None)
+        incompleteAnswers.unset(_.taxableGainOrLoss)   shouldBe incompleteAnswers.copy(taxableGainOrLoss = None)
+        incompleteAnswers.unset(_.hasEstimatedDetails) shouldBe incompleteAnswers.copy(hasEstimatedDetails = None)
+        incompleteAnswers.unset(_.taxDue)              shouldBe incompleteAnswers.copy(taxDue = None)
+        incompleteAnswers.unset(_.mandatoryEvidence)   shouldBe incompleteAnswers.copy(mandatoryEvidence = None)
         incompleteAnswers.unset(_.yearToDateLiability) shouldBe incompleteAnswers.copy(yearToDateLiability = None)
       }
 
       "given complete answers" in {
-        completeAnswers.unset(_.taxableGainOrLoss)   shouldBe incompleteAnswers
-          .copy(taxableGainOrLoss = None)
-        completeAnswers.unset(_.hasEstimatedDetails) shouldBe incompleteAnswers
-          .copy(hasEstimatedDetails = None)
+        completeAnswers.unset(_.taxableGainOrLoss)   shouldBe incompleteAnswers.copy(taxableGainOrLoss = None)
+        completeAnswers.unset(_.hasEstimatedDetails) shouldBe incompleteAnswers.copy(hasEstimatedDetails = None)
         completeAnswers.unset(_.taxDue)              shouldBe incompleteAnswers.copy(taxDue = None)
-        completeAnswers.unset(_.mandatoryEvidence)   shouldBe incompleteAnswers
-          .copy(mandatoryEvidence = None)
+        completeAnswers.unset(_.mandatoryEvidence)   shouldBe incompleteAnswers.copy(mandatoryEvidence = None)
         completeAnswers.unset(_.yearToDateLiability) shouldBe incompleteAnswers.copy(yearToDateLiability = None)
 
       }
@@ -111,7 +103,7 @@ class YearToDateLiabilityAnswersSpec extends AnyWordSpec with Matchers with Scal
   "IncompleteCalculatedYTDAnswers" must {
 
     "have a method which converts incomplete answers to complete answers" in {
-      forAll { completeAnswers: CompleteCalculatedYTDAnswers =>
+      forAll { (completeAnswers: CompleteCalculatedYTDAnswers) =>
         IncompleteCalculatedYTDAnswers.fromCompleteAnswers(
           completeAnswers
         ) shouldBe IncompleteCalculatedYTDAnswers(
@@ -154,33 +146,21 @@ class YearToDateLiabilityAnswersSpec extends AnyWordSpec with Matchers with Scal
     "have a method which unsets fields" when {
 
       "given incomplete answers" in {
-        incompleteAnswers.unset(_.estimatedIncome)   shouldBe incompleteAnswers
-          .copy(estimatedIncome = None)
-        incompleteAnswers.unset(_.personalAllowance) shouldBe incompleteAnswers
-          .copy(personalAllowance = None)
-        incompleteAnswers.unset(
-          _.hasEstimatedDetails
-        )                                            shouldBe incompleteAnswers.copy(hasEstimatedDetails = None)
-        incompleteAnswers.unset(_.calculatedTaxDue)  shouldBe incompleteAnswers
-          .copy(calculatedTaxDue = None)
-        incompleteAnswers.unset(_.taxDue)            shouldBe incompleteAnswers
-          .copy(taxDue = None)
-        incompleteAnswers.unset(_.mandatoryEvidence) shouldBe incompleteAnswers
-          .copy(mandatoryEvidence = None)
+        incompleteAnswers.unset(_.estimatedIncome)     shouldBe incompleteAnswers.copy(estimatedIncome = None)
+        incompleteAnswers.unset(_.personalAllowance)   shouldBe incompleteAnswers.copy(personalAllowance = None)
+        incompleteAnswers.unset(_.hasEstimatedDetails) shouldBe incompleteAnswers.copy(hasEstimatedDetails = None)
+        incompleteAnswers.unset(_.calculatedTaxDue)    shouldBe incompleteAnswers.copy(calculatedTaxDue = None)
+        incompleteAnswers.unset(_.taxDue)              shouldBe incompleteAnswers.copy(taxDue = None)
+        incompleteAnswers.unset(_.mandatoryEvidence)   shouldBe incompleteAnswers.copy(mandatoryEvidence = None)
       }
 
       "given complete answers" in {
-        completeAnswers.unset(_.estimatedIncome)     shouldBe incompleteAnswers
-          .copy(estimatedIncome = None)
-        completeAnswers.unset(_.personalAllowance)   shouldBe incompleteAnswers
-          .copy(personalAllowance = None)
-        completeAnswers.unset(_.hasEstimatedDetails) shouldBe incompleteAnswers
-          .copy(hasEstimatedDetails = None)
-        completeAnswers.unset(_.calculatedTaxDue)    shouldBe incompleteAnswers
-          .copy(calculatedTaxDue = None)
+        completeAnswers.unset(_.estimatedIncome)     shouldBe incompleteAnswers.copy(estimatedIncome = None)
+        completeAnswers.unset(_.personalAllowance)   shouldBe incompleteAnswers.copy(personalAllowance = None)
+        completeAnswers.unset(_.hasEstimatedDetails) shouldBe incompleteAnswers.copy(hasEstimatedDetails = None)
+        completeAnswers.unset(_.calculatedTaxDue)    shouldBe incompleteAnswers.copy(calculatedTaxDue = None)
         completeAnswers.unset(_.taxDue)              shouldBe incompleteAnswers.copy(taxDue = None)
-        completeAnswers.unset(_.mandatoryEvidence)   shouldBe incompleteAnswers
-          .copy(mandatoryEvidence = None)
+        completeAnswers.unset(_.mandatoryEvidence)   shouldBe incompleteAnswers.copy(mandatoryEvidence = None)
       }
 
     }

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/MongoSupport.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/MongoSupport.scala
@@ -21,7 +21,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import uk.gov.hmrc.mongo.test.MongoSupport
 
 trait MongoSupportSpec extends MongoSupport with BeforeAndAfterEach with BeforeAndAfterAll {
-  this: Suite with Matchers =>
+  this: Suite & Matchers =>
 
   abstract override def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/NameMatchRetryStoreImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/NameMatchRetryStoreImplSpec.scala
@@ -26,8 +26,8 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UnsuccessfulNameMatchAttempts
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UnsuccessfulNameMatchAttempts.NameMatchDetails.IndividualSautrNameMatchDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameMatchGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameMatchGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.GGCredId
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.BusinessPartnerRecordNameMatchRetryStoreSpec._
 import uk.gov.hmrc.mongo.TimestampSupport

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/SessionStoreImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/SessionStoreImplSpec.scala
@@ -47,7 +47,7 @@ class SessionStoreImplSpec
   "SessionStoreImpl" must {
 
     "be able to insert SessionData into mongo and read it back" in new TestEnvironment {
-      forAll { sessionData: SessionData =>
+      forAll { (sessionData: SessionData) =>
         val result = sessionStore.store(sessionData)
 
         await(result) should be(Right(()))

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/agents/AgentVerifierMatchRetryStoreImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/repos/agents/AgentVerifierMatchRetryStoreImplSpec.scala
@@ -24,8 +24,8 @@ import play.api.Configuration
 import play.api.test.Helpers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.agents.UnsuccessfulVerifierAttempts
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.VerifierMatchGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.VerifierMatchGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{CgtReference, GGCredId}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.MongoSupportSpec
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.repos.agents.AgentVerifierMatchRetryStoreImplSpec._

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/EmailVerificationServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/EmailVerificationServiceImplSpec.scala
@@ -21,10 +21,11 @@ import cats.instances.future._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.Call
 import play.api.test.Helpers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.EmailVerificationConnector
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics.MockMetrics
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics.Metrics
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.Error
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.Email
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.http.AcceptLanguage
@@ -35,7 +36,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class EmailVerificationServiceImplSpec extends AnyWordSpec with Matchers with MockFactory {
+class EmailVerificationServiceImplSpec extends AnyWordSpec with Matchers with MockFactory with GuiceOneServerPerSuite {
 
   private val mockConnector = mock[EmailVerificationConnector]
 
@@ -52,8 +53,7 @@ class EmailVerificationServiceImplSpec extends AnyWordSpec with Matchers with Mo
       .expects(expectedEmail, expectedName, expectedContinueCall, expectedLanguage, *)
       .returning(EitherT.fromEither[Future](result))
 
-  val service =
-    new EmailVerificationServiceImpl(mockConnector, MockMetrics.metrics)
+  val service = new EmailVerificationServiceImpl(mockConnector, app.injector.instanceOf[Metrics])
 
   private val emptyJsonBody = "{}"
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/NameMatchRetryServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/NameMatchRetryServiceImplSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.services
 
 import cats.data.EitherT
-import cats.instances.future._
+import cats.instances.future.*
 import com.typesafe.config.ConfigFactory
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
@@ -28,23 +28,23 @@ import play.api.i18n.Lang
 import play.api.libs.json.{Reads, Writes}
 import play.api.mvc.Request
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UnsuccessfulNameMatchAttempts.NameMatchDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.UnsuccessfulNameMatchAttempts.NameMatchDetails.{IndividualRepresenteeNameMatchDetails, IndividualSautrNameMatchDetails, TrustNameMatchDetails}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameMatchGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.NameMatchGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscribedDetails
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.audit.BusinessPartnerRecordNameMatchAuditDetails.{IndividualNameWithNinoAuditDetails, IndividualNameWithSaUtrAuditDetails, TrustNameWithTrnAuditDetails}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.audit.{BusinessPartnerRecordNameMatchAttemptEvent, BusinessPartnerRecordNameMatchAuditDetails, NameMatchAccountLocked}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.BusinessPartnerRecordRequest.{IndividualBusinessPartnerRecordRequest, TrustBusinessPartnerRecordRequest}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeReferenceId
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeReferenceId.{NoReferenceId, RepresenteeCgtReference, RepresenteeNino, RepresenteeSautr}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.audit.CgtAccountNameMatchAttemptEvent
@@ -55,7 +55,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
-import scala.reflect._
+import scala.reflect.*
 
 class NameMatchRetryServiceImplSpec extends AnyWordSpec with Matchers with MockFactory {
 
@@ -101,7 +101,7 @@ class NameMatchRetryServiceImplSpec extends AnyWordSpec with Matchers with MockF
           _: ExecutionContext,
           _: HeaderCarrier,
           _: Writes[NameMatchAccountLocked],
-          _: Request[_]
+          _: Request[?]
         )
       )
       .expects("NameMatchAccountLocked", event, "name-match-account-locked", *, *, *, *)
@@ -122,7 +122,7 @@ class NameMatchRetryServiceImplSpec extends AnyWordSpec with Matchers with MockF
           _: ExecutionContext,
           _: HeaderCarrier,
           _: Writes[BusinessPartnerRecordNameMatchAttemptEvent],
-          _: Request[_]
+          _: Request[?]
         )
       )
       .expects(
@@ -152,7 +152,7 @@ class NameMatchRetryServiceImplSpec extends AnyWordSpec with Matchers with MockF
           _: ExecutionContext,
           _: HeaderCarrier,
           _: Writes[CgtAccountNameMatchAttemptEvent],
-          _: Request[_]
+          _: Request[?]
         )
       )
       .expects(
@@ -176,7 +176,7 @@ class NameMatchRetryServiceImplSpec extends AnyWordSpec with Matchers with MockF
     expectedGGCredID: GGCredId
   )(result: Either[Error, Option[UnsuccessfulNameMatchAttempts[A]]]) =
     (retryStore
-      .get[A](_: GGCredId)(_: Reads[A]))
+      .get[A](_: GGCredId)(using _: Reads[A]))
       .expects(expectedGGCredID, *)
       .returning(Future.successful(result))
 
@@ -185,7 +185,7 @@ class NameMatchRetryServiceImplSpec extends AnyWordSpec with Matchers with MockF
     unsuccessfulNameMatchAttempts: UnsuccessfulNameMatchAttempts[A]
   )(result: Either[Error, Unit]) =
     (retryStore
-      .store[A](_: GGCredId, _: UnsuccessfulNameMatchAttempts[A])(_: Writes[A]))
+      .store[A](_: GGCredId, _: UnsuccessfulNameMatchAttempts[A])(using _: Writes[A]))
       .expects(expectedGGCredID, unsuccessfulNameMatchAttempts, *)
       .returning(Future.successful(result))
 
@@ -254,7 +254,7 @@ class NameMatchRetryServiceImplSpec extends AnyWordSpec with Matchers with MockF
 
     implicit val hc: HeaderCarrier = HeaderCarrier()
 
-    implicit val request: Request[_] = FakeRequest()
+    implicit val request: Request[?] = FakeRequest()
 
     "getting the number of previous unsuccessful attempts" must {
 
@@ -895,7 +895,7 @@ class NameMatchRetryServiceImplSpec extends AnyWordSpec with Matchers with MockF
   }
 
   private def testIsErrorOfType[A <: NameMatchDetails, E <: NameMatchServiceError[A] : ClassTag](
-    result: EitherT[Future, NameMatchServiceError[A], _]
+    result: EitherT[Future, NameMatchServiceError[A], ?]
   ): Unit =
     await(result.value) match {
       case Left(_: E) => ()

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/UKAddressLookupServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/UKAddressLookupServiceImplSpec.scala
@@ -21,9 +21,10 @@ import cats.instances.future._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.test.Helpers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.AddressLookupConnector
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics.MockMetrics
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics.Metrics
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.Error
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{AddressLookupResult, Postcode}
@@ -34,7 +35,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.chaining.scalaUtilChainingOps
 
-class UKAddressLookupServiceImplSpec extends AnyWordSpec with Matchers with MockFactory {
+class UKAddressLookupServiceImplSpec extends AnyWordSpec with Matchers with MockFactory with GuiceOneServerPerSuite {
 
   private val mockConnector = mock[AddressLookupConnector]
 
@@ -49,7 +50,7 @@ class UKAddressLookupServiceImplSpec extends AnyWordSpec with Matchers with Mock
       .expects(expectedPostcode, filter, *)
       .returning(EitherT.fromEither[Future](result))
 
-  val service = new UKAddressLookupServiceImpl(mockConnector, MockMetrics.metrics)
+  val service = new UKAddressLookupServiceImpl(mockConnector, app.injector.instanceOf[Metrics])
 
   private def response(addresses: List[RawAddress]) = Right(AddressLookupResponse(addresses))
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/onboarding/BusinessPartnerRecordServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/onboarding/BusinessPartnerRecordServiceImplSpec.scala
@@ -30,9 +30,9 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.{NonUkAddress, UkAddress}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.{Address, Country, Postcode}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.Email
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.BusinessPartnerRecordGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.CgtReference
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.{IndividualName, TrustName}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.bpr.{BusinessPartnerRecord, BusinessPartnerRecordRequest, BusinessPartnerRecordResponse}

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/onboarding/IvServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/onboarding/IvServiceImplSpec.scala
@@ -21,9 +21,10 @@ import cats.instances.future._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.test.Helpers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.onboarding.IvConnector
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics.MockMetrics
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics.Metrics
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.Error
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.iv.IvErrorStatus._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.onboarding.IvServiceImpl.IvStatusResponse
@@ -33,11 +34,11 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class IvServiceImplSpec extends AnyWordSpec with Matchers with MockFactory {
+class IvServiceImplSpec extends AnyWordSpec with Matchers with MockFactory with GuiceOneServerPerSuite {
 
   private val mockConnector = mock[IvConnector]
 
-  val service = new IvServiceImpl(mockConnector, MockMetrics.metrics)
+  val service = new IvServiceImpl(mockConnector, app.injector.instanceOf[Metrics])
 
   private def mockIvGetFailedJourneyStatus(
     journeyId: UUID

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/onboarding/SubscriptionServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/onboarding/SubscriptionServiceImplSpec.scala
@@ -20,23 +20,24 @@ import cats.data.EitherT
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.i18n.Lang
 import play.api.libs.json.{JsNumber, JsObject, Json}
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.CGTPropertyDisposalsConnector
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics.MockMetrics
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.metrics.Metrics
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.Error
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.AddressSource.{ManuallyEntered => ManuallyEnteredAddress}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailSource.{ManuallyEntered => ManuallyEnteredEmail}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.AddressSource.ManuallyEntered as ManuallyEnteredAddress
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.email.EmailSource.ManuallyEntered as ManuallyEnteredEmail
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.OnboardingDetailsGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SubscribedDetailsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.{CgtReference, SapNumber}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.ContactNameSource.{ManuallyEntered => ManuallyEnteredContactName}
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.name.ContactNameSource.ManuallyEntered as ManuallyEnteredContactName
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding.SubscriptionResponse.{AlreadySubscribed, SubscriptionSuccessful}
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.onboarding._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.CompleteRepresenteeAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeReferenceId.RepresenteeCgtReference
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -44,11 +45,11 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class SubscriptionServiceImplSpec extends AnyWordSpec with Matchers with MockFactory {
+class SubscriptionServiceImplSpec extends AnyWordSpec with Matchers with MockFactory with GuiceOneServerPerSuite {
 
   private val mockConnector = mock[CGTPropertyDisposalsConnector]
 
-  val service = new SubscriptionServiceImpl(mockConnector, MockMetrics.metrics)
+  val service = new SubscriptionServiceImpl(mockConnector, app.injector.instanceOf[Metrics])
 
   private def mockSubscribe(
     expectedSubscriptionDetails: SubscriptionDetails,

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/CgtCalculationServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/CgtCalculationServiceImplSpec.scala
@@ -25,10 +25,10 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.test.Helpers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.returns.ReturnsConnector
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.Error
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FurtherReturnCalculationGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.YearToDateLiabilityAnswersGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/PaymentsServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/PaymentsServiceImplSpec.scala
@@ -68,7 +68,7 @@ class PaymentsServiceImplSpec extends AnyWordSpec with Matchers with MockFactory
   val service = new PaymentsServiceImpl(mockConnector, stub[AuditService])
 
   implicit val hc: HeaderCarrier   = HeaderCarrier()
-  implicit val request: Request[_] = FakeRequest()
+  implicit val request: Request[?] = FakeRequest()
 
   private val emptyJsonBody = "{}"
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/ReturnsServiceImplSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns
 
 import cats.data.EitherT
-import cats.instances.future._
+import cats.instances.future.*
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -25,28 +25,29 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.Lang
 import play.api.mvc.Request
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.config.ViewConfig
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.returns.ReturnsConnector
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.JourneyStatus.FillingOutReturn
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Address.UkAddress
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.address.Postcode
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.finance.*
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.AddressGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.CompleteReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.DraftReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen.completeExamplePropertyDetailsAnswersGen
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExampleCompanyDetailsAnswersGen.completeExampleCompanyDetailsAnswersGen
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ExamplePropertyDetailsAnswersGen._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SingleMixedUseDetailsAnswersGen.completeMixedUsePropertyDetailsAnswers
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.JourneyStatusGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.RepresenteeAnswersGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnAPIGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.ReturnGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.SingleMixedUseDetailsAnswersGen.given_Gen_CompleteMixedUsePropertyDetailsAnswers
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TriageQuestionsGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.ids.CgtReference
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.*
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.CompleteReturn.{CompleteMultipleDisposalsReturn, CompleteMultipleIndirectDisposalReturn, CompleteSingleDisposalReturn, CompleteSingleIndirectDisposalReturn, CompleteSingleMixedUseDisposalReturn}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExampleCompanyDetailsAnswers.CompleteExampleCompanyDetailsAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.ExamplePropertyDetailsAnswers.CompleteExamplePropertyDetailsAnswers
@@ -56,7 +57,6 @@ import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.MultipleDisposals
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.RepresenteeAnswers.CompleteRepresenteeAnswers
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SingleDisposalTriageAnswers.{CompleteSingleDisposalTriageAnswers, IncompleteSingleDisposalTriageAnswers}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns.SubmitReturnResponse.ReturnCharge
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.returns._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, TaxYear, TimeUtils}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.AuditService
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.ReturnsServiceImpl.{GetDraftReturnResponse, ListReturnsResponse}
@@ -134,7 +134,7 @@ class ReturnsServiceImplSpec extends AnyWordSpec with Matchers with MockFactory 
   val service = new ReturnsServiceImpl(mockConnector, stub[AuditService], config)
 
   implicit val hc: HeaderCarrier   = HeaderCarrier()
-  implicit val request: Request[_] = FakeRequest()
+  implicit val request: Request[?] = FakeRequest()
   private val emptyJsonBody        = "{}"
 
   "ReturnsServiceImpl" when {

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/TaxYearServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/returns/TaxYearServiceImplSpec.scala
@@ -25,7 +25,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.test.Helpers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.returns.ReturnsConnector
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.TaxYearGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.{Error, TaxYear}
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.services.returns.TaxYearServiceImpl.{AvailableTaxYearsResponse, TaxYearResponse}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/upscan/UpscanServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/services/upscan/UpscanServiceImplSpec.scala
@@ -27,9 +27,9 @@ import play.api.mvc.{Call, Request}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.connectors.upscan.UpscanConnector
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.FileUploadGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.Generators.sample
-import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen._
+import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.generators.IdGen.given
 import uk.gov.hmrc.cgtpropertydisposalsfrontend.models.upscan.{UploadReference, UploadRequest, UpscanUpload, UpscanUploadMeta}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
@@ -43,7 +43,7 @@ class UpscanServiceImplSpec extends AnyWordSpec with Matchers with ScalaCheckDri
   private val reference            = sample[UploadReference]
   private val upload               = sample[UpscanUpload]
   implicit val hc: HeaderCarrier   = HeaderCarrier()
-  implicit val request: Request[_] = FakeRequest()
+  implicit val request: Request[?] = FakeRequest()
 
   private val emptyJsonBody = "{}"
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/util/ConnectorSupport.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/util/ConnectorSupport.scala
@@ -25,7 +25,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.http.test.WireMockSupport
 
 trait ConnectorSupport extends WireMockSupport with GuiceOneAppPerSuite {
-  this: Suite with TestSuite =>
+  this: Suite & TestSuite =>
   def serviceId: String
 
   val selfUrl = "https://self:999"

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/util/WireMockMethods.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/util/WireMockMethods.scala
@@ -51,7 +51,7 @@ trait WireMockMethods {
         .pipe(headers.foldLeft(_) { case (m, (key, value)) => m.withHeader(key, equalTo(value)) })
         .pipe { mapping =>
           body match {
-            case Some(extractedBody) => mapping.withRequestBody(equalTo(extractedBody))
+            case Some(extractedBody) => mapping.withRequestBody(equalToJson(extractedBody))
             case None                => mapping
           }
         }


### PR DESCRIPTION
- Other options to replace play-json-derived-codecs were considered and deemed not ideal for their current versions. This is due to lack of interoperability with play-json. In order to maintain that, automatic derivation of codecs was replaced with manual read/write configurations for most of the models (sealed traits).
- hmrc-play library has made some changes, breaking, that require few updates to twirl syntax and this was mainly identified for conditional blocks. Also, the key change of removing uppercase on task list status based on tag. So, that has been inlined to code as recommended.
- Removal of scalacheck-shapeless to make way for better use of scala 3 type class derivation. So, this now uses scalacheck-derived for arbitrary genereators.
- Remove overusage of implicits and where required replace them with given.
- Wiremock POST request body verification to be JSON based rather than string.