### PR TITLE
DLS-11820 | Fix draft returns with incorrect tax year in disposal date

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/controllers/returns/triage/SingleDisposalsTriageController.scala
@@ -522,7 +522,7 @@ class SingleDisposalsTriageController @Inject() (
                     )
 
                     val result = existingDisposalDate match {
-                      case Some(existingDate) if existingDate.value === date =>
+                      case Some(existingDate) if existingDate.value === date && existingDate.taxYear.contains(date) =>
                         EitherT.pure[Future, Error](Some(existingDate.taxYear))
 
                       case _ =>
@@ -1152,9 +1152,10 @@ class SingleDisposalsTriageController @Inject() (
                   { date =>
                     val existingDisposalDate = triageAnswers.fold(_.disposalDate, c => Some(c.disposalDate))
                     val result               = existingDisposalDate match {
-                      case Some(existingDate) if existingDate.value === date.value =>
+                      case Some(existingDate)
+                          if existingDate.value === date.value && existingDate.taxYear.contains(date.value) =>
                         EitherT.pure[Future, Error](Some(existingDate.taxYear))
-                      case _                                                       =>
+                      case _ =>
                         for {
                           taxYear                         <- taxYearService.taxYear(date.value)
                           updatedDisposalDate              = updateDisposalDate(date.value, taxYear, triageAnswers)

--- a/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/TaxYear.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposalsfrontend/models/TaxYear.scala
@@ -60,6 +60,9 @@ object TaxYear {
         if (futureTaxYearsEnabled) TimeUtils.today().plusYears(1L) else TimeUtils.today()
       today < taxTear.endDateExclusive && today >= taxTear.startDateInclusive
     }
+
+    def contains(date: LocalDate): Boolean =
+      date >= taxTear.startDateInclusive && date < taxTear.endDateExclusive
   }
 
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,11 +2,11 @@ import sbt.*
 
 object AppDependencies {
   val playVersion      = "play-30"
-  val bootstrapVersion = "9.12.0"
+  val bootstrapVersion = "9.13.0"
   val mongoVersion     = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion" % "12.1.0",
+    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion" % "12.5.0",
     "uk.gov.hmrc"       %% s"bootstrap-frontend-$playVersion" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"         % mongoVersion,
     "uk.gov.hmrc"       %% s"domain-$playVersion"             % "10.0.0",


### PR DESCRIPTION
**Issue:**
As mentioned in JIRA ticket, user is having an issue where their draft return for 2025/26 is being treated/included for 2024/25

**Context:**
This is due to a bug in tax year service logic in backend when the change was done for dynamic tax year config. It was returning the last know tax year without the start/end dates updated for the new tax year. This has resulted in draft returns to be stored with disposal date having previous tax year. Rates wouldn't be effected as current and previous tax year rates are same. Looks like this particular issue from end user happened in between us releasing and identifying the issue and patching.

**Fix:**
Simple thing would be for draft return to be deleted and start again or cache to expire. But, this would not be an ideal change for users to go through the full return journey. Instead, the disposal date submit section of return should handle cases where the disposal date year doesn't match the tax year held in session. In those cases, we recalculate the tax year (from backend which should now return a correct one) and update the triage answers of return.

**Testing:**
- Unit tests have been added to handle the case, in both property and shares submit
- All ATs run (run_everything), run output mentioned below
- Will need a manual test aswell for this. But, this will have to be in 2 stages where backend version with tax year bug is first deployed. Then, a draft return should be started with dates mentioned in ticket. Verify that it is being included in calculations for previous tax year (2024/25). Redeploy the latest version of backend and verify that updating disposal date on FE should now put the draft return in correct tax year (2025/26)

**AT Test run:** 
```
[info] Passed: Total 247, Failed 0, Errors 0, Passed 247
[success] Total time: 7972 s (02:12:52.0), completed 19 Jun 2025, 10:18:56
[error] No accessibility assessment results to copy.
[success] Total time: 0 s, completed 19 Jun 2025, 10:18:56
```