### PR TITLE
HOLLY-11819 | Update upscan request config to include min file size

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/upscan/UpscanConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/upscan/UpscanConnector.scala
@@ -89,8 +89,7 @@ class UpscanConnectorImpl @Inject() (
       backEndBaseUrl + s"/cgt-property-disposals/upscan-call-back/upload-reference/${uploadReference.value}",
       selfBaseUrl + successRedirect.url,
       selfBaseUrl + errorRedirect.url,
-      0,
-      maxFileSize
+      maximumFileSize = maxFileSize
     )
 
     logger.info(

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/upscan/UpscanInitiateRequest.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/upscan/UpscanInitiateRequest.scala
@@ -22,7 +22,7 @@ final case class UpscanInitiateRequest(
   callbackUrl: String,
   successRedirect: String,
   errorRedirect: String,
-  minimumFileSize: Long,
+  minimumFileSize: Long = 1,
   maximumFileSize: Long
 )
 

--- a/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/upscan/UpscanConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposalsfrontend/connectors/upscan/UpscanConnectorImplSpec.scala
@@ -86,8 +86,7 @@ class UpscanConnectorImplSpec
         s"http://$wireMockHost:$wireMockPort/cgt-property-disposals/upscan-call-back/upload-reference/${reference.value}",
         s"host1.com${mockSuccess.url}",
         s"host1.com${mockFailure.url}",
-        0,
-        1234
+        maximumFileSize = 1234
       )
       behave like upscanConnectorBehaviour(
         when(POST, expectedUrl, body = Some(Json.toJson(payload).toString())),


### PR DESCRIPTION
- Update upscan initiate request to set min size on the file body. This is the field that gets used in upscan to configure the content-length, and to enforce non-empty files this should be set to >0. Fields used by s3 as part of the upload are checked for exact file body length and that doesn't include any metadata.