### PR TITLE
DLS-11613 | Fix model ser/deser to work with type tagged objects

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/JourneyType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/JourneyType.scala
@@ -29,12 +29,20 @@ case object Amend extends JourneyType
 object JourneyType {
   implicit val format: Format[JourneyType] = new Format[JourneyType] {
     override def reads(json: JsValue): JsResult[JourneyType] = json match {
-      case JsString("OnBoarding") => JsSuccess(OnBoarding)
-      case JsString("Returns")    => JsSuccess(Returns)
-      case JsString("Amend")      => JsSuccess(Amend)
-      case _                      => JsError("Invalid journey type")
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "OnBoarding" => JsSuccess(OnBoarding)
+          case "Returns"    => JsSuccess(Returns)
+          case "Amend"      => JsSuccess(Amend)
+          case other        => JsError(s"Unknown JourneyType: $other")
+        }
+      case _                                    => JsError("Expected wrapper object for JourneyType")
     }
 
-    override def writes(o: JourneyType): JsValue = JsString(o.toString)
+    override def writes(o: JourneyType): JsObject = o match {
+      case OnBoarding => Json.obj("OnBoarding" -> Json.obj())
+      case Returns    => Json.obj("Returns" -> Json.obj())
+      case Amend      => Json.obj("Amend" -> Json.obj())
+    }
   }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/UserType.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/UserType.scala
@@ -32,14 +32,23 @@ object UserType {
 
   implicit val format: Format[UserType] = new Format[UserType] {
     override def reads(json: JsValue): JsResult[UserType] = json match {
-      case JsString("Individual")               => JsSuccess(Individual)
-      case JsString("Organisation")             => JsSuccess(Organisation)
-      case JsString("NonGovernmentGatewayUser") => JsSuccess(NonGovernmentGatewayUser)
-      case JsString("Agent")                    => JsSuccess(Agent)
-      case _                                    => JsError("Invalid user type")
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "Individual"               => JsSuccess(Individual)
+          case "Organisation"             => JsSuccess(Organisation)
+          case "NonGovernmentGatewayUser" => JsSuccess(NonGovernmentGatewayUser)
+          case "Agent"                    => JsSuccess(Agent)
+          case other                      => JsError(s"Unknown UserType: $other")
+        }
+      case _                                    => JsError("Expected wrapper object for UserType")
     }
 
-    override def writes(o: UserType): JsValue = JsString(o.toString)
+    override def writes(o: UserType): JsObject = o match {
+      case Individual               => Json.obj("Individual" -> Json.obj())
+      case Organisation             => Json.obj("Organisation" -> Json.obj())
+      case NonGovernmentGatewayUser => Json.obj("NonGovernmentGatewayUser" -> Json.obj())
+      case Agent                    => Json.obj("Agent" -> Json.obj())
+    }
   }
 
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/address/AddressSource.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/address/AddressSource.scala
@@ -31,14 +31,18 @@ object AddressSource {
 
   implicit val format: Format[AddressSource] = new Format[AddressSource] {
     override def reads(json: JsValue): JsResult[AddressSource] = json match {
-      case JsString("BusinessPartnerRecord") => JsSuccess(BusinessPartnerRecord)
-      case JsString("ManuallyEntered")       => JsSuccess(ManuallyEntered)
-      case _                                 => JsError("Invalid address source")
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "ManuallyEntered"       => JsSuccess(ManuallyEntered)
+          case "BusinessPartnerRecord" => JsSuccess(BusinessPartnerRecord)
+          case other                   => JsError(s"Unknown AddressSource: $other")
+        }
+      case _                                    => JsError("Expected wrapper object for AddressSource")
     }
 
-    override def writes(o: AddressSource): JsValue = o match {
-      case BusinessPartnerRecord => JsString("BusinessPartnerRecord")
-      case ManuallyEntered       => JsString("ManuallyEntered")
+    override def writes(o: AddressSource): JsObject = o match {
+      case ManuallyEntered       => Json.obj("ManuallyEntered" -> Json.obj())
+      case BusinessPartnerRecord => Json.obj("BusinessPartnerRecord" -> Json.obj())
     }
   }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/email/EmailSource.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/email/EmailSource.scala
@@ -33,16 +33,20 @@ object EmailSource {
 
   implicit val format: Format[EmailSource] = new Format[EmailSource] {
     override def reads(json: JsValue): JsResult[EmailSource] = json match {
-      case JsString("GovernmentGateway")     => JsSuccess(GovernmentGateway)
-      case JsString("BusinessPartnerRecord") => JsSuccess(BusinessPartnerRecord)
-      case JsString("ManuallyEntered")       => JsSuccess(ManuallyEntered)
-      case _                                 => JsError("Invalid email source")
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "ManuallyEntered"       => JsSuccess(ManuallyEntered)
+          case "GovernmentGateway"     => JsSuccess(GovernmentGateway)
+          case "BusinessPartnerRecord" => JsSuccess(BusinessPartnerRecord)
+          case other                   => JsError(s"Unknown AddressSource: $other")
+        }
+      case _                                    => JsError("Expected wrapper object for AddressSource")
     }
 
-    override def writes(o: EmailSource): JsValue = o match {
-      case GovernmentGateway     => JsString("GovernmentGateway")
-      case BusinessPartnerRecord => JsString("BusinessPartnerRecord")
-      case ManuallyEntered       => JsString("ManuallyEntered")
+    override def writes(o: EmailSource): JsObject = o match {
+      case ManuallyEntered       => Json.obj("ManuallyEntered" -> Json.obj())
+      case GovernmentGateway     => Json.obj("GovernmentGateway" -> Json.obj())
+      case BusinessPartnerRecord => Json.obj("BusinessPartnerRecord" -> Json.obj())
     }
   }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/ContactNameSource.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/name/ContactNameSource.scala
@@ -31,14 +31,18 @@ object ContactNameSource {
 
   implicit val format: Format[ContactNameSource] = new Format[ContactNameSource] {
     override def reads(json: JsValue): JsResult[ContactNameSource] = json match {
-      case JsString("DerivedFromBusinessPartnerRecord") => JsSuccess(DerivedFromBusinessPartnerRecord)
-      case JsString("ManuallyEntered")                  => JsSuccess(ManuallyEntered)
-      case _                                            => JsError("Invalid contact name source")
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "ManuallyEntered"                  => JsSuccess(ManuallyEntered)
+          case "DerivedFromBusinessPartnerRecord" => JsSuccess(DerivedFromBusinessPartnerRecord)
+          case other                              => JsError(s"Unknown contact name source: $other")
+        }
+      case _                                    => JsError("Expected wrapper object for ContactNameSource")
     }
 
-    override def writes(o: ContactNameSource): JsValue = o match {
-      case DerivedFromBusinessPartnerRecord => JsString("DerivedFromBusinessPartnerRecord")
-      case ManuallyEntered                  => JsString("ManuallyEntered")
+    override def writes(o: ContactNameSource): JsObject = o match {
+      case ManuallyEntered                  => Json.obj("ManuallyEntered" -> Json.obj())
+      case DerivedFromBusinessPartnerRecord => Json.obj("DerivedFromBusinessPartnerRecord" -> Json.obj())
     }
   }
 

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/onboarding/NeedMoreDetailsDetails.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/onboarding/NeedMoreDetailsDetails.scala
@@ -36,14 +36,18 @@ object NeedMoreDetailsDetails {
 
     implicit val format: Format[AffinityGroup] = new Format[AffinityGroup] {
       override def reads(json: JsValue): JsResult[AffinityGroup] = json match {
-        case JsString("Individual")   => JsSuccess(Individual)
-        case JsString("Organisation") => JsSuccess(Organisation)
-        case _                        => JsError("Invalid affinity group")
+        case JsObject(fields) if fields.size == 1 =>
+          fields.head._1 match {
+            case "Individual"   => JsSuccess(Individual)
+            case "Organisation" => JsSuccess(Organisation)
+            case other          => JsError(s"Invalid affinity group: $other")
+          }
+        case _                                    => JsError("Expected wrapper object for AffinityGroup")
       }
 
-      override def writes(o: AffinityGroup): JsValue = o match {
-        case Individual   => JsString("Individual")
-        case Organisation => JsString("Organisation")
+      override def writes(o: AffinityGroup): JsObject = o match {
+        case Individual   => Json.obj("Individual" -> Json.obj())
+        case Organisation => Json.obj("Organisation" -> Json.obj())
       }
     }
   }

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/NumberOfProperties.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/returns/NumberOfProperties.scala
@@ -31,14 +31,18 @@ object NumberOfProperties {
 
   implicit val format: Format[NumberOfProperties] = new Format[NumberOfProperties] {
     override def reads(json: JsValue): JsResult[NumberOfProperties] = json match {
-      case JsString("One")         => JsSuccess(One)
-      case JsString("MoreThanOne") => JsSuccess(MoreThanOne)
-      case _                       => JsError("Invalid number of properties")
+      case JsObject(fields) if fields.size == 1 =>
+        fields.head._1 match {
+          case "One"         => JsSuccess(One)
+          case "MoreThanOne" => JsSuccess(MoreThanOne)
+          case other         => JsError(s"Unknown NumberOfProperties: $other")
+        }
+      case _                                    => JsError("Expected wrapper object for NumberOfProperties")
     }
 
-    override def writes(o: NumberOfProperties): JsValue = o match {
-      case One         => JsString("One")
-      case MoreThanOne => JsString("MoreThanOne")
+    override def writes(o: NumberOfProperties): JsObject = o match {
+      case One         => Json.obj("One" -> Json.obj())
+      case MoreThanOne => Json.obj("MoreThanOne" -> Json.obj())
     }
   }
 


### PR DESCRIPTION
Few of the models that were missed in previous release that need to be aligned for type tagged objects to be serialised into previous known structure from org.julienrf json-derived. 